### PR TITLE
Read CSS as utf8 strings instead of binary

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -148,7 +148,7 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'uiUtil', 'utf8'],
                 assert.ok(htmlArticle.match("^.*<h1[^>]*>A Fool for You</h1>"), "'A Fool for You' title somewhere in the article");
                 done();
             };
-            localZimArchive.readArticle(aFoolForYouDirEntry, callbackFunction);
+            localZimArchive.readUtf8File(aFoolForYouDirEntry, callbackFunction);
         });
         QUnit.test("check findDirEntriesWithPrefix 'A'", function(assert) {
             var done = assert.async();            
@@ -325,7 +325,7 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'uiUtil', 'utf8'],
                 assert.ok(dirEntry !== null, "Title found");
                 if (dirEntry !== null) {
                     assert.equal(dirEntry.namespace +"/"+ dirEntry.url, "A/Ray_Charles.html", "URL is correct.");
-                    localZimArchive.readArticle(dirEntry, function(dirEntry2, data) {
+                    localZimArchive.readUtf8File(dirEntry, function(dirEntry2, data) {
                         assert.equal(dirEntry2.title, "Ray Charles", "Title is correct.");
                         assert.equal(data.length, 157186, "Data length is correct.");
                         assert.equal(data.indexOf("the only true genius in show business"), 5535, "Specific substring at beginning found.");

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -747,7 +747,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             selectedArchive.resolveRedirect(dirEntry, readArticle);
         }
         else {
-            selectedArchive.readArticle(dirEntry, displayArticleInForm);
+            selectedArchive.readUtf8File(dirEntry, displayArticleInForm);
         }
     }
     
@@ -959,13 +959,13 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     } else {
                         selectedArchive.getDirEntryByTitle(title)
                         .then(function (dirEntry) {
-                            return selectedArchive.readBinaryFile(dirEntry,
+                            return selectedArchive.readUtf8File(dirEntry,
                                 function (fileDirEntry, content) {
                                     var fullUrl = fileDirEntry.namespace + "/" + fileDirEntry.url; 
-                                    var contentString = util.uintToString(content);
-                                    if (cssCache) cssCache.set(fullUrl, contentString);
-                                    uiUtil.replaceCSSLinkWithInlineCSS(link, contentString); 
-                                });
+                                    if (cssCache) cssCache.set(fullUrl, content);
+                                    uiUtil.replaceCSSLinkWithInlineCSS(link, content); 
+                                }
+                            );
                         }).fail(function (e) {
                             console.error("could not find DirEntry for CSS : " + title, e);
                         });
@@ -984,14 +984,14 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     // It's a Javascript file contained in the ZIM file
                     var title = uiUtil.removeUrlParameters(decodeURIComponent(srcMatch[1]));
                     selectedArchive.getDirEntryByTitle(title).then(function(dirEntry) {
-                        if (dirEntry === null)
+                        if (dirEntry === null) {
                             console.log("Error: js file not found: " + title);
-                        else
+                        } else {
                             selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
-                                // TODO : I have to disable javascript for now
-                                // var jsContent = encodeURIComponent(util.uintToString(content));
-                                //script.attr("src", 'data:text/javascript;charset=UTF-8,' + jsContent);
+                                // TODO : JavaScript support not yet functional [kiwix-js #152]
+                                uiUtil.feedNodeWithBlob(script, 'src', content, 'text/javascript');
                             });
+                        }
                     }).fail(function (e) {
                         console.error("could not find DirEntry for javascript : " + title, e);
                     });

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -225,7 +225,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      * @param {DirEntry} dirEntry
      * @param {callbackStringContent} callback
      */
-    ZIMArchive.prototype.readArticle = function(dirEntry, callback) {
+    ZIMArchive.prototype.readUtf8File = function(dirEntry, callback) {
         dirEntry.readData().then(function(data) {
             callback(dirEntry, utf8.parse(data));
         });


### PR DESCRIPTION
See discussion in #370 . It has yet to be determined whether JavaScript files should also be decoded as UTF8, or, since we will store them as Blobs, whether a binary format is appropriate for the browser to decode. Since we do not yet use the JavaScript function, that should be left to future investigation.