### PR TITLE
Fixing Stackexchange links #205

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -850,13 +850,9 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     // Add an onclick event to go to this article
                     // instead of following the link
                     
-                    if (url.substring(0, 2) === "./") {
-                        url = url.substring(2);
-                    }
-                    // Remove the initial slash if it's an absolute URL
-                    else if (url.substring(0, 1) === "/") {
-                        url = url.substring(1);
-                    }
+					//Get rid of any absolute or relative prefixes (../, ./../, /../.., etc.)
+                        url = url.replace(/^[.\/]*([\S\s]+)$/, "$1");
+
                     $(this).on('click', function(e) {
                         var decodedURL = decodeURIComponent(url);
                         pushBrowserHistoryState(decodedURL);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -854,7 +854,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                         url = url.replace(/^[.\/]*([\S\s]+)$/, "$1");
                         //Some Stackexchange links (e.g. "duplicate" and "related" questions) are missing the "question" path, so add it back
                         //Regex matches a pattern that looks like: 1234/what-is-mathematics.html and changes to: question/1234/what-is-mathematics.html
-                        url = url.replace(/^(\d+\/[\s\S]+\.html?)$/ig, "question/$1");
+                        url = url.replace(/^(\d+\/[\s\S]+\.html?)$/i, "question/$1");
 
                     $(this).on('click', function(e) {
                         var decodedURL = decodeURIComponent(url);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -852,6 +852,9 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     
 					//Get rid of any absolute or relative prefixes (../, ./../, /../.., etc.)
                         url = url.replace(/^[.\/]*([\S\s]+)$/, "$1");
+                        //Some Stackexchange links (e.g. "duplicate" and "related" questions) are missing the "question" path, so add it back
+                        //Regex matches a pattern that looks like: 1234/what-is-mathematics.html and changes to: question/1234/what-is-mathematics.html
+                        url = url.replace(/^(\d+\/[\s\S]+\.html?)$/ig, "question/$1");
 
                     $(this).on('click', function(e) {
                         var decodedURL = decodeURIComponent(url);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -851,10 +851,10 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     // instead of following the link
                     
 					//Get rid of any absolute or relative prefixes (../, ./../, /../.., etc.)
-                        url = url.replace(/^[.\/]*([\S\s]+)$/, "$1");
+                        url = url.replace(/^[.\/]*([\s\S]+)$/, "$1");
                         //Some Stackexchange links (e.g. "duplicate" and "related" questions) are missing the "question" path, so add it back
-                        //Regex matches a pattern that looks like: 1234/what-is-mathematics.html and changes to: question/1234/what-is-mathematics.html
-                        url = url.replace(/^(\d+\/[\s\S]+\.html?)$/i, "question/$1");
+                        //Regex matches a pattern that looks like: 1234/what-is-mathematics.html and changes to: question/1234/what-is-mathematics.html. Some references are 1234.html so this also adds question to such patterns
+                        url = url.replace(/^(\d+(?:\/[\s\S]+)?\.html?)$/i, "question/$1");
 
                     $(this).on('click', function(e) {
                         var decodedURL = decodeURIComponent(url);

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -247,7 +247,8 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
         });
     };
     
-    var regexpTitleWithoutNameSpace = /^[^\/]+$/;
+    //Supports Stackexchange [kiwix-js #205]
+    var regexpTitleWithoutNameSpace = /^(?![\w-]\/[^\/]+?)/;
 
     /**
      * Searches a DirEntry (article / page) by its title.


### PR DESCRIPTION
This seems to support links, tags, and even user profiles. Tested with `mathoverflow.net_en_all_2017-10.zim` on Firefox OS Simulator. I also just tested it with `philosophy.stackexchange.com_en_all_2017-10.zim`. My tests have been a bit cursory, but no errors found yet.