### PR TITLE
Enable drag and drop of ZIM files

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -198,9 +198,10 @@
                         <div class="row">
                             <h2>Configuration</h2>
                             <div class="column">
-                                This application needs a ZIM archive to work. If you did not download one yet, please see the About section
+                                <p id="downloadInstruction">This application needs a ZIM archive to work. For download instructions, please see the About section</p>
+                                <p id="selectorsDisplay" style="display: none;"><a href="#" id="selectorsDisplayLink">Display file selectors</a></p>
                                 <div id="openLocalFiles" style="display: none;">
-                                    Please select the .zim file (or all the .zimaa, .zimab etc in case of a split ZIM file)<br />
+                                    Please select or drag and drop the .zim file (or all the .zimaa, .zimab etc in case of a split ZIM file)<br />
                                     <input type="file" id="archiveFiles" multiple class="btn" accept=".zim,.dat,.idx,.txt,.zimaa,.zimab,.zimac,.zimad,.zimae,.zimaf,.zimag,.zimah,.zimai,.zimaj,.zimak,.zimal,.zimam,.ziman,.zimao,.zimap,.zimaq,.zimar,.zimas,.zimat,.zimau,.zimav,.zimaw,.zimax,.zimay,.zimaz,.zimba,.zimbb,.zimbc,.zimbd,.zimbe,.zimbf,.zimbg,.zimbh,.zimbi,.zimbj,.zimbk,.zimbl,.zimbm,.zimbn,.zimbo,.zimbp,.zimbq,.zimbr,.zimbs,.zimbt,.zimbu,.zimbv,.zimbw,.zimbx,.zimby,.zimbz" /><br />
                                     <strong>Only Mediawiki-based (wiki*.zim* files, like wikipedia), StackExchange and some video-based ZIMs (e.g. TEDx) have been tested</strong>.
                                     Dynamic content is not currently supported in jQuery mode.<br />

--- a/www/index.html
+++ b/www/index.html
@@ -122,7 +122,7 @@
                     <br />
                     <h4>Step 2 : copy the content onto your device</h4>
                     If you have enough space, you can put several archives.
-                    <h4>Step 3 : open the extension, go to the "Configure" menu and select your ZIM file</h4>
+                    <h4>Step 3 : drag and drop the archive file into the open the app, or go to the "Configure" menu and select your ZIM file</h4>
                     <h4>Step 4 : enjoy Wikipedia offline!</h4>
                     <h3>Privacy policy</h3>
                     <h4>Short answer :</h4>
@@ -131,7 +131,7 @@
                     Anyway, if you think your Internet access can be watched and/or if you are paranoid, you should shut down your 3G and Wifi access before using the application.
                     <br />This application only reads the archive files of your device : it does not read any other files.
                     <h3>Feedback / helping / contributing</h3>
-                    This application is still a work in progress. There are many bugs and improvements that need to be done.
+                    This application is still work in progress. There may be bugs and issues, and new features are planned.
                     Suggestions and patches/pull requests are welcome : the source code is on <a href="https://github.com/kiwix/kiwix-js" target="_blank">github</a>.
                     The <a href="https://github.com/kiwix/kiwix-js/issues" target="_blank">bugtracker</a> is on github too. We use it as our roadmap.
                     <br />Alternatively, you can send your feedback <a href="mailto:mossroy@mossroy.fr?subject=%5BKiwix%5D%20Feedback%20about%20Kiwix%20JS">by email</a>.
@@ -199,10 +199,12 @@
                             <h2>Configuration</h2>
                             <div class="column">
                                 <p id="downloadInstruction">This application needs a ZIM archive to work. For download instructions, please see the About section</p>
-                                <p id="selectorsDisplay" style="display: none;"><a href="#" id="selectorsDisplayLink">Display file selectors</a></p>
+                                <div id="selectorsDisplay" style="display: none;">
+                                    <p>Drag and drop a new ZIM file, or <a href="#" id="selectorsDisplayLink">display file selectors</a></p>
+                                </div>
                                 <div id="openLocalFiles" style="display: none;">
                                     <p>Please select or drag and drop the .zim file (or all the .zimaa, .zimab etc in case of a split ZIM file)</p>
