### PR TITLE
Recognize relative asset URLs

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -812,9 +812,9 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     // Regex below finds images, scripts, stylesheets and media sources with ZIM-type metadata and image namespaces [kiwix-js #378]
     // or with URLs that are relative to the current article.
     // It first searches for <img, <script, <link, etc., then scans forward to find, on a word boundary, either src=["'] 
-    // OR href=["'] (ignoring any extra whitespace), and it then tests everything up to the next ["'] against either a pattern 
-    // that matches ZIM URLs with namespaces [-IJ] ("-" = metadata or "I" / "J" = image), or (if that fails) a pattern that matches
-    // a relative URL. Finally it removes any relative or absolute path from ZIM-style URLs. 
+    // OR href=['"], and it then tests everything up to the next ['"] against either a pattern that matches ZIM URLs with 
+    // namespaces [-IJ] ('-' = metadata or 'I'/'J' = image), or (if that fails) a pattern that matches a relative URL.
+    // When the regex is used below, it will also remove any relative or absolute path from ZIM-style URLs. 
     // DEV: If you want to support more namespaces, add them to the END of the character set [-IJ] (not to the beginning) 
     var regexpTagsWithZimUrl = /(<(?:img|script|link|video|audio|source|track)\b[^>]+?\b)(?:src|href)\b[^'"]+['"](?:(?:\.\.\/|\/)+([-IJ]\/[^"']*)|([^\/:"']+[^"':]*))['"]/ig;
     

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -816,7 +816,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     // namespaces [-IJ] ('-' = metadata or 'I'/'J' = image), or (if that fails) a pattern that matches a relative URL.
     // When the regex is used below, it will also remove any relative or absolute path from ZIM-style URLs. 
     // DEV: If you want to support more namespaces, add them to the END of the character set [-IJ] (not to the beginning) 
-    var regexpTagsWithZimUrl = /(<(?:img|script|link|video|audio|source|track)\b[^>]+?\b)(?:src|href)\b[^'"]+['"](?:(?:\.\.\/|\/)+([-IJ]\/[^"']*)|([^\/:"']+[^"':]*))['"]/ig;
+    var regexpTagsWithZimUrl = /(<(?:img|script|link|video|audio|source|track)\b[^>]+?\b)(?:src|href)\b[^'"]+['"](?:(?:\.\.\/|\/)+([-IJ]\/[^"']*)|([^\/:."']+[^"':]*))['"]/ig;
     
     // Cache for CSS styles contained in ZIM.
     // It significantly speeds up subsequent page display. See kiwix-js issue #335

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -843,7 +843,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         // Replaces relative and ZIM-style URLs of img, script, link and media tags with a data-kiwixurl to prevent 404 errors [kiwix-js #272 #376]
         // This replacement also processes ZIM URLs to remove the path so that the URL is ready for subsequent jQuery functions
         htmlArticle = htmlArticle.replace(regexpTagsWithZimUrl, function(p0, p1, p2, p3) { 
-            var url = regexpZIMUrlWithNamespace.test(p2) ? p2 : baseUrl + p3;
+            var url = p2 ? p2 : baseUrl + p3;
             return p1 + 'data-kiwixurl="' + url + '"'; 
         });
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -816,7 +816,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     // namespaces [-IJ] ('-' = metadata or 'I'/'J' = image), or (if that fails) a pattern that matches a relative URL.
     // When the regex is used below, it will also remove any relative or absolute path from ZIM-style URLs. 
     // DEV: If you want to support more namespaces, add them to the END of the character set [-IJ] (not to the beginning) 
