### PR TITLE
Prevent render until all CSS is fulfilled

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -255,7 +255,10 @@
                     </div>
                 </div>
                 <div id="readingArticle" style="display: none;" class="container">
-                    Reading article <span id="articleName"></span> from archive... Please wait <img src="img/spinner.gif" alt="Please wait..." />
+                    <p>Reading article <span id="articleName"></span> from archive... Please wait <img src="img/spinner.gif" alt="Please wait..." /></p>
+                </div>
+                <div id="cachingCSS" style="display: none;" class="container">
+                    <p>Caching styles to speed up future page display...</p>
                 </div>
                 <iframe id="articleContent" class="articleIFrame" src="article.html"></iframe>
             </article>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -870,9 +870,6 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             articleContent.innerHTML = htmlArticle;
             // Add any missing classes stripped from the <html> tag
             if (htmlCSS) articleContent.getElementsByTagName('body')[0].classList.add(htmlCSS);
-            // Actually display the iframe content
-            $("#readingArticle").hide();
-            $("#articleContent").show();
             // Allow back/forward in browser history
             pushBrowserHistoryState(dirEntry.namespace + "/" + dirEntry.url);
             
@@ -956,29 +953,49 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             for (var i = collapsedBlocks.length; i--;) {
                 collapsedBlocks[i].classList.add('open-block');
             }
-            
-            $('#articleContent').contents().find('link[data-kiwixurl]').each(function() {
+
+            var cssCount = 0;
+            var cssFulfilled = 0;
+            $('#articleContent').contents().find('link[data-kiwixurl]').each(function () {
+                cssCount++;
                 var link = $(this);
                 var linkUrl = link.attr("data-kiwixurl");
                 var title = uiUtil.removeUrlParameters(decodeURIComponent(linkUrl));
-                if (cssCache && cssCache.has(title)) {
+                if (cssCache.has(title)) {
                     var cssContent = cssCache.get(title);
                     uiUtil.replaceCSSLinkWithInlineCSS(link, cssContent);
+                    cssFulfilled++;
                 } else {
+                    $('#cachingCSS').show();
                     selectedArchive.getDirEntryByTitle(title)
                     .then(function (dirEntry) {
                         return selectedArchive.readUtf8File(dirEntry,
                             function (fileDirEntry, content) {
-                                var fullUrl = fileDirEntry.namespace + "/" + fileDirEntry.url; 
-                                if (cssCache) cssCache.set(fullUrl, content);
-                                uiUtil.replaceCSSLinkWithInlineCSS(link, content); 
+                                var fullUrl = fileDirEntry.namespace + "/" + fileDirEntry.url;
+                                cssCache.set(fullUrl, content);
+                                uiUtil.replaceCSSLinkWithInlineCSS(link, content);
+                                cssFulfilled++;
+                                renderIfCSSFulfilled();
                             }
                         );
                     }).fail(function (e) {
                         console.error("could not find DirEntry for CSS : " + title, e);
+                        cssCount--;
+                        renderIfCSSFulfilled();
                     });
                 }
             });
+            renderIfCSSFulfilled();
+
+            // Some pages are extremely heavy to render, so we prevent rendering by keeping the iframe hidden
+            // until all CSS content is available [kiwix-js #381]
+            function renderIfCSSFulfilled() {
+                if (cssFulfilled >= cssCount) {
+                    $('#cachingCSS').hide();
+                    $('#readingArticle').hide();
+                    $('#articleContent').show();
+                }
+            }
         }
 
         function loadJavaScriptJQuery() {


### PR DESCRIPTION
@mossroy , I agree that this is a less risky way of solving (or rather, ameliorating) #381 for a v2.3 release.

I've implemented your helpful suggestions in commit https://github.com/kiwix/kiwix-js/commit/127ff299de66c16398e250dc56fbd696a0388ee8. Tested on IE, Edge, FFOS, Firefox Quantum.

I've also, optionally, added a commit https://github.com/kiwix/kiwix-js/commit/41f1b7042ac87ba83e171e0a42416a836f67bd42 which displays an additional message to the user when the app is retrieving CSS from the ZIM instead of the cache. Because that is slow, and because first impressions often count strongly with apps, giving this additional small piece of feedback could be a user-friendly gesture. The message won't display again on subsequent page loads unless a further piece of CSS needs to be cached.

It's easy to drop that commit if you feel it's unnecessary. On FFOS, because of the very small screen size, it does look a bit cluttered the first time. But I think nowadays most mobiles have more width. However, the message could be abbreviated to just "Caching styles...". See what you think.
