### PR TITLE
Read the language of a ZIM file right after it is loaded.

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -133,6 +133,7 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'uiUtil', 'utf8'],
         QUnit.module("ZIM initialisation");
         QUnit.test("ZIM archive is ready", function(assert) {
             assert.ok(localZimArchive.isReady() === true, "ZIM archive should be set as ready");
+            assert.equal(localZimArchive.language, "eng", "ZIM file read uses the English language");
         });
                 
         QUnit.module("zim_direntry_search_and_read");

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -29,7 +29,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      * 
      * @typedef ZIMArchive
      * @property {ZIMFile} _file The ZIM file (instance of ZIMFile, that might physically be split into several actual files)
-     * @property {String} _language Language of the content
+     * @property {String} language Language(s) of the content, as defined in http://www.openzim.org/wiki/Metadata
      */
     
     /**
@@ -49,10 +49,21 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
     function ZIMArchive(storage, path, callbackReady) {
         var that = this;
         that._file = null;
-        that._language = ""; //@TODO
+        that.language = null;
         var createZimfile = function(fileArray) {
             zimfile.fromFileArray(fileArray).then(function(file) {
                 that._file = file;
+                // Let's read the language inside the ZIM file
+                that.getDirEntryByTitle("M/Language").then(function(dirEntry) {
+                    if (dirEntry === null || dirEntry === undefined) {
+                        console.warn("Title M/Language not found in the archive");
+                    }
+                    else {
+                        that.readUtf8File(dirEntry, function(dirEntryRead, data) {
+                            that.language = data;
+                        });
+                    }
+                }).fail(function(e) { console.warn("Language not found in the archive", e); });
                 callbackReady(that);
             });
         };

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -61,10 +61,10 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
                     else {
                         that.readUtf8File(dirEntry, function(dirEntryRead, data) {
                             that.language = data;
+                            callbackReady(that);
                         });
                     }
-                }).fail(function(e) { console.warn("Language not found in the archive", e); });
-                callbackReady(that);
+                }).fail(function(e) { console.warn("Language not found in the archive", e); callbackReady(that);});
             });
         };
         if (storage && !path) {


### PR DESCRIPTION
So that to populate ZIMArchive.language
Fixes #395