-                                    <input type="file" id="archiveFiles" multiple class="btn" accept=".zim,.dat,.idx,.txt,.zimaa,.zimab,.zimac,.zimad,.zimae,.zimaf,.zimag,.zimah,.zimai,.zimaj,.zimak,.zimal,.zimam,.ziman,.zimao,.zimap,.zimaq,.zimar,.zimas,.zimat,.zimau,.zimav,.zimaw,.zimax,.zimay,.zimaz,.zimba,.zimbb,.zimbc,.zimbd,.zimbe,.zimbf,.zimbg,.zimbh,.zimbi,.zimbj,.zimbk,.zimbl,.zimbm,.zimbn,.zimbo,.zimbp,.zimbq,.zimbr,.zimbs,.zimbt,.zimbu,.zimbv,.zimbw,.zimbx,.zimby,.zimbz" /><br />
+                                    <input type="file" id="archiveFiles" multiple class="btn" accept=".zim,.zimaa,.zimab,.zimac,.zimad,.zimae,.zimaf,.zimag,.zimah,.zimai,.zimaj,.zimak,.zimal,.zimam,.ziman,.zimao,.zimap,.zimaq,.zimar,.zimas,.zimat,.zimau,.zimav,.zimaw,.zimax,.zimay,.zimaz,.zimba,.zimbb,.zimbc,.zimbd,.zimbe,.zimbf,.zimbg,.zimbh,.zimbi,.zimbj,.zimbk,.zimbl,.zimbm,.zimbn,.zimbo,.zimbp,.zimbq,.zimbr,.zimbs,.zimbt,.zimbu,.zimbv,.zimbw,.zimbx,.zimby,.zimbz" /><br />
                                     <strong>Only Mediawiki-based (wiki*.zim* files, like wikipedia), StackExchange and some video-based ZIMs (e.g. TEDx) have been tested</strong>.
                                     Dynamic content is not currently supported in jQuery mode.<br />
                                 </div>

--- a/www/index.html
+++ b/www/index.html
@@ -201,7 +201,7 @@
                                 <p id="downloadInstruction">This application needs a ZIM archive to work. For download instructions, please see the About section</p>
                                 <p id="selectorsDisplay" style="display: none;"><a href="#" id="selectorsDisplayLink">Display file selectors</a></p>
                                 <div id="openLocalFiles" style="display: none;">
-                                    Please select or drag and drop the .zim file (or all the .zimaa, .zimab etc in case of a split ZIM file)<br />
+                                    <p>Please select or drag and drop the .zim file (or all the .zimaa, .zimab etc in case of a split ZIM file)</p>
                                     <input type="file" id="archiveFiles" multiple class="btn" accept=".zim,.dat,.idx,.txt,.zimaa,.zimab,.zimac,.zimad,.zimae,.zimaf,.zimag,.zimah,.zimai,.zimaj,.zimak,.zimal,.zimam,.ziman,.zimao,.zimap,.zimaq,.zimar,.zimas,.zimat,.zimau,.zimav,.zimaw,.zimax,.zimay,.zimaz,.zimba,.zimbb,.zimbc,.zimbd,.zimbe,.zimbf,.zimbg,.zimbh,.zimbi,.zimbj,.zimbk,.zimbl,.zimbm,.zimbn,.zimbo,.zimbp,.zimbq,.zimbr,.zimbs,.zimbt,.zimbu,.zimbv,.zimbw,.zimbx,.zimby,.zimbz" /><br />
                                     <strong>Only Mediawiki-based (wiki*.zim* files, like wikipedia), StackExchange and some video-based ZIMs (e.g. TEDx) have been tested</strong>.
                                     Dynamic content is not currently supported in jQuery mode.<br />

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -602,6 +602,13 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             document.getElementById('downloadInstruction').style.display = 'none';
             document.getElementById('selectorsDisplay').style.display = 'inline';
         }
