### PR TITLE
Use version 47 of Firefox in nightwatch unit and UI tests.

### DIFF
--- a/nightwatch.js
+++ b/nightwatch.js
@@ -27,6 +27,7 @@ module.exports = {
     "firefox" : {
       "desiredCapabilities": {
         "browserName": "firefox",
+        "version": "47.0", // Workaround some timeouts in nightwatch on Firefox>=49. See https://github.com/kiwix/kiwix-js/issues/251
         "javascriptEnabled": true,
         "acceptSslCerts": true,
         "build": "build-" + TRAVIS_JOB_NUMBER,


### PR DESCRIPTION
To workaround some random timeouts in Travis on Firefox>=48
Fixes #251