### PR TITLE
Partially implements #127

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -189,6 +189,7 @@
                 </div>
 
                 <div id="configuration" style="display: none;" class="category-padding">
+                <div id="returntoArticle_top" style="text-align: center;"></div>
                     <h2>Configuration</h2>
                     This application needs a ZIM archive to work. If you did not download one yet, please see the About section
                     <div id="openLocalFiles" style="display: none;">
@@ -208,13 +209,14 @@
                     <div id="contentInjectionModeDiv">
                         Do not touch unless you know what you're doing. <br />
                         Content injection mode : <br/>
-                        <input type="radio" name="contentInjectionMode" value="jquery" id="jQueryModeRadio" checked><label for="jQueryModeRadio">JQuery</label> (slow and memory hungry, but safer)
+                    <input type="radio" name="contentInjectionMode" value="jquery" id="jQueryModeRadio" checked><label for="jQueryModeRadio">&nbsp; JQuery</label> (slow and memory hungry, but safer)
                         <br>
-                        <input type="radio" name="contentInjectionMode" value="serviceworker" id="serviceworkerModeRadio"><label for="serviceworkerModeRadio">ServiceWorker</label> (faster but unstable, and not supported by all platforms. In particular, Firefox extensions do not allow ServiceWorkers for now)
+                    <input type="radio" name="contentInjectionMode" value="serviceworker" id="serviceworkerModeRadio"><label for="serviceworkerModeRadio">&nbsp; ServiceWorker</label> (faster but unstable, and not supported by all platforms. In particular, Firefox extensions do not allow ServiceWorkers for now)
                     </div>
                     <div id="serviceWorkerStatus"></div>
                     <div id="messageChannelStatus"></div>
                     <br />
+                <div id="returntoArticle_bottom" style="text-align: center;"></div>
                 </div>
 
                 <div id="welcomeText" class="container category-padding">
@@ -229,7 +231,8 @@
                     </div>
                 </div>
                 <div id="readingArticle" style="display: none;" class="container">
-                    Reading article <span id="articleName"></span> from archive... Please wait <img src="img/spinner.gif" alt="Please wait..." />
+                    <p>Reading article <span id="articleName"></span> from archive... Please wait <img src="img/spinner.gif" alt="Please wait..." /></p>
+                <div id="progressMessage"><p></p></div>
                 </div>
                 <iframe id="articleContent" src="A/dummyArticle.html" class="articleIFrame">&nbsp;</iframe>
             </article>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -185,6 +185,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     });
     $('input:radio[name=contentInjectionMode]').on('change', function(e) {
         if (checkWarnServiceWorkerMode(this.value)) {
+            document.getElementById('returntoArticle_top').innerHTML = "";
+            document.getElementById('returntoArticle_bottom').innerHTML = "";
             // Do the necessary to enable or disable the Service Worker
             setContentInjectionMode(this.value);
         }
@@ -195,7 +197,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     });
     
     /**
-     * Displays of refreshes the API status shown to the user
+     * Displays or refreshes the API status shown to the user
      */
     function refreshAPIStatus() {
         if (isMessageChannelAvailable()) {
@@ -771,15 +773,19 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
      * @param {String} htmlArticle
      */
     function displayArticleInForm(dirEntry, htmlArticle) {
+        // Display the article inside the web page.
+
+        //Fast-replace img with data-img and hide image [kiwix-js #272]
+        htmlArticle = htmlArticle.replace(/(<img\s+[^>]*\b)src(\s*=)/ig, "$1data-kiwixsrc$2");
+        
+        //Void progress message
+        uiUtil.clear(); //Void progress messages
         $("#readingArticle").hide();
         $("#articleContent").show();
         // Scroll the iframe to its top
         $("#articleContent").contents().scrollTop(0);
-
-        // Display the article inside the web page.
-        //Fast-replace img with data-img and hide image [kiwix-js #272]
-        htmlArticle = htmlArticle.replace(/(<img\s+[^>]*\b)src(\s*=)/ig, "$1data-kiwixsrc$2");
         $('#articleContent').contents().find('body').html(htmlArticle);
+        uiUtil.makeReturnLink(dirEntry); //[kiwix-js #127]
         
         // If the ServiceWorker is not useable, we need to fallback to parse the DOM
         // to inject math images, and replace some links with javascript calls
@@ -845,7 +851,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 var image = $(this);
                 // It's a standard image contained in the ZIM file
                 // We try to find its name (from an absolute or relative URL)
-                var imageMatch = image.attr("data-kiwixsrc").match(regexpImageUrl); //kiwix-js #272
+                var imageMatch = image.attr('data-kiwixsrc').match(regexpImageUrl); //kiwix-js #272
                 if (imageMatch) {
                     var title = decodeURIComponent(imageMatch[1]);
                     selectedArchive.getDirEntryByTitle(title).then(function(dirEntry) {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -53,11 +53,33 @@ define([], function() {
         }
     }
 
+    function makeReturnLink(title) {
+        //Abbreviate title if necessary
+        var shortTitle = title.substring(0, 25);
+        shortTitle = shortTitle == title ? shortTitle : shortTitle + "..."; 
+        var link = '<h4><a href="#" onclick="$(\'#configuration\').hide();$(\'#formArticleSearch\').show();' +
+            '$(\'#articleContent\').show();$(\'#liHomeNav\').attr(\'class\',\'active\');$(\'#liConfigureNav\').attr(\'class\', \'\');' +
+            '$(\'#liAboutNav\').attr(\'class\', \'\');">&lt;&lt; Return to ' + shortTitle + '</a></h4>';
+        document.getElementById("returntoArticle_top").innerHTML = link;
+        document.getElementById("returntoArticle_bottom").innerHTML = link;
+    }
+
+    function poll(msg) {
+        document.getElementById("progressMessage").innerHTML += '<p>' + msg + '</p>';
+    }
+
+    function clear() {
+        document.getElementById("progressMessage").innerHTML = "<p></p>";
+    }
+
     /**
      * Functions and classes exposed by this module
      */
     return {
         feedNodeWithBlob: feedNodeWithBlob,
-        removeUrlParameters: removeUrlParameters
+        removeUrlParameters: removeUrlParameters,
+        makeReturnLink: makeReturnLink,
+        poll: poll,
+        clear: clear
     };
 });


### PR DESCRIPTION
This implements the most urgent aspects of #127 (Reopen the last article after closing/reopening, or after switching between menu items). It implements a link to go back to the article, and disables the link if a major UI option is changed (so as to force a reload). It does not implement storing the article title in a cookie.

Please note that this PR also contains a channel for posting a message to the user on the "spinner" page, which is available here for future use (I use it on kiwix-js-windows). As these changes are very closely related, it seemed best to include it as an available utility in uiUtil.js. Messages posted to the user via uiUtil.poll(msg) will only be visible if the interface is taking a long time to load a file, hence only really on mobile with heavy pages.