### PR TITLE
Add the ZIM file name as a prefix of the iframe URL, in SW mode.

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -70,7 +70,8 @@ self.addEventListener('message', function (event) {
 });
 
 // Pattern for ZIM file namespace - see https://wiki.openzim.org/wiki/ZIM_file_format#Namespaces
-var regexpZIMUrlWithNamespace = new RegExp(/(?:^|\/)([-ABIJMUVWX])\/(.+)/);
+// In our case, there is also the ZIM file name, used as a prefix in the URL
+var regexpZIMUrlWithNamespace = /(?:^|\/)([^\/]+\/)([-ABIJMUVWX])\/(.+)/;
 
 function fetchEventListener(event) {
     if (fetchCaptureEnabled) {
@@ -82,8 +83,9 @@ function fetchEventListener(event) {
                 var title;
                 var titleWithNameSpace;
                 var regexpResult = regexpZIMUrlWithNamespace.exec(event.request.url);
-                nameSpace = regexpResult[1];
-                title = regexpResult[2];
+                var prefix = regexpResult[1];
+                nameSpace = regexpResult[2];
+                title = regexpResult[3];
 
                 // We need to remove the potential parameters in the URL
                 title = removeUrlParameters(decodeURIComponent(title));
@@ -121,7 +123,7 @@ function fetchEventListener(event) {
                         resolve(httpResponse);
                     }
                     else if (event.data.action === 'sendRedirect') {
-                        resolve(Response.redirect(event.data.redirectUrl));
+                        resolve(Response.redirect(prefix + event.data.redirectUrl));
                     }
                     else {
                         console.error('Invalid message received from app.js for ' + titleWithNameSpace, event.data);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -917,7 +917,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                         $("#searchingArticles").show();
                     };
                 };
-                iframeArticleContent.src = dirEntry.namespace + "/" + encodeURIComponent(dirEntry.url);
+                // We put the ZIM filename as a prefix in the URL, so that browser caches are separate for each ZIM file
+                iframeArticleContent.src = selectedArchive._file._files[0].name + "/" + dirEntry.namespace + "/" + encodeURIComponent(dirEntry.url);
                 // Display the iframe content
                 $("#articleContent").show();
             };


### PR DESCRIPTION
So that the browser cache does not mix content between different ZIM files.
Fixes #530 (as long as only relative URLs are used).

@kelson42 : in #138, you told me that the ZIM files should only use relative URLs (since the end of 2014). Can we rely on that?
Because, if ZIM files use absolute URLs in some hyperlinks, the prefix disappears and there might still be some cache issues.
I suspect that it still happens on some recent ZIM files