+        // Check for usable file types
+        for (var i = files.length; i--;) {
+            if (!/\.(?:zim\w{0,2}|dat|idx|txt)$/i.test(files[i].name)) {
+                alert("One or more files does not appear to be a ZIM file!");
+                return;
+            }    
+        }
         resetCssCache();
         selectedArchive = zimArchiveLoader.loadArchiveFromFiles(files, function (archive) {
             // The archive is set : go back to home page to start searching

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -837,9 +837,13 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     // The content is fully loaded by the browser : we can hide the spinner
                     $("#searchingArticles").hide();
                     // Deflect drag-and-drop of ZIM file on the iframe to Config
-                    var docBody = iframeArticleContent.contentDocument.documentElement.getElementsByTagName('body')[0];
-                    docBody.addEventListener('dragover', handleIframeDragover);
-                    docBody.addEventListener('drop', handleIframeDrop);
+                    var doc = iframeArticleContent.contentDocument.documentElement;
+                    var docBody = doc ? doc.getElementsByTagName('body') : null;
+                    docBody = docBody ? docBody[0] : null;
+                    if (docBody) {
+                        docBody.addEventListener('dragover', handleIframeDragover);
+                        docBody.addEventListener('drop', handleIframeDrop);
+                    }
                     iframeArticleContent.contentWindow.onunload = function() {
                         $("#searchingArticles").show();
                     };
@@ -981,15 +985,20 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             $('#articleListHeaderMessage').empty();
             $('#articleListWithHeader').hide();
             $("#prefix").val("");
+            
             // Inject the new article's HTML into the iframe
             var articleContent = iframeArticleContent.contentDocument.documentElement;
             articleContent.innerHTML = htmlArticle;
-            // Add any missing classes stripped from the <html> tag
-            var docBody = articleContent.getElementsByTagName('body')[0];
-            if (htmlCSS) docBody.classList.add(htmlCSS);
-            // Deflect drag-and-drop of ZIM file on the iframe to Config
-            docBody.addEventListener('dragover', handleIframeDragover, false);
-            docBody.addEventListener('drop', handleIframeDrop);
+            
+            var docBody = articleContent.getElementsByTagName('body');
+            docBody = docBody ? docBody[0] : null;
+            if (docBody) {
+                // Add any missing classes stripped from the <html> tag
+                if (htmlCSS) docBody.classList.add(htmlCSS);
+                // Deflect drag-and-drop of ZIM file on the iframe to Config
+                docBody.addEventListener('dragover', handleIframeDragover);
+                docBody.addEventListener('drop', handleIframeDrop);
+            }
 
             // Allow back/forward in browser history
             pushBrowserHistoryState(dirEntry.namespace + "/" + dirEntry.url);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -586,7 +586,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     function displayFileSelect() {
         document.getElementById('openLocalFiles').style.display = 'block';
         // Set the main drop zone
-        configDropZone.addEventListener('dragover', handleGlobalDragover, false);
+        configDropZone.addEventListener('dragover', handleGlobalDragover);
         configDropZone.addEventListener('dragleave', function(e) {
             configDropZone.style.border = '';
         });
@@ -595,7 +595,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             e.preventDefault();
             if (configDropZone.style.display === 'none') document.getElementById('btnConfigure').click();
             e.dataTransfer.dropEffect = 'link';
-        }, false);
+        });
         globalDropZone.addEventListener('drop', handleFileDrop);
         // This handles use of the file picker
         document.getElementById('archiveFiles').addEventListener('change', setLocalArchiveFromFileSelect);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -583,13 +583,15 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         document.getElementById('openLocalFiles').style.display = 'block';
         // Make the whole app a drop zone
         var dropZone = document.getElementById('search-article');
-        dropZone.addEventListener('dragover', function(e) {
-            e.stopPropagation();
-            e.preventDefault();
-            e.dataTransfer.dropEffect = 'link';
-        }, false);
+        dropZone.addEventListener('dragover', handleDragOver, false);
         dropZone.addEventListener('drop', setLocalArchiveFromDroppedFiles);
         document.getElementById('archiveFiles').addEventListener('change', setLocalArchiveFromFileSelect);