-    var regexpTagsWithZimUrl = /(<(?:img|script|link|video|audio|source|track)\b[^>]*?\s)(?:src|href)\s*=\s*['"](?:(?:\.\.\/|\/)+([-IJ]\/[^"']*)|([^\/:."']+[^"':]*))['"]/ig;
+    var regexpTagsWithZimUrl = /(<(?:img|script|link|video|audio|source|track)\b[^>]*?\s)(?:src|href)\s*=\s*['"](?:(?:\.\.\/|\/)+([-IJ]\/[^"']*)|([^\/:#?"']+[^"':]*))['"]/ig;
     
     // Cache for CSS styles contained in ZIM.
     // It significantly speeds up subsequent page display. See kiwix-js issue #335

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -810,7 +810,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     // Pattern to find a ZIM URL (with its namespace) - see http://www.openzim.org/wiki/ZIM_file_format#Namespaces
     var regexpZIMUrlWithNamespace = /(?:^|\/)([-ABIJMUVWX]\/.+)/;
     // Regex below finds images, scripts, stylesheets and media sources with ZIM-type metadata and image namespaces [kiwix-js #378]
-    // or with URLs that are relative to the current article.
+    // or assets with URLs that are relative to the current article.
     // It first searches for <img, <script, <link, etc., then scans forward to find, on a word boundary, either src=["'] 
     // OR href=['"], and it then tests everything up to the next ['"] against either a pattern that matches ZIM URLs with 
     // namespaces [-IJ] ('-' = metadata or 'I'/'J' = image), or (if that fails) a pattern that matches a relative URL.

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -802,7 +802,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 console.error("Invalid message received", event.data);
             }
         }
-    };
+    }
     
     // Compile some regular expressions needed to modify links
     // Pattern to find the path in a url
@@ -810,11 +810,12 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     // Pattern to find a ZIM URL (with its namespace) - see http://www.openzim.org/wiki/ZIM_file_format#Namespaces
     var regexpZIMUrlWithNamespace = /(?:^|\/)([-ABIJMUVWX]\/.+)/;
     // Regex below finds images, scripts, stylesheets and media sources with ZIM-type metadata and image namespaces [kiwix-js #378]
+    // or with URLs that are relative to the current article.
     // It first searches for <img, <script, <link, etc., then scans forward to find, on a word boundary, either src=["'] 
     // OR href=["'] (ignoring any extra whitespace), and it then tests everything up to the next ["'] against either a pattern 
     // that matches ZIM URLs with namespaces [-IJ] ("-" = metadata or "I" / "J" = image), or (if that fails) a pattern that matches
-    // a relative URL. Finally it removes any relative or absolute path. 
-    // DEV: If you want to support more namespaces, add them to the END of the character set [-I] (not to the beginning) 
+    // a relative URL. Finally it removes any relative or absolute path from ZIM-style URLs. 
+    // DEV: If you want to support more namespaces, add them to the END of the character set [-IJ] (not to the beginning) 
     var regexpTagsWithZimUrl = /(<(?:img|script|link|video|audio|source|track)\b[^>]+?\b)(?:src|href)\b[^'"]+['"](?:(?:\.\.\/|\/)+([-IJ]\/[^"']*)|([^\/:"']+[^"':]*))['"]/ig;
     
     // Cache for CSS styles contained in ZIM.

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -811,12 +811,12 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     var regexpZIMUrlWithNamespace = /(?:^|\/)([-ABIJMUVWX]\/.+)/;
     // Regex below finds images, scripts, stylesheets and media sources with ZIM-type metadata and image namespaces [kiwix-js #378]
     // or assets with URLs that are relative to the current article.
-    // It first searches for <img, <script, <link, etc., then scans forward to find, on a word boundary, either src=["'] 
+    // It first searches for <img, <script, <link, etc., then scans forward to find, on a word boundary, either src=['"] 
     // OR href=['"], and it then tests everything up to the next ['"] against either a pattern that matches ZIM URLs with 
     // namespaces [-IJ] ('-' = metadata or 'I'/'J' = image), or (if that fails) a pattern that matches a relative URL.
     // When the regex is used below, it will also remove any relative or absolute path from ZIM-style URLs. 
     // DEV: If you want to support more namespaces, add them to the END of the character set [-IJ] (not to the beginning) 
-    var regexpTagsWithZimUrl = /(<(?:img|script|link|video|audio|source|track)\b[^>]+?\b)(?:src|href)\b[^'"]+['"](?:(?:\.\.\/|\/)+([-IJ]\/[^"']*)|([^\/:."']+[^"':]*))['"]/ig;
+    var regexpTagsWithZimUrl = /(<(?:img|script|link|video|audio|source|track)\b[^>]*?\s)(?:src|href)\s*=\s*['"](?:(?:\.\.\/|\/)+([-IJ]\/[^"']*)|([^\/:."']+[^"':]*))['"]/ig;
     
     // Cache for CSS styles contained in ZIM.
     // It significantly speeds up subsequent page display. See kiwix-js issue #335


### PR DESCRIPTION
This PR addresses #446 . It works by adding any relative asset URLs to the regex we have that turns ZIM-style URLs (src or href) into data-kiwixurl. This then allows our existing functions for both images and videos to find these URLs without any further modification of those functions.