### PR TITLE
Added support for reading the article aloud using the text to speech API

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -67,6 +67,10 @@
     height: 0px; 
 }
 
+#textToSpeech_voices {
+  margin-left: 4px;
+}
+
 .articleIFrame {
     width: 100%;
     border: 0;

--- a/www/index.html
+++ b/www/index.html
@@ -76,7 +76,7 @@
                                 </span>
                             </span>
                         </span>
-                        <span class="nopadding col-md-2 col-sm-2 col-xs-5">
+                        <span class="nopadding col-md-3 col-sm-3 col-xs-5">
                             <!-- Random article button -->
                             <span class="btn-group btn-group-xs">
                                 <a class="btn btn-default btn-xs" id="btnRandomArticle"><span class="glyphicon glyphicon-random"></span><small><br/>Random</small></a>
@@ -85,6 +85,7 @@
                             <span class="btn-group btn-group-xs">
                                 <a class="btn btn-default btn-xs" style="display: none;" id="textToSpeech_start"><span class="glyphicon glyphicon-play"></span><small><br/>Read</small></a>
                                 <a class="btn btn-default btn-xs" style="display: none;" id="textToSpeech_stop"><span class="glyphicon glyphicon-stop"></span><small><br/>Stop</small></a>
+                                <select id="textToSpeech_voices" style="display: none;"></select>
                             </span>
                         </span>
                     </div>

--- a/www/index.html
+++ b/www/index.html
@@ -77,8 +77,14 @@
                             </span>
                         </span>
                         <span class="nopadding col-md-2 col-sm-2 col-xs-5">
+                            <!-- Random article button -->
                             <span class="btn-group btn-group-xs">
                                 <a class="btn btn-default btn-xs" id="btnRandomArticle"><span class="glyphicon glyphicon-random"></span><small><br/>Random</small></a>
+                            </span>
+                            <!-- Text To Speech buttons -->
+                            <span class="btn-group btn-group-xs">
+                                <a class="btn btn-default btn-xs" style="display: none;" id="textToSpeech_start"><span class="glyphicon glyphicon-play"></span><small><br/>Read</small></a>
+                                <a class="btn btn-default btn-xs" style="display: none;" id="textToSpeech_stop"><span class="glyphicon glyphicon-stop"></span><small><br/>Stop</small></a>
                             </span>
                         </span>
                     </div>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -884,18 +884,16 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         // Load the blank article to clear the iframe (NB iframe onload event runs *after* this)
         iframeArticleContent.src = "article.html";
 
+        // Shows the text to speech button for the loaded article. 
+        // If the speech API is not available, the button is not displayed.
         function showTextToSpeech() {
             var textToSpeechStart = $("#textToSpeech_start");   
             var textToSpeechStop = $("#textToSpeech_stop");
-            
-            // First hide all the textToSpeech buttons 
-            textToSpeechStart.hide();
-            textToSpeechStop.hide();
 
             if (!browserSupportsTextToSpeech()) {
                 return;
             }
-            
+
             textToSpeechStart.show();
             textToSpeechStart.on('click', function() {
                 textToSpeechStart.hide();
@@ -912,6 +910,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             });
         }
 
+        // Returns true if the browser supports text to speech APIs.
         function browserSupportsTextToSpeech() {
             return SpeechSynthesisUtterance && window.speechSynthesis;
         }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -876,12 +876,45 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             parseAnchorsJQuery();
             loadImagesJQuery();
             loadCSSJQuery();
+            showTextToSpeech();
             //JavaScript loading currently disabled
             //loadJavaScriptJQuery();            
         };
      
         // Load the blank article to clear the iframe (NB iframe onload event runs *after* this)
         iframeArticleContent.src = "article.html";
+
+        function showTextToSpeech() {
+            var textToSpeechStart = $("#textToSpeech_start");   
+            var textToSpeechStop = $("#textToSpeech_stop");
+            
+            // First hide all the textToSpeech buttons 
+            textToSpeechStart.hide();
+            textToSpeechStop.hide();
+
+            if (!browserSupportsTextToSpeech()) {
+                return;
+            }
+            
+            textToSpeechStart.show();
+            textToSpeechStart.on('click', function() {
+                textToSpeechStart.hide();
+                textToSpeechStop.show();
+                var documentText = $('#articleContent').contents().find('body')[0].textContent;
+                var utterance = new SpeechSynthesisUtterance(documentText);
+                window.speechSynthesis.speak(utterance);
+            });
+
+            textToSpeechStop.on('click', function() {
+                textToSpeechStart.show();
+                textToSpeechStop.hide();
+                window.speechSynthesis.cancel();
+            });
+        }
+
+        function browserSupportsTextToSpeech() {
+            return SpeechSynthesisUtterance && window.speechSynthesis;
+        }
 
         function parseAnchorsJQuery() {
             var currentProtocol = location.protocol;


### PR DESCRIPTION
Fixes #166: Added support for reading the article aloud using the text to speech API. Added a new button to start reading the opened article. When the speech has started, show a button to stop the speech.

Note that this requires a text to speech API. If browser does not support this API, the read button is not displayed.