+    }
+
+    function handleDragOver(e) {
+        e.stopPropagation();
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'link';
     }
 
     function setLocalArchiveFromDroppedFiles(packet) {
@@ -949,7 +951,12 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             var articleContent = iframeArticleContent.contentDocument.documentElement;
             articleContent.innerHTML = htmlArticle;
             // Add any missing classes stripped from the <html> tag
-            if (htmlCSS) articleContent.getElementsByTagName('body')[0].classList.add(htmlCSS);
+            var docBody = articleContent.getElementsByTagName('body')[0];
+            if (htmlCSS) docBody.classList.add(htmlCSS);
+            // Allow drag-and-drop of ZIM file into the iframe
+            docBody.addEventListener('dragover', handleDragOver, false);
+            docBody.addEventListener('drop', setLocalArchiveFromDroppedFiles);
+
             // Allow back/forward in browser history
             pushBrowserHistoryState(dirEntry.namespace + "/" + dirEntry.url);
             

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -833,7 +833,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 $('#articleListHeaderMessage').empty();
                 $('#articleListWithHeader').hide();
                 $("#prefix").val("");
-                iframeArticleContent.onload = function () {
+                iframeArticleContent.onload = function() {
                     // The content is fully loaded by the browser : we can hide the spinner
                     $("#searchingArticles").hide();
                     // Deflect drag-and-drop of ZIM file on the iframe to Config
@@ -841,6 +841,9 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     var docBody = articleContent.getElementsByTagName('body')[0];
                     docBody.addEventListener('dragover', handleIframeDragover);
                     docBody.addEventListener('drop', handleIframeDrop);
+                    iframeArticleContent.contentWindow.onunload = function() {
+                        $("#searchingArticles").show();
+                    };
                 };
                 iframeArticleContent.src = dirEntry.namespace + "/" + encodeURIComponent(dirEntry.url);
                 // Display the iframe content

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -608,7 +608,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         document.getElementById('openLocalFiles').style.display = 'block';
         this.parentElement.style.display = 'none';
     });
-    
+
     function setLocalArchiveFromFileList(files) {
         // Check for usable file types
         for (var i = files.length; i--;) {
@@ -616,7 +616,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             if (!/\.(?:zim\w{0,2})$/i.test(files[i].name)) {
                 alert("One or more files does not appear to be a ZIM file!");
                 return;
-            }    
+            }
         }
         resetCssCache();
         selectedArchive = zimArchiveLoader.loadArchiveFromFiles(files, function (archive) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -590,6 +590,10 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         configDropZone.addEventListener('dragleave', function(e) {
             configDropZone.style.border = '';
         });
+        globalDropZone.addEventListener('dragover', function(e) {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'link';
+        }, false);
         globalDropZone.addEventListener('drop', handleFileDrop);
         document.getElementById('archiveFiles').addEventListener('change', setLocalArchiveFromFileSelect);
     }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -600,13 +600,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             files = files.dataTransfer.files;
             document.getElementById('openLocalFiles').style.display = 'none';
             document.getElementById('downloadInstruction').style.display = 'none';
-            document.getElementById('selectorsDisplay').style.display = 'block';
-            document.getElementById('selectorsDisplayLink').style.display = 'inline';
-            document.getElementById('selectorsDisplayLink').addEventListener('click', function(e) {
-                e.preventDefault();
-                document.getElementById('openLocalFiles').style.display = 'block';
-                this.style.display = 'none';
-            });
+            document.getElementById('selectorsDisplay').style.display = 'inline';
         }
         resetCssCache();
         selectedArchive = zimArchiveLoader.loadArchiveFromFiles(files, function (archive) {
@@ -615,6 +609,13 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             document.getElementById('downloadInstruction').style.display = 'none';
         });
     }
+    // Add event listener to link which allows user to show file selectors
+    document.getElementById('selectorsDisplayLink').addEventListener('click', function(e) {
+        e.preventDefault();
+        document.getElementById('openLocalFiles').style.display = 'block';
+        this.parentElement.style.display = 'none';
+    });
+
     /**
      * Sets the localArchive from the File selects populated by user
      */

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -837,8 +837,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     // The content is fully loaded by the browser : we can hide the spinner
                     $("#searchingArticles").hide();
                     // Deflect drag-and-drop of ZIM file on the iframe to Config
