### PR TITLE
Add active content warning in jQuery mode

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -124,6 +124,18 @@
     width: 200px;
 }
 
+.alert {
+    margin-bottom: 0 !important;
+}
+
+.alert-link {
+    text-decoration: underline;
+}
+
+#alertBoxHeader {
+    text-align: center;
+}
+
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }

--- a/www/index.html
+++ b/www/index.html
@@ -202,7 +202,8 @@
                                 <div id="openLocalFiles" style="display: none;">
                                     Please select the .zim file (or all the .zimaa, .zimab etc in case of a split ZIM file)<br />
                                     <input type="file" id="archiveFiles" multiple class="btn" accept=".zim,.dat,.idx,.txt,.zimaa,.zimab,.zimac,.zimad,.zimae,.zimaf,.zimag,.zimah,.zimai,.zimaj,.zimak,.zimal,.zimam,.ziman,.zimao,.zimap,.zimaq,.zimar,.zimas,.zimat,.zimau,.zimav,.zimaw,.zimax,.zimay,.zimaz,.zimba,.zimbb,.zimbc,.zimbd,.zimbe,.zimbf,.zimbg,.zimbh,.zimbi,.zimbj,.zimbk,.zimbl,.zimbm,.zimbn,.zimbo,.zimbp,.zimbq,.zimbr,.zimbs,.zimbt,.zimbu,.zimbv,.zimbw,.zimbx,.zimby,.zimbz" /><br />
-                                    <strong>Only Mediawiki-based (wiki*.zim* files, like wikipedia) and StackExchange contents have been tested</strong> for now. Audio/video/dynamic contents are not supported for now.<br />
+                                    <strong>Only Mediawiki-based (wiki*.zim* files, like wikipedia), StackExchange and some video-based ZIMs (e.g. TEDx) have been tested</strong>.
+                                    Dynamic content is not currently supported in jQuery mode.<br />
                                 </div>
                                 <div id="scanningForArchives" style="display: none;">
                                     <br /> Scanning for archives... Please wait <img src="img/spinner.gif" alt="Please wait..." />
@@ -216,6 +217,22 @@
                     </div>
 
                     <div class="container">
+                        <div class="row">
+                            <h3>Display settings</h3>
+                            <div class="column">
+                                <div class="panel panel-info" id="displaySettingsDiv">
+                                    <div class="panel-heading">Display options:</div>
+                                    <div class="panel-body">
+                                        <div class="checkbox">
+                                            <label>
+                                                <input type="checkbox" name="hideActiveContentWarning" id="hideActiveContentWarningCheck">
+                                                <strong>Permanently hide active content warning</strong> (for experienced users)
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                         <div class="row">
                             <h3>Expert settings</h3>
                             <div class="column">
@@ -236,7 +253,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="panel panel-info" id="apiStatusDiv">
+                                <div class="panel panel-warning" id="apiStatusDiv">
                                     <div class="panel-heading">API Status</div>
                                     <div class="panel-body">
                                         <div id="serviceWorkerStatus"></div>
@@ -261,6 +278,8 @@
                     <div id="articleList" class="list-group">
                     </div>
                 </div>
+                <!-- Bootstrap alert box -->
+                <div id="alertBoxHeader"></div>
                 <iframe id="articleContent" class="articleIFrame" src="article.html"></iframe>
             </article>
             <footer>

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -85,11 +85,47 @@ define([], function() {
     }
 
     /**
+     * Displays a Bootstrap warning alert with information about how to access content in a ZIM with unsupported active UI
+     */
+    function displayActiveContentWarning() {
+        // We have to add the alert box in code, because Bootstrap removes it completely from the DOM when the user dismisses it
+        var alertHTML =
+            '<div id="activeContent" class="alert alert-warning alert-dismissible fade in">' +
+                '<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>' +
+                '<strong>Unable to display active content:</strong> This ZIM is not fully supported in jQuery mode.<br />' +
+                'Content may be available by searching above (type a space or a letter of the alphabet), or else ' +
+                '<a id="swModeLink" href="#contentInjectionModeDiv" class="alert-link">switch to Service Worker mode</a> ' +
+                'if your platform supports it. &nbsp;[<a id="stop" href="#displaySettingsDiv" class="alert-link">Permanently hide</a>]' +
+            '</div>';
+        document.getElementById('alertBoxHeader').innerHTML = alertHTML;
+        ['swModeLink', 'stop'].forEach(function(id) {
+            // Define event listeners for both hyperlinks in alert box: these take the user to the Config tab and highlight
+            // the options that the user needs to select
+            document.getElementById(id).addEventListener('click', function () {
+                var elementID = id === 'stop' ? 'hideActiveContentWarningCheck' : 'serviceworkerModeRadio';
+                var thisLabel = document.getElementById(elementID).parentNode;
+                thisLabel.style.borderColor = 'red';
+                thisLabel.style.borderStyle = 'solid';
+                var btnHome = document.getElementById('btnHome');
+                [thisLabel, btnHome].forEach(function (ele) {
+                    // Define event listeners to cancel the highlighting both on the highlighted element and on the Home tab
+                    ele.addEventListener('mousedown', function () {
+                        thisLabel.style.borderColor = '';
+                        thisLabel.style.borderStyle = '';
+                    });
+                });
+                document.getElementById('btnConfigure').click();
+            });
+        });
+    }
+
+    /**
      * Functions and classes exposed by this module
      */
     return {
         feedNodeWithBlob: feedNodeWithBlob,
         replaceCSSLinkWithInlineCSS: replaceCSSLinkWithInlineCSS,
-        removeUrlParameters: removeUrlParameters
+        removeUrlParameters: removeUrlParameters,
+        displayActiveContentWarning: displayActiveContentWarning
     };
 });


### PR DESCRIPTION
This is a first go at addressing #466. I have backported the UI features and detection of the active content warning from Kiwix JS Windows. It intelligently detects an unsupported UI and puts a yellow Bootstrap `alert-warning` just below the search box. The alert is only shown on the landing page (otherwise it would become very annoying), and is removed when the user presses Config or searches for articles. By default, it will appear again whenever the user goes back to a landing page with active content.

The alert can be dismissed temporarily (with the x) or permanently. Hyperlinks to the appropriate settings on the Config page are provided (to activate SW mode, and to hide the warning permanently), and these hyperlinks jump to (and highlight) the setting the user needs to activate. The highlighting feature is backported from Kiwix JS Windows where it is maybe more useful because there are a lot more options that can be confusing. However, it still seems useful here, and educates the user about the Config settings. It also will become more useful as display settings are added.

I've taken the liberty of including a small bit of related code that is part of the same UI feature set in Kiwix JS Windows. It responsively changes the colour of the API status panel from yellow `panel-warning` (when the SW API is unavailable or unregistered) to green `panel-success` when the SW API is available and registered. I think this makes things clearer for the user and is aesthetically pleasing.