### PR TITLE
Apply dirEntry.getMimetype throughout code

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -95,19 +95,12 @@ function fetchEventListener(event) {
                 messageChannel.port1.onmessage = function(event) {
                     if (event.data.action === 'giveContent') {
                         // Content received from app.js
-                        var contentLength;
+                        var contentLength = event.data.content ? event.data.content.byteLength : null;
                         var contentType = event.data.mimetype;
                         var headers = new Headers ();
-                        if (event.data.content && event.data.content.byteLength) {
-                            contentLength = event.data.content.byteLength;
-                            headers.set('Content-Length', contentLength);
-                        }
-                        if (contentType) {
-                            headers.set('Content-Type', contentType);
-                        }
+                        if (contentLength) headers.set('Content-Length', contentLength);
+                        if (contentType) headers.set('Content-Type', contentType);
                         // Test if the content is a video.
-                        // String.prototype.startsWith is not supported by IE11, but IE11 does not support service workers, so it's safe to use it here.
-                        // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
                         if (contentLength >= 1 && /video|mp4|webm|ogg/i.test(contentType)) {
                             // In case of a video, Chrome and Edge need these HTTP headers else seeking doesn't work
                             // (even if we always send all the video content, not the requested range, until the backend supports it)

--- a/service-worker.js
+++ b/service-worker.js
@@ -100,8 +100,10 @@ function fetchEventListener(event) {
                         var headers = new Headers ();
                         if (contentLength) headers.set('Content-Length', contentLength);
                         if (contentType) headers.set('Content-Type', contentType);
-                        // Test if the content is a video.
-                        if (contentLength >= 1 && /video|audio|mp4|webm|og[gmv]|mpeg/i.test(contentType)) {
+                        // Test if the content is a video or audio file
+                        // See kiwix-js #519 and openzim/zimwriterfs #113 for why we test for invalid types like "mp4" or "webm" (without "video/")
+                        // The full list of types produced by zimwriterfs is in https://github.com/openzim/zimwriterfs/blob/master/src/tools.cpp
+                        if (contentLength >= 1 && /^(video|audio)|(^|\/)(mp4|webm|og[gmv]|mpeg)$/i.test(contentType)) {
                             // In case of a video (at least), Chrome and Edge need these HTTP headers else seeking doesn't work
                             // (even if we always send all the video content, not the requested range, until the backend supports it)
                             headers.set('Accept-Ranges', 'bytes');

--- a/service-worker.js
+++ b/service-worker.js
@@ -108,7 +108,7 @@ function fetchEventListener(event) {
                         // Test if the content is a video.
                         // String.prototype.startsWith is not supported by IE11, but IE11 does not support service workers, so it's safe to use it here.
                         // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
-                        if (contentLength && contentLength >= 1 && contentType && contentType.startsWith('video/')) {
+                        if (contentLength && contentLength >= 1 && /video|mp4|webm|ogg/i.test(contentType)) {
                             // In case of a video, Chrome and Edge need these HTTP headers else seeking doesn't work
                             // (even if we always send all the video content, not the requested range, until the backend supports it)
                             headers.set('Accept-Ranges', 'bytes');

--- a/service-worker.js
+++ b/service-worker.js
@@ -101,8 +101,8 @@ function fetchEventListener(event) {
                         if (contentLength) headers.set('Content-Length', contentLength);
                         if (contentType) headers.set('Content-Type', contentType);
                         // Test if the content is a video.
-                        if (contentLength >= 1 && /video|mp4|webm|ogg/i.test(contentType)) {
-                            // In case of a video, Chrome and Edge need these HTTP headers else seeking doesn't work
+                        if (contentLength >= 1 && /video|audio|mp4|webm|og[gmv]|mpeg/i.test(contentType)) {
+                            // In case of a video (at least), Chrome and Edge need these HTTP headers else seeking doesn't work
                             // (even if we always send all the video content, not the requested range, until the backend supports it)
                             headers.set('Accept-Ranges', 'bytes');
                             headers.set('Content-Range', 'bytes 0-' + (contentLength-1) + '/' + contentLength);

--- a/service-worker.js
+++ b/service-worker.js
@@ -108,7 +108,7 @@ function fetchEventListener(event) {
                         // Test if the content is a video.
                         // String.prototype.startsWith is not supported by IE11, but IE11 does not support service workers, so it's safe to use it here.
                         // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
-                        if (contentLength && contentLength >= 1 && /video|mp4|webm|ogg/i.test(contentType)) {
+                        if (contentLength >= 1 && /video|mp4|webm|ogg/i.test(contentType)) {
                             // In case of a video, Chrome and Edge need these HTTP headers else seeking doesn't work
                             // (even if we always send all the video content, not the requested range, until the backend supports it)
                             headers.set('Accept-Ranges', 'bytes');

--- a/service-worker.js
+++ b/service-worker.js
@@ -69,21 +69,6 @@ self.addEventListener('message', function (event) {
     }
 });
 
-// TODO : this way to recognize content types is temporary
-// It must be replaced by reading the actual MIME-Type from the backend
-var regexpJPEG = new RegExp(/\.jpe?g$/i);
-var regexpPNG = new RegExp(/\.png$/i);
-var regexpJS = new RegExp(/\.js/i);
-var regexpCSS = new RegExp(/\.css$/i);
-var regexpSVG = new RegExp(/\.svg$/i);
-var regexpWEBM = new RegExp(/\.webm$/i);
-var regexpMP4 = new RegExp(/\.mp4$/i);
-var regexpOGG = new RegExp(/\.og[mvg]$/i);
-var regexpVTT = new RegExp(/\.vtt$/i);
-var regexpPDF = new RegExp(/\.pdf$/i);
-var regexpZIP = new RegExp(/\.zip$/i);
-var regexpEPUB = new RegExp(/\.epub$/i);
-
 // Pattern for ZIM file namespace - see https://wiki.openzim.org/wiki/ZIM_file_format#Namespaces
 var regexpZIMUrlWithNamespace = new RegExp(/(?:^|\/)([-ABIJMUVWX])\/(.+)/);
 
@@ -96,66 +81,9 @@ function fetchEventListener(event) {
                 var nameSpace;
                 var title;
                 var titleWithNameSpace;
-                var contentType;
                 var regexpResult = regexpZIMUrlWithNamespace.exec(event.request.url);
                 nameSpace = regexpResult[1];
                 title = regexpResult[2];
-
-                // The namespace defines the type of content. See https://wiki.openzim.org/wiki/ZIM_file_format#Namespaces
-                // TODO : read the contentType from the ZIM file instead of hard-coding it here
-                if (nameSpace === 'A') {
-                    if (regexpVTT.test(title)) {
-                        // It's a subtitle
-                        contentType = 'text/vtt';
-                    }
-                    else {
-                        // It's an article
-                        contentType = 'text/html';
-                    }
-                }
-                else if (nameSpace === 'I' || nameSpace === 'J') {
-                    // It's an image or another kind of media
-                    if (regexpJPEG.test(title)) {
-                        contentType = 'image/jpeg';
-                    }
-                    else if (regexpPNG.test(title)) {
-                        contentType = 'image/png';
-                    } 
-                    else if (regexpSVG.test(title)) {
-                        contentType = 'image/svg+xml';
-                    }
-                    else if (regexpWEBM.test(title)) {
-                        contentType = 'video/webm';
-                    }
-                    else if (regexpMP4.test(title)) {
-                        contentType = 'video/mp4';
-                    }
-                    else if (regexpOGG.test(title)) {
-                        contentType = 'video/ogg';
-                    }
-                    else if (regexpPDF.test(title)) {
-                        contentType = 'application/pdf';
-                    }
-                    else if (regexpEPUB.test(title)) {
-                        contentType = 'application/epub+zip';
-                    }
-                    else if (regexpZIP.test(title)) {
-                        contentType = 'application/zip';
-                    }
-                }
-                else if (nameSpace === '-') {
-                    // It's a layout dependency
-                    if (regexpJS.test(title)) {
-                        contentType = 'text/javascript';
-                    }
-                    else if (regexpCSS.test(title)) {
-                        contentType = 'text/css';
-                    }
-                    else if (regexpVTT.test(title)) {
-                        // It's a subtitle
-                        contentType = 'text/vtt';
-                    }
-                }
 
                 // We need to remove the potential parameters in the URL
                 title = removeUrlParameters(decodeURIComponent(title));
@@ -168,6 +96,7 @@ function fetchEventListener(event) {
                     if (event.data.action === 'giveContent') {
                         // Content received from app.js
                         var contentLength;
+                        var contentType = event.data.mimetype;
                         var headers = new Headers ();
                         if (event.data.content && event.data.content.byteLength) {
                             contentLength = event.data.content.byteLength;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1323,6 +1323,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 alert("Article with title " + title + " not found in the archive");
             } else if (download) {
                 selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
+                    var mimetype = contentType || fileDirEntry.getMimetype();
                     uiUtil.displayFileDownloadAlert(title, download, contentType, content);
                 });
             } else {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -161,13 +161,7 @@ define([], function() {
         '    <span id="alertMessage"></span>' +
         '</div>';
         // Download code adapted from https://stackoverflow.com/a/19230668/9727685 
-        if (!contentType) {
-            // DEV: Add more contentTypes here for downloadable files
-            if (/\.epub$/.test(title)) contentType = 'application/epub+zip';
-            if (/\.pdf$/.test(title)) contentType = 'application/pdf';
-            if (/\.zip$/.test(title)) contentType = 'application/zip';
-        }
-        // Set default contentType if there has been no match
+        // Set default contentType if none was provided
         if (!contentType) contentType = 'application/octet-stream';
         var a = document.createElement('a');
         var blob = new Blob([content], { 'type': contentType });


### PR DESCRIPTION
This is a PR to apply the use of `dirEntry.getMimetype()` throughout the code as per #500.

So far I have done Service Worker. I need to check if there are other places remaining where we could use this function.