-                    var articleContent = document.getElementById('articleContent').contentDocument.documentElement;
-                    var docBody = articleContent.getElementsByTagName('body')[0];
+                    var docBody = iframeArticleContent.contentDocument.documentElement.getElementsByTagName('body')[0];
                     docBody.addEventListener('dragover', handleIframeDragover);
                     docBody.addEventListener('drop', handleIframeDrop);
                     iframeArticleContent.contentWindow.onunload = function() {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -586,7 +586,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         dropZone.addEventListener('dragover', function(e) {
             e.stopPropagation();
             e.preventDefault();
-            e.dataTransfer.dropEffect = 'copy';
+            e.dataTransfer.dropEffect = 'link';
         }, false);
         dropZone.addEventListener('drop', setLocalArchiveFromFileList);
         document.getElementById('archiveFiles').addEventListener('change', setLocalArchiveFromFileSelect);
@@ -604,7 +604,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         }
         // Check for usable file types
         for (var i = files.length; i--;) {
-            if (!/\.(?:zim\w{0,2}|dat|idx|txt)$/i.test(files[i].name)) {
+            // DEV: you can support other file types by adding (e.g.) '|dat|idx' after 'zim\w{0,2}'
+            if (!/\.(?:zim\w{0,2})$/i.test(files[i].name)) {
                 alert("One or more files does not appear to be a ZIM file!");
                 return;
             }    

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -585,17 +585,19 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
      */
     function displayFileSelect() {
         document.getElementById('openLocalFiles').style.display = 'block';
-        // Make the whole app a drop zone
+        // Set the main drop zone
         configDropZone.addEventListener('dragover', handleGlobalDragover, false);
         configDropZone.addEventListener('dragleave', function(e) {
             configDropZone.style.border = '';
         });
+        // Also set a global drop zone (allows us to ensure Config is always displayed for the file drop)
         globalDropZone.addEventListener('dragover', function(e) {
             e.preventDefault();
             if (configDropZone.style.display === 'none') document.getElementById('btnConfigure').click();
             e.dataTransfer.dropEffect = 'link';
         }, false);
         globalDropZone.addEventListener('drop', handleFileDrop);
+        // This handles use of the file picker
         document.getElementById('archiveFiles').addEventListener('change', setLocalArchiveFromFileSelect);
     }
 
@@ -626,6 +628,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         document.getElementById('downloadInstruction').style.display = 'none';
         document.getElementById('selectorsDisplay').style.display = 'inline';
         setLocalArchiveFromFileList(files);
+        // This clears the display of any previously picked archive in the file selector
         document.getElementById('archiveFiles').value = null;
     }
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -580,11 +580,34 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
      * Displays the zone to select files from the archive
      */
     function displayFileSelect() {
-        $('#openLocalFiles').show();
-        $('#archiveFiles').on('change', setLocalArchiveFromFileSelect);
+        document.getElementById('openLocalFiles').style.display = 'block';
+        // Make the whole app a drop zone
+        var dropZone = document.getElementById('search-article');
+        dropZone.addEventListener('dragover', function(e) {
+            e.stopPropagation();
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'copy';
+        }, false);
+        dropZone.addEventListener('drop', setLocalArchiveFromFileList);
+        document.getElementById('archiveFiles').addEventListener('change', setLocalArchiveFromFileSelect);
     }
 
     function setLocalArchiveFromFileList(files) {
+        // Check to see if the files are from file select or from drag-and-drop
+        if (files.dataTransfer) {
+            files.stopPropagation();
+            files.preventDefault();
+            files = files.dataTransfer.files;
+            document.getElementById('openLocalFiles').style.display = 'none';
+            document.getElementById('downloadInstruction').style.display = 'none';
+            document.getElementById('selectorsDisplay').style.display = 'block';
+            document.getElementById('selectorsDisplayLink').addEventListener('click', function(e){
+                e.preventDefault();
+                document.getElementById('openLocalFiles').style.display = 'block';
+                this.style.display = 'none';
+            });
+        }
+        files = files.dataTransfer ? files.dataTransfer.files : files;
         resetCssCache();
         selectedArchive = zimArchiveLoader.loadArchiveFromFiles(files, function (archive) {
             // The archive is set : go back to home page to start searching

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -588,20 +588,28 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             e.preventDefault();
             e.dataTransfer.dropEffect = 'link';
         }, false);
-        dropZone.addEventListener('drop', setLocalArchiveFromFileList);
+        dropZone.addEventListener('drop', setLocalArchiveFromDroppedFiles);
         document.getElementById('archiveFiles').addEventListener('change', setLocalArchiveFromFileSelect);
     }
 
+    function setLocalArchiveFromDroppedFiles(packet) {
+        packet.stopPropagation();
+        packet.preventDefault();
+        var files = packet.dataTransfer.files;
+        document.getElementById('openLocalFiles').style.display = 'none';
+        document.getElementById('downloadInstruction').style.display = 'none';
+        document.getElementById('selectorsDisplay').style.display = 'inline';
+        setLocalArchiveFromFileList(files);
+    }
+
+    // Add event listener to link which allows user to show file selectors
+    document.getElementById('selectorsDisplayLink').addEventListener('click', function(e) {
+        e.preventDefault();
+        document.getElementById('openLocalFiles').style.display = 'block';
+        this.parentElement.style.display = 'none';
+    });
+    
     function setLocalArchiveFromFileList(files) {
-        // Check to see if the files are from file select or from drag-and-drop
-        if (files.dataTransfer) {
-            files.stopPropagation();
-            files.preventDefault();
-            files = files.dataTransfer.files;
-            document.getElementById('openLocalFiles').style.display = 'none';
-            document.getElementById('downloadInstruction').style.display = 'none';
-            document.getElementById('selectorsDisplay').style.display = 'inline';
-        }
         // Check for usable file types
         for (var i = files.length; i--;) {
             // DEV: you can support other file types by adding (e.g.) '|dat|idx' after 'zim\w{0,2}'
@@ -617,12 +625,6 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             document.getElementById('downloadInstruction').style.display = 'none';
         });
     }
