### PR TITLE
Fix double-quotes handling to actually remove *.woff* from click package

### DIFF
--- a/scripts/package_ubuntu_touch_app.sh
+++ b/scripts/package_ubuntu_touch_app.sh
@@ -21,7 +21,7 @@ done
 echo "Packaging .click application for Ubuntu Touch, version $VERSION"
 
 # We need to remove the *.woff* files because click considers they are forbidden binaries
-rm -f "$BASEDIR/tmp/www/fonts/*.woff*"
+rm -f "$BASEDIR/tmp/www/fonts"/*.woff*
 # We need to remove these files because the --ignore option of click is not supported in the version of Trusty
 rm -rf "$BASEDIR/tmp/webextension"
 rm -f "$BASEDIR/tmp/manifest.webapp"


### PR DESCRIPTION
Else the package is rejected by click-review