### PR TITLE
Prevent render till css fulfilled from cache or zim

### DIFF
--- a/www/js/init.js
+++ b/www/js/init.js
@@ -22,7 +22,7 @@
  */
 'use strict';
 
-// Provides caching for CSS styles contained in ZIM (variable needs to be available app-wide)
+// Provides caching for assets contained in ZIM (variable needs to be available app-wide)
 // It significantly speeds up subsequent page display. See kiwix-js issue #335
 var assetsCache = new Map();
 

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -22,6 +22,10 @@
  */
 'use strict';
 
+// Provides caching for CSS styles contained in ZIM (variable needs to be available app-wide)
+// It significantly speeds up subsequent page display. See kiwix-js issue #335
+var assetsCache = new Map();
+
 require.config({
     baseUrl: 'js/lib',
     paths: {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -72,6 +72,43 @@ define([], function() {
         }
         link.replaceWith(cssElement);
     }
+
+    /**
+     * Replaces all CSS links that have the given attribute in the html string with inline script tags containing content
+     * from the cache entries. Returns the substituted html in the callback function (even if no substitutions were made).
+     * 
+     * @param {String} html The html string to process
+     * @param {String} attribute The attribute that stores the URL to be substituted
+     * @param {Function} callback The function to call with the substituted html
+         
+     }}
+     */
+    function replaceCSSLinksInHtml(html, attribute, callback) {
+        // This regex creates an array of all link tags that have the given attribute
+        var regexpLinksWithAttribute = new RegExp('<link[^>]+?' + attribute + '=["\']([^"\']+)[^>]*>', 'ig');
+        var titles = [];
+        var linkArray = regexpLinksWithAttribute.exec(html);
+        while (linkArray !== null) {
+            // Store both the link to be replaced and the decoded URL
+            titles.push([linkArray[0], 
+                decodeURIComponent(linkArray[1])]);
+            linkArray = regexpLinksWithAttribute.exec(html);
+        }
+        assetsCache.cssCount = 0;
+        assetsCache.cssFulfilled = 0;
+        titles.forEach(function(title) {
+            assetsCache.cssCount++;
+            var cssContent = assetsCache.get(title[1]);
+            if (cssContent) {
+                assetsCache.cssFulfilled++;
+                html = html.replace(title[0], 
+                    '<style ' + attribute + '="' + title[1] + '">' + cssContent + '</style>');
+            }
+            if (assetsCache.cssCount >= titles.length) {
+                callback(html);
+            }
+        });
+    }
         
     var regexpRemoveUrlParameters = new RegExp(/([^?#]+)[?#].*$/);
     
@@ -90,6 +127,7 @@ define([], function() {
     return {
         feedNodeWithBlob: feedNodeWithBlob,
         replaceCSSLinkWithInlineCSS: replaceCSSLinkWithInlineCSS,
+        replaceCSSLinksInHtml: replaceCSSLinksInHtml,
         removeUrlParameters: removeUrlParameters
     };
 });

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -80,8 +80,6 @@ define([], function() {
      * @param {String} html The html string to process
      * @param {String} attribute The attribute that stores the URL to be substituted
      * @param {Function} callback The function to call with the substituted html
-         
-     }}
      */
     function replaceCSSLinksInHtml(html, attribute, callback) {
         // This regex creates an array of all link tags that have the given attribute


### PR DESCRIPTION
Please try out this PR, @mossroy, which fixes #381 for jQuery mode. I've tested load of the Stackoverflow home page in Edge, Chromium and Firefox in jQuery mode (I haven't tried to load that page in IE, because IE is very slow on normal ZIMs, but other ZIM files work fine in IE with this code). I've also tested the code on FFOS, but not with that ZIM.

It works like this: if (some of) the CSS files are cached, then preload them into the html string before injecting the string into the iframe. If they are not cached (or if some of them aren't), then inject the HTML but keep the iframe hidden until all the CSS files have been fulfilled from the ZIM. Then render the iframe. Since browsers don't render content where `style.display == "none"`, we can take advantage of this behaviour to prevent rendering until all CSS is available and injected through one method or other.

The code is based on a more complete caching solution I've been developing as a replacement for the clunky (but functional) caching-in-the-filesystem that I was doing this time last year for Kiwix JS Windows. The more complete solution uses indexedDB or localStorage to persist the cached assets between ZIM loads (in jQuery and ServiceWorker), and includes the ZIM filename in the cacheKey. It is too big a change to contemplate just for this issue, however, so I've adapted relevant bits.

But you'll notice some embryonic features that will make it easier to develop the following:

1. Addition of JavaScript to the cache (hence I've renamed it assetsCache) -- this will be absolutely vital if we ever hope to support JavaScript; 
2. Asynchronous cache calls (necessary for indexedDB).

You'll also notice that the assetsCache is declared app-wide. This is so that we don't need to pass it around between app.js and uiUtil.js (and a future cache.js) in function calls. Here we're still erasing it between ZIM loads. If you don't like this and have a better way to avoid passing the cache around, please suggest!

The per-ZIM persistent cache *really* makes the app fly, b.t.w.!