-    // Add event listener to link which allows user to show file selectors
-    document.getElementById('selectorsDisplayLink').addEventListener('click', function(e) {
-        e.preventDefault();
-        document.getElementById('openLocalFiles').style.display = 'block';
-        this.parentElement.style.display = 'none';
-    });
 
     /**
      * Sets the localArchive from the File selects populated by user

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -601,13 +601,12 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             document.getElementById('openLocalFiles').style.display = 'none';
             document.getElementById('downloadInstruction').style.display = 'none';
             document.getElementById('selectorsDisplay').style.display = 'block';
-            document.getElementById('selectorsDisplayLink').addEventListener('click', function(e){
+            document.getElementById('selectorsDisplayLink').addEventListener('click', function(e) {
                 e.preventDefault();
                 document.getElementById('openLocalFiles').style.display = 'block';
                 this.style.display = 'none';
             });
         }
-        files = files.dataTransfer ? files.dataTransfer.files : files;
         resetCssCache();
         selectedArchive = zimArchiveLoader.loadArchiveFromFiles(files, function (archive) {
             // The archive is set : go back to home page to start searching

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -601,6 +601,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             document.getElementById('openLocalFiles').style.display = 'none';
             document.getElementById('downloadInstruction').style.display = 'none';
             document.getElementById('selectorsDisplay').style.display = 'block';
+            document.getElementById('selectorsDisplayLink').style.display = 'inline';
             document.getElementById('selectorsDisplayLink').addEventListener('click', function(e) {
                 e.preventDefault();
                 document.getElementById('openLocalFiles').style.display = 'block';
@@ -611,6 +612,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         selectedArchive = zimArchiveLoader.loadArchiveFromFiles(files, function (archive) {
             // The archive is set : go back to home page to start searching
             $("#btnHome").click();
+            document.getElementById('downloadInstruction').style.display = 'none';
         });
     }
     /**

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -592,6 +592,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         });
         globalDropZone.addEventListener('dragover', function(e) {
             e.preventDefault();
+            if (configDropZone.style.display === 'none') document.getElementById('btnConfigure').click();
             e.dataTransfer.dropEffect = 'link';
         }, false);
         globalDropZone.addEventListener('drop', handleFileDrop);
@@ -625,13 +626,14 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         document.getElementById('downloadInstruction').style.display = 'none';
         document.getElementById('selectorsDisplay').style.display = 'inline';
         setLocalArchiveFromFileList(files);
+        document.getElementById('archiveFiles').value = null;
     }
 
     // Add event listener to link which allows user to show file selectors
     document.getElementById('selectorsDisplayLink').addEventListener('click', function(e) {
         e.preventDefault();
         document.getElementById('openLocalFiles').style.display = 'block';
-        this.parentElement.style.display = 'none';
+        document.getElementById('selectorsDisplay').style.display = 'none';
     });
 
     function setLocalArchiveFromFileList(files) {


### PR DESCRIPTION
This is a (relatively) easy PR addressing an old issue #29.

The entire app is enabled as a drop target, so a file can be dropped anywhere except in the populated iframe. I experimented with trying to enable dropping onto the iframe, but it would have required injecting scripts into the frame, which seems excessive, since the file can easily be dropped anywhere above it. 

Once a file has been selected in this way, the file picker and instructions are hidden, but a link is provided to show them again if the user wants to use the file picker.