### PR TITLE
Void the iframe in readArticle function #341

### DIFF
--- a/www/dummyArticle.html
+++ b/www/dummyArticle.html
@@ -7,7 +7,6 @@ and open the template in the editor.
 <html>
     <head>
         <meta charset="utf-8">
-        <base href="A/">
         <title>dummy Article</title>
     </head>
     <body>

--- a/www/index.html
+++ b/www/index.html
@@ -257,7 +257,7 @@
                 <div id="readingArticle" style="display: none;" class="container">
                     Reading article <span id="articleName"></span> from archive... Please wait <img src="img/spinner.gif" alt="Please wait..." />
                 </div>
-                <iframe id="articleContent" src="dummyArticle.html" class="articleIFrame">&nbsp;</iframe>
+                <iframe id="articleContent" class="articleIFrame"></iframe>
             </article>
             <footer>
                 <div id="navigationButtons" class="btn-toolbar">

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -748,6 +748,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             selectedArchive.resolveRedirect(dirEntry, readArticle);
         }
         else {
+            //Void the iframe
+            document.getElementById("articleContent").src = "dummyArticle.html";
             selectedArchive.readArticle(dirEntry, displayArticleInForm);
         }
     }
@@ -826,20 +828,20 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             // Fast-replace img src with data-kiwixsrc [kiwix-js #272]
             htmlArticle = htmlArticle.replace(/(<img\s+[^>]*\b)src(\s*=)/ig, "$1data-kiwixsrc$2");
         }
+
+        // Compute base URL
+        var urlPath = regexpPath.test(dirEntry.url) ? urlPath = dirEntry.url.match(regexpPath)[1] : "";
+        var baseUrl = dirEntry.namespace + "/" + urlPath;
+
+        //Inject base tag into html
+        htmlArticle = htmlArticle.replace(/(<head[^>]*>\s*)/i, '$1<base href="' + baseUrl + '" />\r\n');
+
         // Display the article inside the web page.
-        $('#articleContent').contents().find('body').html(htmlArticle);
+        document.getElementById("articleContent").contentDocument.documentElement.innerHTML = htmlArticle;
         
         // If the ServiceWorker is not useable, we need to fallback to parse the DOM
         // to inject math images, and replace some links with javascript calls
         if (contentInjectionMode === 'jquery') {
-            
-            // Compute base URL
-            var urlPath = regexpPath.test(dirEntry.url) ? urlPath = dirEntry.url.match(regexpPath)[1] : "";
-            var baseUrl = dirEntry.namespace + "/" + urlPath;
-            // Create (or replace) the "base" tag with our base URL
-            $('#articleContent').contents().find('head').find("base").detach();
-            $('#articleContent').contents().find('head').append("<base href='" + baseUrl + "'>");
-            
             var currentProtocol = location.protocol;
             var currentHost = location.host;
 


### PR DESCRIPTION
24th Feb: The latest commit ([Inject baseUrl](https://github.com/kiwix/kiwix-js/pull/342/commits/3b5f7b28ae323e1c4f2e0002433c89846279a770)) incorporates #343 (Add the <base> tag before the document is injected into the DOM). It has been tested on Microsoft Edge, Internet Explorer, Firefox and FFOS simulator.