### PR TITLE
Read bcp47 language of zim

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -133,6 +133,7 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'uiUtil', 'utf8'],
         QUnit.module("ZIM initialisation");
         QUnit.test("ZIM archive is ready", function(assert) {
             assert.ok(localZimArchive.isReady() === true, "ZIM archive should be set as ready");
+            assert.equal(localZimArchive.language, "eng", "ZIM file read uses the English language");
         });
                 
         QUnit.module("zim_direntry_search_and_read");

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -91,7 +91,7 @@ define([], function() {
      * @param {Callback} callback to return the language code 
      */
     function readBCP47LanguageCode(archive, callback) {
-        var altName = archive._file._files[0].name.toLowerCase();
+        var altName = archive._file._files[0].name;
         archive.getMetadata('Name', function(zimName) {
             var bcp47Code;
             // In case the ZIM doesn't have a meta Name attribute, use the altName as a backup
@@ -100,7 +100,7 @@ define([], function() {
             if (/_\w+_/.test(zimName)) {
                 bcp47Code = zimName.replace(/.+?_(\w+)_.*/, '$1').toLowerCase();
                 // DEV: Add any known exceptions below following first pattern
-                bcp47Code = /eng/.test(bcp47Code) ? 'en' : bcp47Code;
+                bcp47Code = /^eng$/.test(bcp47Code) ? 'en' : bcp47Code;
             }
             callback (bcp47Code);
         });

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -102,7 +102,7 @@ define([], function() {
                 // DEV: Add any known exceptions below following first pattern
                 bcp47Code = /^eng$/.test(bcp47Code) ? 'en' : bcp47Code;
             }
-            callback (bcp47Code);
+            callback(bcp47Code);
         });
     }
 

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -85,11 +85,34 @@ define([], function() {
     }
 
     /**
+     * Returns the BCP 47 language code of the specified ZIM archive
+     * 
+     * @param {Object} archive The ZIM archive object
+     * @param {Callback} callback to return the language code 
+     */
+    function readBCP47LanguageCode(archive, callback) {
+        var altName = archive._file._files[0].name.toLowerCase();
+        archive.getMetadata('Name', function(zimName) {
+            var bcp47Code;
+            // In case the ZIM doesn't have a meta Name attribute, use the altName as a backup
+            // (this is the case, e.g., with the stackoverflow_eng ZIM)
+            if (!zimName) zimName = altName;
+            if (/_\w+_/.test(zimName)) {
+                bcp47Code = zimName.replace(/.+?_(\w+)_.*/, '$1').toLowerCase();
+                // DEV: Add any known exceptions below following first pattern
+                bcp47Code = /eng/.test(bcp47Code) ? 'en' : bcp47Code;
+            }
+            callback (bcp47Code);
+        });
+    }
+
+    /**
      * Functions and classes exposed by this module
      */
     return {
         feedNodeWithBlob: feedNodeWithBlob,
         replaceCSSLinkWithInlineCSS: replaceCSSLinkWithInlineCSS,
-        removeUrlParameters: removeUrlParameters
+        removeUrlParameters: removeUrlParameters,
+        readBCP47LanguageCode: readBCP47LanguageCode
     };
 });

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -29,7 +29,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      * 
      * @typedef ZIMArchive
      * @property {ZIMFile} _file The ZIM file (instance of ZIMFile, that might physically be split into several actual files)
-     * @property {String} _language Language of the content
+     * @property {String} language Language(s) of the content, as defined in http://www.openzim.org/wiki/Metadata
      */
     
     /**
@@ -49,10 +49,21 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
     function ZIMArchive(storage, path, callbackReady) {
         var that = this;
         that._file = null;
-        that._language = ""; //@TODO
+        that.language = null;
         var createZimfile = function(fileArray) {
             zimfile.fromFileArray(fileArray).then(function(file) {
                 that._file = file;
+                // Let's read the language inside the ZIM file
+                that.getDirEntryByTitle("M/Language").then(function(dirEntry) {
+                    if (dirEntry === null || dirEntry === undefined) {
+                        console.warn("Title M/Language not found in the archive");
+                    }
+                    else {
+                        that.readUtf8File(dirEntry, function(dirEntryRead, data) {
+                            that.language = data;
+                        });
+                    }
+                }).fail(function(e) { console.warn("Language not found in the archive", e); });
                 callbackReady(that);
             });
         };

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -61,10 +61,10 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
                     else {
                         that.readUtf8File(dirEntry, function(dirEntryRead, data) {
                             that.language = data;
+                            callbackReady(that);
                         });
                     }
-                }).fail(function(e) { console.warn("Language not found in the archive", e); });
-                callbackReady(that);
+                }).fail(function(e) { console.warn("Language not found in the archive", e); callbackReady(that);});
             });
         };
         if (storage && !path) {


### PR DESCRIPTION
As per discussion in #166 , this PR, which relies on @mossroy's unmerged PR #397, attempts to extract the BCP 47 language code that is embedded in the ZIM's meta Name attribute.

Note that I found a ZIM that does not have the meta Name attribute, which is the anomalous stackoverflow. com_eng_all ZIM. Maybe related to this is the fact that this ZIM is the only one I've found that has an ISO-639-3 code embedded in its title. I've implemented an "exceptions" section to cover this case, and also a backup for the file name where the Name attribute is not available for whatever reason. This is somewhat dirty because of course the user could have renamed the ZIM file. But as most ZIMs have the name with the correct language code in the meta Name attribute, this is really a workaround in one exceptional case, from what I can tell.

This PR relies on all ZIMs being provided by Kiwix, and using the standard Kiwix naming convention. If the ZIM does not use this convention, it is likely to return either a blank language code or, possibly (but somewhat unlikely) a garbage code. I don't think there's anything we can do about this.

The only other way to get the BCP 47 code would be to implement a conversion process using very large lookup tables. To cover every possible language, these tables would be enormous and would add significantly to the weight of the app. Since it seems that mwoffliner already does a conversion in order to produce the ZIM's filename, it would IMHO be a waste of effort for us to do the conversion again in-app.

Sample usage of the provided function in, say, app.js:
```
        uiUtil.readBCP47LanguageCode(selectedArchive, function(code) {
            console.log('Language of ZIM is: ' + code);
        });

```
@kasemmarifet please note that using this function does a costly lookup of the Name attribute using a file read. Therefore it should not be use on every article load, as it will impact performance significantly. It should only be used when the user selects the "Read" button and a voice has not already been explicitly chosen by the user.

