### PR TITLE
Support relative text tracks in the A namespace

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1034,9 +1034,13 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
 
         function insertMediaBlobsJQuery() {
             var iframe = iframeArticleContent.contentDocument;
-            Array.prototype.slice.call(iframe.querySelectorAll('video[data-kiwixurl], audio[data-kiwixurl], source[data-kiwixurl], track[data-kiwixurl]'))
+            Array.prototype.slice.call(iframe.querySelectorAll('video[data-kiwixurl], audio[data-kiwixurl], source[data-kiwixurl], track'))
             .forEach(function(mediaSource) {
                 var source = mediaSource.dataset.kiwixurl;
+                if (!source && mediaSource.src) {
+                    // Some ZIMs list text tracks as a relative link within the directory containing the article
+                    source = regexpZIMUrlWithNamespace.test(mediaSource.src) ? mediaSource.src.match(regexpZIMUrlWithNamespace)[1] : source;
+                }
                 if (!source || !regexpZIMUrlWithNamespace.test(source)) {
                     console.error('No usable media source was found!');
                     return;


### PR DESCRIPTION
This PR is an alternative to #447 . It fixes #446 with regard to text tracks only, because I believe that subtitles are the only assets that can be in the A namespace, and hence the only ones that could have a URL relative to the article.

~~However, as a result of #447, I discovered that the regex (see code at beginning of PR changes) could be written in a way that reduces some backtracking, so I've included that optimization from the other PR. According to RegexBuddy's debug tab, writing the regex this way shaves off some 900 steps in a typical search through an article of 11,000 steps. That is about 8% faster. We're talking 8% of milliseconds, so it's minor, but worth including, I think.~~