### PR TITLE
Hide navigationButtons when in Config or About

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -139,6 +139,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         // Show the selected content in the page
         $('#about').hide();
         $('#configuration').hide();
+        $('#navigationButtons').show();
         $('#formArticleSearch').show();
         $("#welcomeText").show();
         $('#articleContent').show();
@@ -167,6 +168,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         // Show the selected content in the page
         $('#about').hide();
         $('#configuration').show();
+        $('#navigationButtons').hide();
         $('#formArticleSearch').hide();
         $("#welcomeText").hide();
         $('#articleListWithHeader').hide();
@@ -187,6 +189,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         // Show the selected content in the page
         $('#about').show();
         $('#configuration').hide();
+        $('#navigationButtons').hide();
         $('#formArticleSearch').hide();
         $("#welcomeText").hide();
         $('#articleListWithHeader').hide();


### PR DESCRIPTION
This is a very simple PR that merely hides the navigation buttons in the footer when the user clicks the About or Config buttons, and shows them again when the user clicks Home. It addresses a small part of #337 , but also shows how easy it is to hide the bottom bar for users who don't want it.