### PR TITLE
Transfer the data from ZIM to ServiceWorker instead of copying it.

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -836,7 +836,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     } else {
                         console.log("Reading binary file...");
                         selectedArchive.readBinaryFile(dirEntry, function(fileDirEntry, content) {
-                            messagePort.postMessage({'action': 'giveContent', 'title' : title, 'content': content});
+                            var message = {'action': 'giveContent', 'title' : title, 'content': content.buffer};
+                            messagePort.postMessage(message, [content.buffer]);
                             console.log("content sent to ServiceWorker");
                         });
                     }


### PR DESCRIPTION
Fixes #416 
It seems to do the job, but I don't measure any performance difference on big wikipedia articles (which I hoped it would speed-up).
Maybe it would be worth on bigger resources like videos? (but we don't support them for now)

I managed to check that the buffers are transferred by adding lines like below before and after the transfer : 
`console.log("length of content.buffer=" + content.buffer.byteLength);`
The length drops to zero after the postMessage.