### PR TITLE
Add more specific mimetype support for images #390

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -84,6 +84,7 @@ var regexpJPEG = new RegExp(/\.jpe?g$/i);
 var regexpPNG = new RegExp(/\.png$/i);
 var regexpJS = new RegExp(/\.js/i);
 var regexpCSS = new RegExp(/\.css$/i);
+var regexpSVG = new RegExp(/\.svg$/i);
 
 // Pattern for ZIM file namespace - see http://www.openzim.org/wiki/ZIM_file_format#Namespaces
 var regexpZIMUrlWithNamespace = new RegExp(/(?:^|\/)([-ABIJMUVWX])\/(.+)/);
@@ -117,6 +118,9 @@ function fetchEventListener(event) {
                     }
                     else if (regexpPNG.test(title)) {
                         contentType = 'image/png';
+                    } 
+                    else if (regexpSVG.test(title)) {
+                        contentType = 'image/svg+xml';
                     }
                 }
                 else if (nameSpace === '-') {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -934,7 +934,16 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 selectedArchive.getDirEntryByTitle(title).then(function(dirEntry) {
                     selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
                         // TODO : use the complete MIME-type of the image (as read from the ZIM file)
-                        uiUtil.feedNodeWithBlob(image, 'src', content, 'image');
+                        var url = fileDirEntry.url;
+                        // Attempt to construct a generic mimetype first as a catchall
+                        var mimetype = url.match(/\.(\w{2,4})$/);
+                        mimetype = mimetype ? "image/" + mimetype[1].toLowerCase() : "image";
+                        // Then make more specific for known image types
+                        mimetype = /\.jpg$/i.test(url) ? "image/jpeg" : mimetype;
+                        mimetype = /\.tif$/i.test(url) ? "image/tiff" : mimetype;
+                        mimetype = /\.ico$/i.test(url) ? "image/x-icon" : mimetype;
+                        mimetype = /\.svg$/i.test(url) ? "image/svg+xml" : mimetype;
+                        uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
                     });
                 }).fail(function (e) {
                     console.error("could not find DirEntry for image:" + title, e);


### PR DESCRIPTION
This proposes a pragmatic solution to #390. For ServiceWorker, I have merely added SVGs to the pragmatic code that is already there (that type was missing).

For jQuery, I've used a more compact solution. These regexes are extremely small and quick for the system to match, and I'm not sure anything much would be saved by compiling them in advance, given that the bottleneck is extraction from the ZIM. Speedup here is probably immaterial and the operations can easily be completed in a minute fraction of the time between images arriving. EDIT: ah, of course I forget, unless we're using a Worker, there is no "time between", as there is only one thread. But it's still probably minimal.

In any case, this is probably "meanwhile" code, unless someone would like to bite the bullet with #137 now?