### PR TITLE
Add API for reading ZIM Metadata.

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -134,6 +134,26 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'uiUtil', 'utf8'],
         QUnit.test("ZIM archive is ready", function(assert) {
             assert.ok(localZimArchive.isReady() === true, "ZIM archive should be set as ready");
         });
+        
+        QUnit.module("ZIM metadata");
+        QUnit.test("read ZIM language", function(assert) {
+            var done = assert.async();            
+            assert.expect(1);
+            var callbackFunction = function(language) {
+                assert.equal(language , 'eng', 'The language read inside the Metadata should be "eng" for "English"');
+                done();
+            };
+            localZimArchive.getMetadata("Language", callbackFunction);
+        });
+        QUnit.test("try to read a missing metadata", function(assert) {
+            var done = assert.async();            
+            assert.expect(1);
+            var callbackFunction = function(string) {
+                assert.equal(string, undefined, 'The metadata zzz should not be found inside the ZIM');
+                done();
+            };
+            localZimArchive.getMetadata("zzz", callbackFunction);
+        });
                 
         QUnit.module("zim_direntry_search_and_read");
         QUnit.test("check DirEntry.fromStringId 'A Fool for You'", function(assert) {

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -37,6 +37,10 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      * @param {ZIMArchive} zimArchive Ready-to-use ZIMArchive
      */
     
+    /**
+     * @callback callbackMetadata
+     * @param {String} data metadata string
+     */
     
     /**
      * Creates a ZIM archive object to access the ZIM file at the given path in the given storage.
@@ -279,6 +283,28 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
     ZIMArchive.prototype.getRandomDirEntry = function(callback) {
         var index = Math.floor(Math.random() * this._file.articleCount);
         this._file.dirEntryByUrlIndex(index).then(callback);
+    };
+    
+    /**
+     * Read a Metadata string inside the ZIM file.
+     * @param {String} key
+     * @param {callbackMetadata} callback
+     */
+    ZIMArchive.prototype.getMetadata = function (key, callback) {
+        var that = this;
+        this.getDirEntryByTitle("M/" + key).then(function (dirEntry) {
+            if (dirEntry === null || dirEntry === undefined) {
+                console.warn("Title M/" + key + " not found in the archive");
+                callback();
+            } else {
+                that.readUtf8File(dirEntry, function (dirEntryRead, data) {
+                    callback(data);
+                });
+            }
+        }).fail(function (e) {
+            console.warn("Metadata with key " + key + " not found in the archive", e);
+            callback();
+        });
     };
 
     /**


### PR DESCRIPTION
Fixes #395
It is especially useful to read the language of the ZIM file