### PR TITLE
Remove false assumption about position of assets in ZIM

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -646,40 +646,35 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
   
     /**
      * Display the list of articles with the given array of DirEntry
-     * @param {Array.<DirEntry>} dirEntryArray
-     * @param {Integer} maxArticles
+     * @param {Array} dirEntryArray The array of dirEntries returned from the binary search
      */
-    function populateListOfArticles(dirEntryArray, maxArticles) {       
+    function populateListOfArticles(dirEntryArray) {
         var articleListHeaderMessageDiv = $('#articleListHeaderMessage');
-        var nbDirEntry = 0;
-        if (dirEntryArray) {
-            nbDirEntry = dirEntryArray.length;
-        }
+        var nbDirEntry = dirEntryArray ? dirEntryArray.length : 0;
 
         var message;
-        if (maxArticles >= 0 && nbDirEntry >= maxArticles) {
-            message = maxArticles + " first articles below (refine your search).";
-        }
-        else {
-            message = nbDirEntry + " articles found.";
+        if (nbDirEntry >= MAX_SEARCH_RESULT_SIZE) {
+            message = 'First ' + MAX_SEARCH_RESULT_SIZE + ' articles below (refine your search).';
+        } else {
+            message = nbDirEntry + ' articles found.';
         }
         if (nbDirEntry === 0) {
-            message = "No articles found.";
+            message = 'No articles found.';
         }
-              
+
         articleListHeaderMessageDiv.html(message);
-        
 
         var articleListDiv = $('#articleList');
-        var articleListDivHtml = "";
-        for (var i = 0; i < dirEntryArray.length; i++) {
+        var articleListDivHtml = '';
+        var listLength = dirEntryArray.length < MAX_SEARCH_RESULT_SIZE ? dirEntryArray.length : MAX_SEARCH_RESULT_SIZE;
+        for (var i = 0; i < listLength; i++) {
             var dirEntry = dirEntryArray[i];
-            
-            articleListDivHtml += "<a href='#' dirEntryId='" + dirEntry.toStringId().replace(/'/g,"&apos;")
-                    + "' class='list-group-item'>" + dirEntry.title + "</a>";
+            var title = dirEntry.title ? dirEntry.title : '[' + dirEntry.url + ']';
+            articleListDivHtml += '<a href="#" dirEntryId="' + dirEntry.toStringId().replace(/'/g, '&apos;') +
+                '" class="list-group-item">' + title + '</a>';
         }
         articleListDiv.html(articleListDivHtml);
-        $("#articleList a").on("click",handleTitleClick);
+        $('#articleList a').on('click', handleTitleClick);
         $('#searchingArticles').hide();
         $('#articleListWithHeader').show();
     }

--- a/www/js/lib/util.js
+++ b/www/js/lib/util.js
@@ -227,10 +227,11 @@ define(['q'], function(q) {
      * continue the search.
      * If lowerBound is not set, returns only indices where query returns 0 and null otherwise.
      * If lowerBound is set, returns the smallest index where query does not return > 0.
-     * @param {Integer} begin
-     * @param {Integer} end
-     * @param query Function
-     * @param {Boolean} lowerBound
+     * @param {Integer} begin The beginning of the search window
+     * @param {Integer} end The end of the search window
+     * @param {Function} query The query to run to test the current point in the window
+     * @param {Boolean} lowerBound Determines the type of search
+     * @returns {Promise} Promise for the lowest dirEntry that fulfils (or fails to fulfil) the query
      */
     function binarySearch(begin, end, query, lowerBound) {
         if (end <= begin)
@@ -245,7 +246,7 @@ define(['q'], function(q) {
             else
                 return mid;
         });
-    };
+    }
     
     /**
      * Converts a Base64 Content to a Blob

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -172,23 +172,26 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
     };
     
     /**
-     * Look for DirEntries with title starting with the given prefix (case-sensitive)
+     * Look for dirEntries with title starting with the given prefix (case-sensitive)
      * 
-     * @param {String} prefix
-     * @param {Integer} resultSize
-     * @param {callbackDirEntryList} callback
+     * @param {String} prefix The case-sensitive value against which dirEntry titles (or url) will be compared
+     * @param {Integer} resultSize The maximum number of results to return
+     * @param {callbackDirEntryList} callback The function to call with the array of dirEntries with titles that begin with prefix
      */
     ZIMArchive.prototype.findDirEntriesWithPrefixCaseSensitive = function(prefix, resultSize, callback) {
         var that = this;
         util.binarySearch(0, this._file.articleCount, function(i) {
             return that._file.dirEntryByTitleIndex(i).then(function(dirEntry) {
-                if (dirEntry.title === "")
-                    return -1; // ZIM sorts empty titles (assets) to the end
-                else if (dirEntry.namespace < "A")
-                    return 1;
-                else if (dirEntry.namespace > "A")
-                    return -1;
-                return prefix <= dirEntry.title ? -1 : 1;
+                if (dirEntry.namespace < "A") return 1;
+                if (dirEntry.namespace > "A") return -1;
+                // We should now be in namespace A
+                if (dirEntry.title) { 
+                    return prefix <= dirEntry.title ? -1 : 1;
+                } else {
+                    // Some dirEntries (e.g. subtitles) have no title, but are still sorted in the A namespace,
+                    // so, like libzim, we have to use the url as a comparator [kiwix-js #440 #443]
+                    return prefix <= dirEntry.url ? -1 : 1;
+                }
             });
         }, true).then(function(firstIndex) {
             var dirEntries = [];
@@ -196,7 +199,8 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
                 if (index >= firstIndex + resultSize || index >= that._file.articleCount)
                     return dirEntries;
                 return that._file.dirEntryByTitleIndex(index).then(function(dirEntry) {
-                    if (dirEntry.title.slice(0, prefix.length) === prefix && dirEntry.namespace === "A")
+                    var title = dirEntry.title ? dirEntry.title : dirEntry.url;
+                    if (!title.indexOf(prefix) && dirEntry.namespace === "A")
                         dirEntries.push(dirEntry);
                     return addDirEntries(index + 1);
                 });


### PR DESCRIPTION
This is a proposed fix for #440 . It will probably slow down searches in some ZIMs with lots of dirEntries, such as full Wikipedia, so it needs testing on a range of ZIMs to be sure there are no unintended effects.