### PR TITLE
Read mime type list from zim archive

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -281,11 +281,12 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'uiUtil', 'utf8'],
         });
         QUnit.test("Image 'm/RayCharles_AManAndHisSoul.jpg' can be loaded", function(assert) {
             var done = assert.async();
-            assert.expect(4);
+            assert.expect(5);
             localZimArchive.getDirEntryByTitle("I/m/RayCharles_AManAndHisSoul.jpg").then(function(dirEntry) {
                 assert.ok(dirEntry !== null, "DirEntry found");
                 if (dirEntry !== null) {
                     assert.equal(dirEntry.namespace +"/"+ dirEntry.url, "I/m/RayCharles_AManAndHisSoul.jpg", "URL is correct.");
+                    assert.equal(dirEntry.getMimetype(), "image/jpeg", "MIME type is correct.");
                     localZimArchive.readBinaryFile(dirEntry, function(title, data) {
                         assert.equal(data.length, 4951, "Data length is correct.");
                         var beginning = new Uint8Array([255, 216, 255, 224, 0, 16, 74, 70,
@@ -301,11 +302,12 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'uiUtil', 'utf8'],
         QUnit.test("Stylesheet '-/s/style.css' can be loaded", function(assert) {
             var done = assert.async();
             
-            assert.expect(4);
+            assert.expect(5);
             localZimArchive.getDirEntryByTitle("-/s/style.css").then(function(dirEntry) {
                 assert.ok(dirEntry !== null, "DirEntry found");
                 if (dirEntry !== null) {
                     assert.equal(dirEntry.namespace +"/"+ dirEntry.url, "-/s/style.css", "URL is correct.");
+                    assert.equal(dirEntry.getMimetype(), "text/css", "MIME type is correct.");
                     localZimArchive.readBinaryFile(dirEntry, function(dirEntry, data) {
                         assert.equal(data.length, 104495, "Data length is correct.");
                         data = utf8.parse(data);
@@ -320,11 +322,12 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'uiUtil', 'utf8'],
         });
         QUnit.test("Javascript '-/j/local.js' can be loaded", function(assert) {
             var done = assert.async();
-            assert.expect(4);
+            assert.expect(5);
             localZimArchive.getDirEntryByTitle("-/j/local.js").then(function(dirEntry) {
                 assert.ok(dirEntry !== null, "DirEntry found");
                 if (dirEntry !== null) {
                     assert.equal(dirEntry.namespace +"/"+ dirEntry.url, "-/j/local.js", "URL is correct.");
+                    assert.equal(dirEntry.getMimetype(), "text/javascript", "MIME type is correct.");
                     localZimArchive.readBinaryFile(dirEntry, function(dirEntry, data) {
                         assert.equal(data.length, 41, "Data length is correct.");
                         data = utf8.parse(data);
@@ -340,11 +343,12 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'uiUtil', 'utf8'],
         });
         QUnit.test("Split article 'A/Ray_Charles.html' can be loaded", function(assert) {
             var done = assert.async();
-            assert.expect(6);
+            assert.expect(7);
             localZimArchive.getDirEntryByTitle("A/Ray_Charles.html").then(function(dirEntry) {
                 assert.ok(dirEntry !== null, "Title found");
                 if (dirEntry !== null) {
                     assert.equal(dirEntry.namespace +"/"+ dirEntry.url, "A/Ray_Charles.html", "URL is correct.");
+                    assert.equal(dirEntry.getMimetype(), "text/html", "MIME type is correct.");
                     localZimArchive.readUtf8File(dirEntry, function(dirEntry2, data) {
                         assert.equal(dirEntry2.getTitleOrUrl(), "Ray Charles", "Title is correct.");
                         assert.equal(data.length, 157186, "Data length is correct.");

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -327,7 +327,7 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'uiUtil', 'utf8'],
                 assert.ok(dirEntry !== null, "DirEntry found");
                 if (dirEntry !== null) {
                     assert.equal(dirEntry.namespace +"/"+ dirEntry.url, "-/j/local.js", "URL is correct.");
-                    assert.equal(dirEntry.getMimetype(), "text/javascript", "MIME type is correct.");
+                    assert.equal(dirEntry.getMimetype(), "application/javascript", "MIME type is correct.");
                     localZimArchive.readBinaryFile(dirEntry, function(dirEntry, data) {
                         assert.equal(data.length, 41, "Data length is correct.");
                         data = utf8.parse(data);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1013,20 +1013,9 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 var title = decodeURIComponent(imageUrl);
                 selectedArchive.getDirEntryByTitle(title).then(function(dirEntry) {
                     selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
-                        // TODO : use the complete MIME-type of the image (as read from the ZIM file)
-                        //var url = fileDirEntry.url;
                         selectedArchive.getMimetypeString(dirEntry.mimetype, function(mimetype) {
                             uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
                         });
-                        // Attempt to construct a generic mimetype first as a catchall
-                        // var mimetype = url.match(/\.(\w{2,4})$/);
-                        // mimetype = mimetype ? "image/" + mimetype[1].toLowerCase() : "image";
-                        // // Then make more specific for known image types
-                        // mimetype = /\.jpg$/i.test(url) ? "image/jpeg" : mimetype;
-                        // mimetype = /\.tif$/i.test(url) ? "image/tiff" : mimetype;
-                        // mimetype = /\.ico$/i.test(url) ? "image/x-icon" : mimetype;
-                        // mimetype = /\.svg$/i.test(url) ? "image/svg+xml" : mimetype;
-                        // uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
                     });
                 }).fail(function (e) {
                     console.error("could not find DirEntry for image:" + title, e);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1014,16 +1014,19 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 selectedArchive.getDirEntryByTitle(title).then(function(dirEntry) {
                     selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
                         // TODO : use the complete MIME-type of the image (as read from the ZIM file)
-                        var url = fileDirEntry.url;
+                        //var url = fileDirEntry.url;
+                        selectedArchive.getMimetypeString(dirEntry.mimetype, function(mimetype) {
+                            uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
+                        });
                         // Attempt to construct a generic mimetype first as a catchall
-                        var mimetype = url.match(/\.(\w{2,4})$/);
-                        mimetype = mimetype ? "image/" + mimetype[1].toLowerCase() : "image";
-                        // Then make more specific for known image types
-                        mimetype = /\.jpg$/i.test(url) ? "image/jpeg" : mimetype;
-                        mimetype = /\.tif$/i.test(url) ? "image/tiff" : mimetype;
-                        mimetype = /\.ico$/i.test(url) ? "image/x-icon" : mimetype;
-                        mimetype = /\.svg$/i.test(url) ? "image/svg+xml" : mimetype;
-                        uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
+                        // var mimetype = url.match(/\.(\w{2,4})$/);
+                        // mimetype = mimetype ? "image/" + mimetype[1].toLowerCase() : "image";
+                        // // Then make more specific for known image types
+                        // mimetype = /\.jpg$/i.test(url) ? "image/jpeg" : mimetype;
+                        // mimetype = /\.tif$/i.test(url) ? "image/tiff" : mimetype;
+                        // mimetype = /\.ico$/i.test(url) ? "image/x-icon" : mimetype;
+                        // mimetype = /\.svg$/i.test(url) ? "image/svg+xml" : mimetype;
+                        // uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
                     });
                 }).fail(function (e) {
                     console.error("could not find DirEntry for image:" + title, e);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1013,9 +1013,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 var title = decodeURIComponent(imageUrl);
                 selectedArchive.getDirEntryByTitle(title).then(function(dirEntry) {
                     selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
-                        selectedArchive.getMimetypeString(dirEntry.mimetype, function(mimetype) {
-                            uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
-                        });
+                        var mimetype = selectedArchive.getMimetypeString(dirEntry.mimetype);
+                        uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
                     });
                 }).fail(function (e) {
                     console.error("could not find DirEntry for image:" + title, e);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1013,7 +1013,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 var title = decodeURIComponent(imageUrl);
                 selectedArchive.getDirEntryByTitle(title).then(function(dirEntry) {
                     selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
-                        var mimetype = selectedArchive.getMimetypeString(dirEntry.mimetype);
+                        var mimetype = selectedArchive.getMimetype(dirEntry.mimetype);
                         uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
                     });
                 }).fail(function (e) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1013,7 +1013,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 var title = decodeURIComponent(imageUrl);
                 selectedArchive.getDirEntryByTitle(title).then(function(dirEntry) {
                     selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
-                        var mimetype = selectedArchive.getMimetype(dirEntry.mimetype);
+                        var mimetype = dirEntry.getMimetype();
                         uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
                     });
                 }).fail(function (e) {

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -116,16 +116,6 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
     };
     
     /**
-     * Looks up the dirEntry's mimetype number in the ZIM file's MIME type list, and returns the corresponding MIME type
-     * 
-     * @param {Integer} mimetype The mimetype number stored in dirEntry.mimetype, used as a lookup value
-     * @return {String} The MIME type corresponding to mimetype in the ZIM file's MIME type list
-     */
-    ZIMArchive.prototype.getMimetype = function(mimetype) {
-        return this._file.mimeTypes.get(mimetype);
-    };
-    
-    /**
      * Looks for the DirEntry of the main page
      * @param {callbackDirEntry} callback
      * @returns {Promise} that resolves to the DirEntry

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -116,11 +116,6 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
     };
     
     /**
-     * @param {Map} mimeTypeList Defines a Map to hold the MIME Type list
-     */
-    ZIMArchive.prototype.mimeTypeList = new Map;
-
-    /**
      * Populates mimeTypeList from the ZIM archive if necessary, and looks up the MIME type string from the given dirEntry's mimetype
      * 
      * @param {Integer} mimetype The mimetype number stored in dirEntry.mimetype, used as a lookup value
@@ -128,10 +123,9 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      */
     ZIMArchive.prototype.getMimetypeString = function(mimetype, callback) {
         if (this.isReady()) {
-            if (this.mimeTypeList.size === 0) {
-                // The mimeTypeList hasn't been populated yet, so let's populate it
-                
-            }
+            this._file.mimeTypeMap().then(function(data) {
+                callback(data.get(mimetype));
+            });
         }
     };
     

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -84,7 +84,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
                 });
             }
         }
-    };
+    }
 
     /**
      * Searches the directory for all parts of a split archive.
@@ -113,6 +113,26 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      */
     ZIMArchive.prototype.isReady = function() {
         return this._file !== null;
+    };
+    
+    /**
+     * @param {Map} mimeTypeList Defines a Map to hold the MIME Type list
+     */
+    ZIMArchive.prototype.mimeTypeList = new Map;
+
+    /**
+     * Populates mimeTypeList from the ZIM archive if necessary, and looks up the MIME type string from the given dirEntry's mimetype
+     * 
+     * @param {Integer} mimetype The mimetype number stored in dirEntry.mimetype, used as a lookup value
+     * @param {Function} callback The function to call with the result
+     */
+    ZIMArchive.prototype.getMimetypeString = function(mimetype, callback) {
+        if (this.isReady()) {
+            if (this.mimeTypeList.size === 0) {
+                // The mimeTypeList hasn't been populated yet, so let's populate it
+                
+            }
+        }
     };
     
     /**

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -116,7 +116,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
     };
     
     /**
-     * Populates mimeTypeList from the ZIM archive if necessary, and looks up the MIME type string from the given dirEntry's mimetype
+     * Gets the mimeTypeList from the ZIM archive and looks up the MIME type string from the given dirEntry's mimetype
      * 
      * @param {Integer} mimetype The mimetype number stored in dirEntry.mimetype, used as a lookup value
      * @param {Function} callback The function to call with the result

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -122,7 +122,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      * @return {String} The MIME type corresponding to mimetype in the ZIM file's MIME type list
      */
     ZIMArchive.prototype.getMimetype = function(mimetype) {
-            return this._file.mimeTypes.get(mimetype);
+        return this._file.mimeTypes.get(mimetype);
     };
     
     /**

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -123,9 +123,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      */
     ZIMArchive.prototype.getMimetypeString = function(mimetype, callback) {
         if (this.isReady()) {
-            this._file.mimeTypeMap().then(function(data) {
-                callback(data.get(mimetype));
-            });
+            callback(this._file.mimeTypes.get(mimetype));
         }
     };
     

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -116,12 +116,12 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
     };
     
     /**
-     * Gets the mimeTypeList from the ZIM archive and looks up the MIME type string from the given dirEntry's mimetype
+     * Looks up the dirEntry's mimetype number in the ZIM file's MIME type list, and returns the corresponding MIME type
      * 
      * @param {Integer} mimetype The mimetype number stored in dirEntry.mimetype, used as a lookup value
-     * @return {String} The MIME Type corresponding to mimetype in the ZIM file's MIME Type list
+     * @return {String} The MIME type corresponding to mimetype in the ZIM file's MIME type list
      */
-    ZIMArchive.prototype.getMimetypeString = function(mimetype) {
+    ZIMArchive.prototype.getMimetype = function(mimetype) {
             return this._file.mimeTypes.get(mimetype);
     };
     

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -119,12 +119,10 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      * Gets the mimeTypeList from the ZIM archive and looks up the MIME type string from the given dirEntry's mimetype
      * 
      * @param {Integer} mimetype The mimetype number stored in dirEntry.mimetype, used as a lookup value
-     * @param {Function} callback The function to call with the result
+     * @return {String} The MIME Type corresponding to mimetype in the ZIM file's MIME Type list
      */
-    ZIMArchive.prototype.getMimetypeString = function(mimetype, callback) {
-        if (this.isReady()) {
-            callback(this._file.mimeTypes.get(mimetype));
-        }
+    ZIMArchive.prototype.getMimetypeString = function(mimetype) {
+            return this._file.mimeTypes.get(mimetype);
     };
     
     /**

--- a/www/js/lib/zimDirEntry.js
+++ b/www/js/lib/zimDirEntry.js
@@ -31,7 +31,7 @@ define([], function() {
      * @property {File} _zimfile The ZIM file
      * @property {Boolean} redirect
      * @property {Integer} offset
-     * @property {Integer} mimetype MIME type number as defined in the MIME type list
+     * @property {Integer} mimetypeInteger MIME type number as defined in the MIME type list
      * @property {String} namespace defines to which namespace this directory entry belongs 
      * @property {Integer} redirectTarget
      * @property {Integer} cluster cluster number in which the data of this directory entry is stored 
@@ -49,7 +49,7 @@ define([], function() {
         this._zimfile = zimfile;
         this.redirect = dirEntryData.redirect;
         this.offset = dirEntryData.offset;
-        this.mimetype = dirEntryData.mimetype;
+        this.mimetypeInteger = dirEntryData.mimetypeInteger;
         this.namespace = dirEntryData.namespace;
         this.redirectTarget = dirEntryData.redirectTarget;
         this.cluster = dirEntryData.cluster;
@@ -66,7 +66,7 @@ define([], function() {
      */
     DirEntry.prototype.toStringId = function() {
         //@todo also store isRedirect and redirectTarget
-        return this.offset + '|' + this.mimetype + '|' + this.namespace + '|' + this.cluster + '|' +
+        return this.offset + '|' + this.mimetypeInteger + '|' + this.namespace + '|' + this.cluster + '|' +
                 this.blob + '|' + this.url + '|' + this.title + '|' + this.redirect + '|' + this.redirectTarget;
     };
     
@@ -96,7 +96,7 @@ define([], function() {
         var data = {};
         var idParts = stringId.split("|");
         data.offset = parseInt(idParts[0], 10);
-        data.mimetype = parseInt(idParts[1], 10);
+        data.mimetypeInteger = parseInt(idParts[1], 10);
         data.namespace = idParts[2];
         data.cluster = parseInt(idParts[3], 10);
         data.blob = parseInt(idParts[4], 10);
@@ -120,10 +120,10 @@ define([], function() {
     /**
      * Looks up the dirEntry's mimetype number in the ZIM file's MIME type list, and returns the corresponding MIME type
      * 
-     * @return {String} The MIME type corresponding to mimetype in the ZIM file's MIME type list
+     * @return {String} The MIME type corresponding to mimetypeInteger in the ZIM file's MIME type list
      */
     DirEntry.prototype.getMimetype = function() {
-        return this._zimfile.mimeTypes.get(this.mimetype);
+        return this._zimfile.mimeTypes.get(this.mimetypeInteger);
     };
 
     /**

--- a/www/js/lib/zimDirEntry.js
+++ b/www/js/lib/zimDirEntry.js
@@ -116,6 +116,15 @@ define([], function() {
     DirEntry.prototype.getTitleOrUrl = function() {
         return this.title ? this.title : this.url;
     };
+    
+    /**
+     * Looks up the dirEntry's mimetype number in the ZIM file's MIME type list, and returns the corresponding MIME type
+     * 
+     * @return {String} The MIME type corresponding to mimetype in the ZIM file's MIME type list
+     */
+    DirEntry.prototype.getMimetype = function() {
+        return this._zimfile.mimeTypes.get(this.mimetype);
+    };
 
     /**
      * Functions and classes exposed by this module

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -117,7 +117,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
      * 
      * @returns {Promise} A promise for the MIME Type list as a Map
      */
-    ZIMFile.prototype._mimeTypeMap = function() {
+    ZIMFile.prototype._readMimetypeMap = function() {
         var typeMap = new Map;
         return this._readSlice(this.mimeListPos, 256).then(function(data) {
             // DEV: We have read 256 bytes: increase this if you encounter longer MIME type lists
@@ -274,7 +274,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
                 zf.mimeListPos = readInt(header, 56, 8);
                 zf.mainPage = readInt(header, 64, 4);
                 zf.layoutPage = readInt(header, 68, 4);
-                zf._mimeTypeMap().then(function(data) {
+                zf._readMimetypeMap().then(function(data) {
                     zf.mimeTypes = data;
                 });
                 return zf;

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -111,15 +111,17 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
     };
 
     /**
-     * Reads the whole MIME Type list and returns it as a populated Map
+     * Reads the whole MIME type list and returns it as a populated Map
      * The mimeTypeMap is extracted once after the user has picked the ZIM file
      * and is stored as ZIMFile.mimetypes.
      * 
-     * @return {Promise} A promise for the MIME Type list as a Map
+     * @returns {Promise} A promise for the MIME Type list as a Map
      */
     ZIMFile.prototype._mimeTypeMap = function() {
         var typeMap = new Map;
         return this._readSlice(this.mimeListPos, 256).then(function(data) {
+            // DEV: We have read 256 bytes: increase this if you encounter longer MIME Type lists
+            // also change "while (pos < 255)" below
             if (data.subarray) {
                 var i = 1;
                 var pos = -1;
@@ -129,6 +131,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
                     mimeString = utf8.parse(data.subarray(pos), true);
                     // If the parsed data is an empty string, we have reached the end of the MIME Type list, so break 
                     if (!mimeString) break;
+                    // Store the parsed string in the Map
                     typeMap.set(i, mimeString);
                     i++;
                     while (data[pos] !== 0) {

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -213,6 +213,10 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
      * The mimeTypeMap is extracted once after the user has picked the ZIM file
      * and is stored as ZIMFile.mimeTypes
      * 
+     * @param {File} file The ZIM file (or first file in array of files) from which the MIME type list 
+*                      is to be extracted
+     * @param {Integer} mimeListPos The offset in <file> at which the MIME type list is found
+     * @param {Integer} urlPtrPos The offset of the byte after the end of the MIME type list in <file>
      * @returns {Promise} A promise for the MIME Type list as a Map
      */
     function readMimetypeMap(file, mimeListPos, urlPtrPos) {

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -141,7 +141,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
             }
             return typeMap;
         }).fail(function(err) {
-            console.errror('Unable to read MIME type list: ' + err);
+            console.error('Unable to read MIME type list', err);
             return new Map;
         });
     };

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -120,7 +120,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
     ZIMFile.prototype._mimeTypeMap = function() {
         var typeMap = new Map;
         return this._readSlice(this.mimeListPos, 256).then(function(data) {
-            // DEV: We have read 256 bytes: increase this if you encounter longer MIME Type lists
+            // DEV: We have read 256 bytes: increase this if you encounter longer MIME type lists
             // also change "while (pos < 255)" below
             if (data.subarray) {
                 var i = 1;
@@ -129,7 +129,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
                 while (pos < 255) {
                     pos++; 
                     mimeString = utf8.parse(data.subarray(pos), true);
-                    // If the parsed data is an empty string, we have reached the end of the MIME Type list, so break 
+                    // If the parsed data is an empty string, we have reached the end of the MIME type list, so break 
                     if (!mimeString) break;
                     // Store the parsed string in the Map
                     typeMap.set(i, mimeString);
@@ -140,6 +140,9 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
                 }
             }
             return typeMap;
+        }).fail(function(err) {
+            console.errror('Unable to read MIME type list: ' + err);
+            return new Map;
         });
     };
     

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -271,7 +271,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
                 zf.mimeListPos = readInt(header, 56, 8);
                 zf.mainPage = readInt(header, 64, 4);
                 zf.layoutPage = readInt(header, 68, 4);
-                zf._mimeTypeMap(zf.mimeListPos).then(function(data) {
+                zf._mimeTypeMap().then(function(data) {
                     zf.mimeTypes = data;
                 });
                 return zf;

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -224,7 +224,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
         var size = urlPtrPos - mimeListPos;
         return util.readFileSlice(file, mimeListPos, size).then(function(data) {
             if (data.subarray) {
-                var i = 1;
+                var i = 0;
                 var pos = -1;
                 var mimeString;
                 while (pos < size) {

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -134,7 +134,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
                     // Store the parsed string in the Map
                     typeMap.set(i, mimeString);
                     i++;
-                    while (data[pos] !== 0) {
+                    while (data[pos]) {
                         pos++;
                     }
                 }

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -119,14 +119,13 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
      */
     ZIMFile.prototype._readMimetypeMap = function() {
         var typeMap = new Map;
-        return this._readSlice(this.mimeListPos, 256).then(function(data) {
-            // DEV: We have read 256 bytes: increase this if you encounter longer MIME type lists
-            // also change "while (pos < 255)" below
+        var size = this.urlPtrPos - this.mimeListPos;
+        return this._readSlice(this.mimeListPos, size).then(function(data) {
             if (data.subarray) {
                 var i = 1;
                 var pos = -1;
                 var mimeString;
-                while (pos < 255) {
+                while (pos < size) {
                     pos++; 
                     mimeString = utf8.parse(data.subarray(pos), true);
                     // If the parsed data is an empty string, we have reached the end of the MIME type list, so break 

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -113,7 +113,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
     /**
      * Reads the whole MIME type list and returns it as a populated Map
      * The mimeTypeMap is extracted once after the user has picked the ZIM file
-     * and is stored as ZIMFile.mimetypes.
+     * and is stored as ZIMFile.mimeTypes
      * 
      * @returns {Promise} A promise for the MIME Type list as a Map
      */

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -111,6 +111,16 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
     };
 
     /**
+     * Reads the whole MIME Type list and returns it as a populated Map
+     * 
+     * @param {Function} callback The function to call with the returned mimeTypeList
+     */
+    ZIMFile.prototype.mimeTypeList = function(callback) {
+        // This is where the action will happen!
+
+    };
+    
+    /**
      * 
      * @param {Integer} offset
      * @returns {DirEntry} DirEntry

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -110,17 +110,14 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
         }
     };
 
-    // Variable to hold the mimeTypeMap between page reads
-    ZIMFile.prototype.mimeTypeMapCache = new Map;
-
     /**
      * Reads the whole MIME Type list and returns it as a populated Map
      * 
      * @return {Promise} A promise for the MIME Type list as a Map
      */
     ZIMFile.prototype.mimeTypeMap = function() {
-        var typeMap = this.mimeTypeMapCache;
-        // If we have already populated the mimeTypeMapCache, we can just return it
+        var typeMap = this.mimeTypes;
+        // If we have already populated mimeTypes, we can just return it
         if (typeMap.size) {
             return Q.resolve().then(function() {
                 return typeMap;
@@ -277,6 +274,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
                 zf.mimeListPos = readInt(header, 56, 8);
                 zf.mainPage = readInt(header, 64, 4);
                 zf.layoutPage = readInt(header, 68, 4);
+                zf.mimeTypes = new Map;
                 return zf;
             });
         }

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -158,10 +158,10 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
             var dirEntry =
             {
                 offset: offset,
-                mimetype: readInt(data, 0, 2),
+                mimetypeInteger: readInt(data, 0, 2),
                 namespace: String.fromCharCode(data[3])
             };
-            dirEntry.redirect = (dirEntry.mimetype === 0xffff);
+            dirEntry.redirect = (dirEntry.mimetypeInteger === 0xffff);
             if (dirEntry.redirect)
                 dirEntry.redirectTarget = readInt(data, 8, 4);
             else

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -111,41 +111,6 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
     };
 
     /**
-     * Reads the whole MIME type list and returns it as a populated Map
-     * The mimeTypeMap is extracted once after the user has picked the ZIM file
-     * and is stored as ZIMFile.mimeTypes
-     * 
-     * @returns {Promise} A promise for the MIME Type list as a Map
-     */
-    ZIMFile.prototype._readMimetypeMap = function() {
-        var typeMap = new Map;
-        var size = this.urlPtrPos - this.mimeListPos;
-        return this._readSlice(this.mimeListPos, size).then(function(data) {
-            if (data.subarray) {
-                var i = 1;
-                var pos = -1;
-                var mimeString;
-                while (pos < size) {
-                    pos++; 
-                    mimeString = utf8.parse(data.subarray(pos), true);
-                    // If the parsed data is an empty string, we have reached the end of the MIME type list, so break 
-                    if (!mimeString) break;
-                    // Store the parsed string in the Map
-                    typeMap.set(i, mimeString);
-                    i++;
-                    while (data[pos]) {
-                        pos++;
-                    }
-                }
-            }
-            return typeMap;
-        }).fail(function(err) {
-            console.error('Unable to read MIME type list', err);
-            return new Map;
-        });
-    };
-    
-    /**
      * 
      * @param {Integer} offset
      * @returns {DirEntry} DirEntry
@@ -243,6 +208,41 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
         });
     };
 
+    /**
+     * Reads the whole MIME type list and returns it as a populated Map
+     * The mimeTypeMap is extracted once after the user has picked the ZIM file
+     * and is stored as ZIMFile.mimeTypes
+     * 
+     * @returns {Promise} A promise for the MIME Type list as a Map
+     */
+    function readMimetypeMap(file, mimeListPos, urlPtrPos) {
+        var typeMap = new Map;
+        var size = urlPtrPos - mimeListPos;
+        return util.readFileSlice(file, mimeListPos, size).then(function(data) {
+            if (data.subarray) {
+                var i = 1;
+                var pos = -1;
+                var mimeString;
+                while (pos < size) {
+                    pos++; 
+                    mimeString = utf8.parse(data.subarray(pos), true);
+                    // If the parsed data is an empty string, we have reached the end of the MIME type list, so break 
+                    if (!mimeString) break;
+                    // Store the parsed string in the Map
+                    typeMap.set(i, mimeString);
+                    i++;
+                    while (data[pos]) {
+                        pos++;
+                    }
+                }
+            }
+            return typeMap;
+        }).fail(function(err) {
+            console.error('Unable to read MIME type list', err);
+            return new Map;
+        });
+    }
+    
     return {
         /**
          * 
@@ -262,21 +262,22 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
                   }
                   return 0;
             });
-            return util.readFileSlice(fileArray[0], 0, 80).then(function(header)
-            {
-                var zf = new ZIMFile(fileArray);
-                zf.articleCount = readInt(header, 24, 4);
-                zf.clusterCount = readInt(header, 28, 4);
-                zf.urlPtrPos = readInt(header, 32, 8);
-                zf.titlePtrPos = readInt(header, 40, 8);
-                zf.clusterPtrPos = readInt(header, 48, 8);
-                zf.mimeListPos = readInt(header, 56, 8);
-                zf.mainPage = readInt(header, 64, 4);
-                zf.layoutPage = readInt(header, 68, 4);
-                zf._readMimetypeMap().then(function(data) {
+            return util.readFileSlice(fileArray[0], 0, 80).then(function(header) {
+                var mimeListPos = readInt(header, 56, 8);
+                var urlPtrPos = readInt(header, 32, 8);
+                return readMimetypeMap(fileArray[0], mimeListPos, urlPtrPos).then(function(data) {
+                    var zf = new ZIMFile(fileArray);
+                    zf.articleCount = readInt(header, 24, 4);
+                    zf.clusterCount = readInt(header, 28, 4);
+                    zf.urlPtrPos = urlPtrPos;
+                    zf.titlePtrPos = readInt(header, 40, 8);
+                    zf.clusterPtrPos = readInt(header, 48, 8);
+                    zf.mimeListPos = mimeListPos;
+                    zf.mainPage = readInt(header, 64, 4);
+                    zf.layoutPage = readInt(header, 68, 4);
                     zf.mimeTypes = data;
+                    return zf;
                 });
-                return zf;
             });
         }
     };

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -271,8 +271,8 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
                 zf.mimeListPos = readInt(header, 56, 8);
                 zf.mainPage = readInt(header, 64, 4);
                 zf.layoutPage = readInt(header, 68, 4);
-                zf.mimeTypes = zf._mimeTypeMap().then(function(data) {
-                    return data;
+                zf._mimeTypeMap(zf.mimeListPos).then(function(data) {
+                    zf.mimeTypes = data;
                 });
                 return zf;
             });


### PR DESCRIPTION
~~This PR is *not* ready to merge. I'm opening it in order to test the prototype code and get help on it.~~

The code is in a working state (in jQuery mode so far), but has a problem I'd like help with. It reads the mimeTypeList correctly and stores it in a prototype Map. This works well, and prevents reading the binary data from the ZIM file multiple times per page load. Pages load successfully, and assets are assigned the correct MIME type.

~~The problem is that the map unexpectedly persists between ZIM file loads, which is not good. I don't know how to place it in the ZIM file scope. I shouldn't have to erase it explicitly on new archive load, because it's a prototype of  ZIMFile -- see zimfile.js line 114:~~

 ~~`ZIMFile.prototype.mimeTypeMapCache = new Map;`.~~

~~I'm fairly new to defining prototypes, so I'm probably doing something obviously wrong. Any clues?~~
EDIT: See below for solution