### PR TITLE
Use several browsers for automated unit and UI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ before_script:
     - npm install nightwatch http-server
     - "./node_modules/http-server/bin/http-server . &"
 script:
-    - "./node_modules/nightwatch/bin/nightwatch -c nightwatch.js --env firefox"
+    # The free account on Sauce does not allow more than 5 concurrent sessions (including the main one)
+    # So we separate the recent and old browsers in order to respect this limit.
+    - "./node_modules/nightwatch/bin/nightwatch -c nightwatch.js --env firefox,chrome,edge"
+    - "./node_modules/nightwatch/bin/nightwatch -c nightwatch.js --env firefox45,chrome58,ie11"
     - pkill node
 deploy:
     - provider: script

--- a/browser-tests/nightwatch_runner.js
+++ b/browser-tests/nightwatch_runner.js
@@ -1,18 +1,44 @@
+/**
+ * nightwatch_runner.js : Tests to be run with nightwatch.
+ * 
+ * Copyright 2017 Mossroy and contributors
+ * License GPL v3:
+ * 
+ * This file is part of Kiwix.
+ * 
+ * Kiwix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kiwix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
+ */
+'use strict';
 module.exports = {
     'Unit Tests': function(browser) {
-        browser
-            .url('http://localhost:8080/tests.html')
-            .waitForElementVisible('#qunit-testresult', 10000)
-            .pause(10000);
-        browser.expect.element('#qunit-testresult').text.to.contain('tests completed in');
-        browser.expect.element('#qunit-testresult .failed').text.to.equal('0');
-        browser.expect.element('#qunit-testresult .passed').text.not.to.equal('0');
-        browser.end();
+        // We need to skip the UI tests on Internet Explorer,
+        // because they are not supported, even if the UI tests are supported on this browser
+        if (browser.options.desiredCapabilities.browserName !== "internet explorer") {
+            browser
+                .url('http://localhost:8080/tests.html')
+                .waitForElementVisible('#qunit-testresult', 10000)
+                .pause(10000);
+            browser.expect.element('#qunit-testresult').text.to.contain('tests completed in');
+            browser.expect.element('#qunit-testresult .failed').text.to.equal('0');
+            browser.expect.element('#qunit-testresult .passed').text.not.to.equal('0');
+            browser.end();
+        }
     },
     'UI Tests': function(browser) {
         browser
             .url('http://localhost:8080/')
-            .waitForElementVisible('body', 1000)
+            .waitForElementVisible('#archiveFiles', 20000)
             .execute(function() {
                 window.setRemoteArchives('http://localhost:8080/tests/wikipedia_en_ray_charles_2015-06.zimaa',
                     'http://localhost:8080/tests/wikipedia_en_ray_charles_2015-06.zimab',

--- a/nightwatch.js
+++ b/nightwatch.js
@@ -1,5 +1,27 @@
-'use strict'
-var TRAVIS_JOB_NUMBER = process.env.TRAVIS_JOB_NUMBER
+/**
+ * nightwatch.js : Configuration of nightwatch.
+ * Global settings of NightWatch.
+ * 
+ * Copyright 2017 Mossroy and contributors
+ * License GPL v3:
+ * 
+ * This file is part of Kiwix.
+ * 
+ * Kiwix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kiwix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
+ */
+'use strict';
+var TRAVIS_JOB_NUMBER = process.env.TRAVIS_JOB_NUMBER;
 
 module.exports = {
   "src_folders" : ["browser-tests"],
@@ -24,10 +46,56 @@ module.exports = {
         "waitForConditionTimeout": 600
       }
     },
+    "firefox45" : {
+      "desiredCapabilities": {
+        "browserName": "firefox",
+        "version": "45.0",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true,
+        "build": "build-" + TRAVIS_JOB_NUMBER,
+        "tunnel-identifier": TRAVIS_JOB_NUMBER
+      }
+    },
     "firefox" : {
       "desiredCapabilities": {
         "browserName": "firefox",
-        "version": "47.0", // Workaround some timeouts in nightwatch on Firefox>=49. See https://github.com/kiwix/kiwix-js/issues/251
+        "javascriptEnabled": true,
+        "acceptSslCerts": true,
+        "build": "build-" + TRAVIS_JOB_NUMBER,
+        "tunnel-identifier": TRAVIS_JOB_NUMBER
+      }
+    },
+    "chrome58" : {
+      "desiredCapabilities": {
+        "browserName": "chrome",
+        "version": "58.0",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true,
+        "build": "build-" + TRAVIS_JOB_NUMBER,
+        "tunnel-identifier": TRAVIS_JOB_NUMBER
+      }
+    },
+    "chrome" : {
+      "desiredCapabilities": {
+        "browserName": "chrome",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true,
+        "build": "build-" + TRAVIS_JOB_NUMBER,
+        "tunnel-identifier": TRAVIS_JOB_NUMBER
+      }
+    },
+    "edge" : {
+      "desiredCapabilities": {
+        "browserName": "MicrosoftEdge",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true,
+        "build": "build-" + TRAVIS_JOB_NUMBER,
+        "tunnel-identifier": TRAVIS_JOB_NUMBER
+      }
+    },
+    "ie11" : {
+      "desiredCapabilities": {
+        "browserName": "internet explorer",
         "javascriptEnabled": true,
         "acceptSslCerts": true,
         "build": "build-" + TRAVIS_JOB_NUMBER,
@@ -35,4 +103,4 @@ module.exports = {
       }
     }
   }
-}
+};


### PR DESCRIPTION
Instead of only one version of Firefox, this PR makes the automated unit and UI tests run on : 
- Firefox 45
- latest version of Firefox
- latest version of Chrome
- latest version of Edge
- Internet Explorer 11 (skipping the unit tests because they don't work, but the UI tests do work)