### PR TITLE
Support epub and other downloads from ZIM in jQuery mode

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -283,6 +283,8 @@
                 <iframe id="articleContent" class="articleIFrame" src="article.html"></iframe>
             </article>
             <footer>
+                <!-- Bootstrap alert box -->
+                <div id="alertBoxFooter"></div>
                 <div id="navigationButtons" class="btn-toolbar">
                     <div class="btn-group btn-group-justified">
                         <a class="btn btn-lg" id="btnHomeBottom" title="Home"><span class="glyphicon glyphicon-home"></span></a>

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -120,12 +120,69 @@ define([], function() {
     }
 
     /**
+     * Displays a Bootstrap alert box at the foot of the page to enable saving the content of the given title to the device's filesystem
+     * and initiates download/save process if this is supported by the OS or Browser
+     * 
+     * @param {String} title The path and filename to the file to be extracted
+     * @param {Boolean|String} download A Bolean value that will trigger download of title, or the filename that should
+     *     be used to save the file in local FS
+     * @param {String} contentType The mimetype of the downloadable file, if known
+     * @param {Uint8Array} content The binary-format content of the downloadable file
+     */
+    function displayFileDownloadAlert(title, download, contentType, content) {
+        // We have to create the alert box in code, because Bootstrap removes it completely from the DOM when the user dismisses it
+        document.getElementById('alertBoxFooter').innerHTML =
+        '<div id="downloadAlert" class="alert alert-info alert-dismissible">' +
+        '    <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>' +
+        '    <span id="alertMessage"></span>' +
+        '</div>';
+        // Download code adapted from https://stackoverflow.com/a/19230668/9727685 
+        if (!contentType) {
+            // DEV: Add more contentTypes here for downloadable files
+            if (/\.epub$/.test(title)) contentType = 'application/epub+zip';
+            if (/\.pdf$/.test(title)) contentType = 'application/pdf';
+            if (/\.zip$/.test(title)) contentType = 'application/zip';
+        }
+        // Set default contentType if there has been no match
+        if (!contentType) contentType = 'application/octet-stream';
+        var a = document.createElement('a');
+        var blob = new Blob([content], { 'type': contentType });
+        // If the filename to use for saving has not been specified, construct it from title
+        var filename = download === true ? title.replace(/^.*\/([^\/]+)$/, '$1') : download;
+        // Make filename safe
+        filename = filename.replace(/[\/\\:*?"<>|]/g, '_');
+        a.href = window.URL.createObjectURL(blob);
+        a.target = '_blank';
+        a.type = contentType;
+        a.download = filename;
+        a.classList.add('alert-link');
+        a.innerHTML = filename;
+        var alertMessage = document.getElementById('alertMessage');
+        alertMessage.innerHTML = '<strong>Download</strong> If the download does not start, please tap the following link: ';
+        // We have to add the anchor to a UI element for Firefox to be able to click it programmatically: see https://stackoverflow.com/a/27280611/9727685
+        alertMessage.appendChild(a);
+        try { a.click(); }
+        catch (err) {
+            // If the click fails, user may be able to download by manually clicking the link
+            // But for IE11 we need to force use of the saveBlob method with the onclick event 
+            if (window.navigator && window.navigator.msSaveBlob) {
+                a.addEventListener('click', function(e) {
+                    window.navigator.msSaveBlob(blob, filename);
+                    e.preventDefault();
+                });
+            }
+        }
+        $("#searchingArticles").hide();
+    }
+
+    /**
      * Functions and classes exposed by this module
      */
     return {
         feedNodeWithBlob: feedNodeWithBlob,
         replaceCSSLinkWithInlineCSS: replaceCSSLinkWithInlineCSS,
         removeUrlParameters: removeUrlParameters,
-        displayActiveContentWarning: displayActiveContentWarning
+        displayActiveContentWarning: displayActiveContentWarning,
+        displayFileDownloadAlert: displayFileDownloadAlert
     };
 });


### PR DESCRIPTION
This code addresses issue #439 . Currently the epub links in Guttenberg ZIMs are useless in jQuery mode. This PR handles the "download" of the epub from the ZIM to the OS's filesystem, or to open the file using the browser's open method. The code is tested and working with `gutenberg_es_all_2018-10.zim` in Edge, Chromium 66, Firefox ESR, FFOS simulator, and IE11.

Since JS doesn't work, to choose a book to test, type a space in the search field, and choose any title with the word "(cover)" in the name. Then click on the big red download icon (not the HTML5 icon, which is a simple html/text-based version of the book). In some browsers the file will automatically be saved in the download location set in the browser. In others, the user is offered a choice to save the file or open it.

The user will need to have an epub app/reader installed unless the OS provides one. In Windows 10, Edge acts as the system epub reader, with a nice resizable interface and page flipping (unless the user has installed a different epub app).

In FFOS Simulator, a message pops up at the top of the app screen to say that the file has been successfully downloaded, but when I tap on the message (the one at the top of the screen, not the alert box at the bottom), I then get a message that the file does not exist in the file system. I guess this is a quirk of the simulator not having a physical filesystem, or else that there is no installed app to handle epub files.

There is no rush to merge this before #457 (2.5 Release), unless it's felt desirable to add to the feature set of 2.5. I've tested the code fairly extensively, but it could do with testing on other systems (e.g. Linux), and I don't know how downloads are likely to be handled in extensions.