### PR TITLE
Allow keyboard selection in search list

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -73,6 +73,10 @@
     background: lightblue;
 }
 
+#articleList a:hover, #articleList a.hover {
+    background: lightblue;
+}
+
 .articleIFrame {
     width: 100%;
     border: 0;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -117,7 +117,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             var activeElement = document.querySelector("#articleList .hover") || document.querySelector("#articleList a");
             if (!activeElement) return;
             // If user presses Enter, read the dirEntry
-            if (/^Enter$/.test(e.key)) {
+            if (/Enter/.test(e.key)) {
                 if (activeElement.classList.contains('hover')) {
                     var dirEntryId = activeElement.getAttribute('dirEntryId');
                     findDirEntryFromDirEntryIdAndLaunchArticleRead(dirEntryId);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -872,8 +872,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     function findDirEntryFromDirEntryIdAndLaunchArticleRead(dirEntryId) {
         if (selectedArchive.isReady()) {
             var dirEntry = selectedArchive.parseDirEntryId(dirEntryId);
-            // Remove focus from search field to hide keyboard
-            $("#searchArticles").focus();
+            // Remove focus from search field to hide keyboard and to allow navigation keys to be used
+            document.getElementById('articleContent').contentWindow.focus();
             $("#searchingArticles").show();
             if (dirEntry.isRedirect()) {
                 selectedArchive.resolveRedirect(dirEntry, readArticle);
@@ -905,8 +905,6 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 iframeArticleContent.onload = function() {
                     // The content is fully loaded by the browser : we can hide the spinner
                     $("#searchingArticles").hide();
-                    // Place focus on document so that any mobile on-screen keyboard is removed and navigation keys work
-                    if (!params.isLandingPage) iframeArticleContent.contentWindow.focus();
                     // Deflect drag-and-drop of ZIM file on the iframe to Config
                     var doc = iframeArticleContent.contentDocument.documentElement;
                     var docBody = doc ? doc.getElementsByTagName('body') : null;
@@ -1056,11 +1054,6 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             $('#articleListHeaderMessage').empty();
             $('#articleListWithHeader').hide();
             $("#prefix").val("");
-            // Place focus on document so that any mobile on-screen keyboard is removed and navigation keys work
-            // NB Firefox requires this to be async, probably because the injection of the iframe is async
-            if (!params.isLandingPage) setTimeout(function() {
-                iframeArticleContent.contentWindow.focus();
-            }, 10);
             
             // Inject the new article's HTML into the iframe
             var articleContent = iframeArticleContent.contentDocument.documentElement;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -93,8 +93,11 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         document.getElementById("searchArticles").click();
         return false;
     });
+    // Handle keyboard events in the prefix (article search) field
     var keyPressHandled = false;
     $('#prefix').on('keydown', function(e) {
+        // If user presses Escape...
+        // (IE11 returns "Esc" and the other browsers "Escape"; regex below matches both)
         if (/^Esc/.test(e.key)) {
             // Hide the article list
             e.preventDefault();
@@ -103,7 +106,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             $('#articleContent').focus();
             keyPressHandled = true;
         }
-        // Keyboard selection code adapted from https://stackoverflow.com/a/14747926/9727685
+        // Arrow-key selection code adapted from https://stackoverflow.com/a/14747926/9727685
         if (/^((Arrow)?Down|(Arrow)?Up|Enter)$/.test(e.key)) {
             // User pressed Down arrow or Up arrow or Enter
             e.preventDefault();
@@ -112,14 +115,16 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             keyPressHandled = true;
             var activeElement = document.querySelector("#articleList .hover") || document.querySelector("#articleList a");
             if (!activeElement) return;
-            if (/Enter/.test(e.key)) {
+            // If user presses Enter, read the dirEntry
+            if (/^Enter$/.test(e.key)) {
                 if (activeElement.classList.contains('hover')) {
                     var dirEntryId = activeElement.getAttribute('dirEntryId');
                     findDirEntryFromDirEntryIdAndLaunchArticleRead(dirEntryId);
                     return;
                 }
             }
-            if (/(Arrow)?Down/.test(e.key)) {
+            // If user presses ArrowDown (in IE11, we get "Down")...
+            if (/^(Arrow)?Down$/.test(e.key)) {
                 if (activeElement.classList.contains('hover')) {
                     activeElement.classList.remove('hover');
                     activeElement = activeElement.nextElementSibling || activeElement;
@@ -127,7 +132,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     if (!uiUtil.isElementInView(nextElement, true)) nextElement.scrollIntoView(false);
                 }
             }
-            if (/(Arrow)?Up/.test(e.key)) {
+            // If user presses ArrowUp (in IE11, we get "Up")...
+            if (/^(Arrow)?Up$/.test(e.key)) {
                 activeElement.classList.remove('hover');
                 activeElement = activeElement.previousElementSibling || activeElement;
                 var previousElement = activeElement.previousElementSibling || activeElement;
@@ -135,21 +141,24 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 if (previousElement === activeElement) document.getElementById('top').scrollIntoView();
             }
             activeElement.classList.add('hover');
-            
         }
     });
+    // Search for titles as user types characters
     $('#prefix').on('keyup', function(e) {
         if (selectedArchive !== null && selectedArchive.isReady()) {
+            // Prevent processing by keyup event if we already handled the keypress in keydown event
             if (keyPressHandled)
                 keyPressHandled = false;
             else
                 onKeyUpPrefix(e);
         }
     });
+    // Restore the search results if user goes back into prefix field
     $('#prefix').on('focus', function(e) {
         if ($('#prefix').val() !== '') 
             $('#articleListWithHeader').show();
     });
+    // Hide the search resutls if user moves out of prefix field
     $('#prefix').on('blur', function() {
         $('#articleListWithHeader').hide();
     });

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1057,7 +1057,10 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             $('#articleListWithHeader').hide();
             $("#prefix").val("");
             // Place focus on document so that any mobile on-screen keyboard is removed and navigation keys work
-            iframeArticleContent.contentWindow.focus();
+            // NB Firefox requires this to be async, probably because the injection of the iframe is async
+            setTimeout(function(){
+                iframeArticleContent.contentWindow.focus();
+            }, 1);
             
             // Inject the new article's HTML into the iframe
             var articleContent = iframeArticleContent.contentDocument.documentElement;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1060,7 +1060,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             // NB Firefox requires this to be async, probably because the injection of the iframe is async
             if (!params.isLandingPage) setTimeout(function() {
                 iframeArticleContent.contentWindow.focus();
-            }, 1);
+            }, 10);
             
             // Inject the new article's HTML into the iframe
             var articleContent = iframeArticleContent.contentDocument.documentElement;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -97,7 +97,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     var keyPressHandled = false;
     $('#prefix').on('keydown', function(e) {
         // If user presses Escape...
-        // (IE11 returns "Esc" and the other browsers "Escape"; regex below matches both)
+        // IE11 returns "Esc" and the other browsers "Escape"; regex below matches both
         if (/^Esc/.test(e.key)) {
             // Hide the article list
             e.preventDefault();
@@ -107,6 +107,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             keyPressHandled = true;
         }
         // Arrow-key selection code adapted from https://stackoverflow.com/a/14747926/9727685
+        // IE11 produces "Down" instead of "ArrowDown" and "Up" instead of "ArrowUp"
         if (/^((Arrow)?Down|(Arrow)?Up|Enter)$/.test(e.key)) {
             // User pressed Down arrow or Up arrow or Enter
             e.preventDefault();
@@ -123,8 +124,9 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     return;
                 }
             }
-            // If user presses ArrowDown (in IE11, we get "Down")...
-            if (/^(Arrow)?Down$/.test(e.key)) {
+            // If user presses ArrowDown...
+            // (NB selection is limited to five possibilities by regex above)
+            if (/Down/.test(e.key)) {
                 if (activeElement.classList.contains('hover')) {
                     activeElement.classList.remove('hover');
                     activeElement = activeElement.nextElementSibling || activeElement;
@@ -132,8 +134,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     if (!uiUtil.isElementInView(nextElement, true)) nextElement.scrollIntoView(false);
                 }
             }
-            // If user presses ArrowUp (in IE11, we get "Up")...
-            if (/^(Arrow)?Up$/.test(e.key)) {
+            // If user presses ArrowUp...
+            if (/Up/.test(e.key)) {
                 activeElement.classList.remove('hover');
                 activeElement = activeElement.previousElementSibling || activeElement;
                 var previousElement = activeElement.previousElementSibling || activeElement;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -906,7 +906,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     // The content is fully loaded by the browser : we can hide the spinner
                     $("#searchingArticles").hide();
                     // Place focus on document so that any mobile on-screen keyboard is removed and navigation keys work
-                    iframeArticleContent.contentWindow.focus();
+                    if (!params.isLandingPage) iframeArticleContent.contentWindow.focus();
                     // Deflect drag-and-drop of ZIM file on the iframe to Config
                     var doc = iframeArticleContent.contentDocument.documentElement;
                     var docBody = doc ? doc.getElementsByTagName('body') : null;
@@ -1058,7 +1058,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             $("#prefix").val("");
             // Place focus on document so that any mobile on-screen keyboard is removed and navigation keys work
             // NB Firefox requires this to be async, probably because the injection of the iframe is async
-            setTimeout(function(){
+            if (!params.isLandingPage) setTimeout(function() {
                 iframeArticleContent.contentWindow.focus();
             }, 1);
             

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -905,6 +905,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 iframeArticleContent.onload = function() {
                     // The content is fully loaded by the browser : we can hide the spinner
                     $("#searchingArticles").hide();
+                    // Place focus on document so that any mobile on-screen keyboard is removed and navigation keys work
+                    iframeArticleContent.contentWindow.focus();
                     // Deflect drag-and-drop of ZIM file on the iframe to Config
                     var doc = iframeArticleContent.contentDocument.documentElement;
                     var docBody = doc ? doc.getElementsByTagName('body') : null;
@@ -1054,6 +1056,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             $('#articleListHeaderMessage').empty();
             $('#articleListWithHeader').hide();
             $("#prefix").val("");
+            // Place focus on document so that any mobile on-screen keyboard is removed and navigation keys work
+            iframeArticleContent.contentWindow.focus();
             
             // Inject the new article's HTML into the iframe
             var articleContent = iframeArticleContent.contentDocument.documentElement;
@@ -1071,7 +1075,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
 
             // Allow back/forward in browser history
             pushBrowserHistoryState(dirEntry.namespace + "/" + dirEntry.url);
-            
+
             parseAnchorsJQuery();
             loadImagesJQuery();
             // JavaScript is currently disabled, so we need to make the browser interpret noscript tags

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -176,6 +176,21 @@ define([], function() {
     }
 
     /**
+     * Checks whether an element is partially or fully inside the current viewport
+     * 
+     * @param {Element} el The DOM element for which to check visibility
+     * @param {Boolean} fully If true, checks that the entire element is inside the viewport
+     * @returns {Boolean} True if the element is fully or partially inside the current viewport
+     */
+    function isElementInView(el, fully) {
+        var rect = el.getBoundingClientRect();
+        if (fully)
+            return rect.top > 0 && rect.bottom < window.innerHeight && rect.left > 0 && rect.right < window.innerWidth;
+        else 
+            return rect.top < window.innerHeight && rect.bottom > 0 && rect.left < window.innerWidth && rect.right > 0;
+    }
+
+    /**
      * Functions and classes exposed by this module
      */
     return {
@@ -183,6 +198,7 @@ define([], function() {
         replaceCSSLinkWithInlineCSS: replaceCSSLinkWithInlineCSS,
         removeUrlParameters: removeUrlParameters,
         displayActiveContentWarning: displayActiveContentWarning,
-        displayFileDownloadAlert: displayFileDownloadAlert
+        displayFileDownloadAlert: displayFileDownloadAlert,
+        isElementInView: isElementInView
     };
 });

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -179,8 +179,10 @@ define([], function() {
      * Checks whether an element is partially or fully inside the current viewport
      * 
      * @param {Element} el The DOM element for which to check visibility
-     * @param {Boolean} fully If true, checks that the entire element is inside the viewport
-     * @returns {Boolean} True if the element is fully or partially inside the current viewport
+     * @param {Boolean} fully If true, checks that the entire element is inside the viewport; 
+     *          if false, checks whether any part of the element is inside the viewport
+     * @returns {Boolean} True if the element is fully or partially (depending on the value of <fully>)
+     *          inside the current viewport
      */
     function isElementInView(el, fully) {
         var rect = el.getBoundingClientRect();


### PR DESCRIPTION
This addresses #55 . It also has the functionality of #499 built into this PR, but #499 could be merged first in order to keep the development steps in order. This is tested on Edge 44, Edge 76, Firefox ESR, Internet Explorer 11. It also works on FFOS simulator if using the computer keyboard to select titles. However, this isn't really relevant in that context, I think.

There is one display bug on FFOS simulator only, which is that if we scroll down (with down arrow on computer keyboard) a long list of found titles, and then scroll back up (with up arrow), then the whole app scrolls up a little in the IDE, leaving an odd space at the bottom. I think this is just an artefact of the simulator, and I guess it can't be tested on a real device because a keyboard can't be attached.

The other issue on FFOS simulator is that the on-screen keyboard remains in place even after pressing the physical button. This is because I have to keep focus on the prefix field, to monitor further key presses. But again, I think this is not a "real" issue in any touchscreen app environment, just an artefact of the simulator.