### PR TITLE
Send an HTTP Redirect in SW mode when there is a ZIM redirect.

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -166,6 +166,9 @@ function fetchEventListener(event) {
                         console.log('ServiceWorker responding to the HTTP request for ' + titleWithNameSpace + ' (size=' + event.data.content.length + ' octets)' , httpResponse);
                         resolve(httpResponse);
                     }
+                    else if (event.data.action === 'sendRedirect') {
+                        resolve(Response.redirect(event.data.redirectUrl));
+                    }
                     else {
                         console.log('Invalid message received from app.js for ' + titleWithNameSpace, event.data);
                         reject(event.data);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -776,7 +776,15 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                         console.error("Title " + title + " not found in archive.");
                         messagePort.postMessage({'action': 'giveContent', 'title' : title, 'content': ''});
                     } else if (dirEntry.isRedirect()) {
-                        selectedArchive.resolveRedirect(dirEntry, readFile);
+                        selectedArchive.resolveRedirect(dirEntry, function(resolvedDirEntry) {
+                            var redirectURL = resolvedDirEntry.namespace + "/" +resolvedDirEntry.url;
+                            // Ask the ServiceWork to send an HTTP redirect to the browser.
+                            // We could send the final content directly, but it is necessary to let the browser know in which directory it ends up.
+                            // Else, if the redirect URL is in a different directory than the original URL,
+                            // the relative links in the HTML content would fail. See #312
+                            messagePort.postMessage({'action':'sendRedirect', 'title':title, 'redirectUrl': redirectURL});
+                            console.log("redirect to " + redirectURL + " sent to ServiceWorker");                            
+                        });
                     } else {
                         console.log("Reading binary file...");
                         selectedArchive.readBinaryFile(dirEntry, function(fileDirEntry, content) {


### PR DESCRIPTION
It is necessary to let the browser know in which directory it is.
Else the relative links can be broken if the original URL is in a
different directory than the final URL.

Fixes #312