### PR TITLE
Move HTTP links to HTTPS

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -31,7 +31,7 @@
         GNU General Public License for more details.
 
         You should have received a copy of the GNU General Public License
-        along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
+        along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <https://www.gnu.org/licenses/>
 
         -->
 
@@ -109,8 +109,6 @@
                     <br />Once you have downloaded material from the Kiwix website, you will be able to read material from Wikipedia and many other sources.
                     <br />You can search among the article titles, and read any of these articles offline, without needing Internet access.
                     <br />All the content of Wikipedia is inside your device (including the images). It might also work with any content in the <a href="https://wiki.openzim.org/wiki/OpenZIM">OpenZIM format</a>, but has been only tested on the Wikipedia ones.
-                    <br />
-                    <br />Note : version 1.x of this application was designed for <a href="http://dumpathome.evopedia.info/dumps/finished/">Evopedia archives</a> and it's still compatible with it, but this format and <a href="http://www.evopedia.info">project</a> are now discontinued.
                     <h3>Usage</h3>
                     <h4>Step 1 : download some content</h4>
                     from <a href="https://download.kiwix.org/zim" target="_blank">https://download.kiwix.org/zim/</a>, with a regular computer.
@@ -170,19 +168,19 @@
                     <br />GNU General Public License for more details.
                     <br />
                     <br />You should have received a copy of the GNU General Public License
-                    <br />along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <a href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses/</a>
+                    <br />along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>
                     </i>
                     <br />
                     <br />Main libraries and ressources used :
                     <ul>
-                        <li><a href="http://jquery.com/" target="_blank">jQuery</a> 3, released under the <a href="http://jquery.org/license" target="_blank">MIT license</a></li>
-                        <li><a href="http://getbootstrap.com/" target="_blank">Bootstrap</a> 3, released under the <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache license 2.0</a>, which includes icons from <a href="http://glyphicons.com/">Glyphicons</a></li>
-                        <li><a href="http://www.requirejs.org/" target="_blank">RequireJS</a> 2, released under the <a href="https://github.com/jrburke/requirejs/blob/master/LICENSE" target="_blank">MIT license or new BSD license</a></li>
-                        <li><a href="http://qunitjs.com/" target="_blank">QUnit</a> 2, released under the <a href="http://jquery.org/license" target="_blank">MIT license</a></li>
-                        <li>Kiwix logo from <a href="https://www.kiwix.org/" target="_blank">kiwix.org</a>, released under the <a href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons Attribution Share Alike</a></li>
-                        <li>OpenZIM specifications from <a href="https://wiki.openzim.org/wiki/OpenZIM" target="_blank">www.openzim.org</a>, released under the <a href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons Attribution Share Alike</a></li>
+                        <li><a href="https://jquery.com/" target="_blank">jQuery</a> 3, released under the <a href="https://jquery.org/license" target="_blank">MIT license</a></li>
+                        <li><a href="https://getbootstrap.com/" target="_blank">Bootstrap</a> 3, released under the <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache license 2.0</a>, which includes icons from <a href="https://glyphicons.com/">Glyphicons</a></li>
+                        <li><a href="https://requirejs.org/" target="_blank">RequireJS</a> 2, released under the <a href="https://github.com/jrburke/requirejs/blob/master/LICENSE" target="_blank">MIT license or new BSD license</a></li>
+                        <li><a href="https://qunitjs.com/" target="_blank">QUnit</a> 2, released under the <a href="https://jquery.org/license" target="_blank">MIT license</a></li>
+                        <li>Kiwix logo from <a href="https://www.kiwix.org/" target="_blank">kiwix.org</a>, released under the <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons Attribution Share Alike</a></li>
+                        <li>OpenZIM specifications from <a href="https://wiki.openzim.org/wiki/OpenZIM" target="_blank">www.openzim.org</a>, released under the <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons Attribution Share Alike</a></li>
                         <li>Emscripten to generate a XZ decompressor in javascript : <a href="https://github.com/kripken/emscripten" target="_blank">https://github.com/kripken/emscripten</a>, released under the <a href="https://github.com/kripken/emscripten" target="_blank">MIT license</a></li>
-                        <li><a href="http://tukaani.org/xz/embedded.html">XZ Embedded</a> (the XZ library converted to Javascript with Emscripten), in public domain</li>
+                        <li><a href="https://tukaani.org/xz/embedded.html">XZ Embedded</a> (the XZ library converted to Javascript with Emscripten), in public domain</li>
                     </ul>
                     <h3>Other platforms/versions</h3>
                     Other Kiwix clients exist on various platforms. See the official site : <a href="https://www.kiwix.org/" target="_blank">https://www.kiwix.org/</a>
@@ -303,7 +301,7 @@
         <!-- Using require.js, a module system for javascript, include the
              js files. This loads "main.js", which in turn can load other
              files, all handled by require.js:
-             http://requirejs.org/docs/api.html#jsfiles -->
+             https://requirejs.org/docs/api.html#jsfiles -->
         <script type="text/javascript"
                 data-main="js/init.js"
         src="js/lib/require.js"></script>


### PR DESCRIPTION
Have moved all the links to HTTPS and tested if they still work.

I have also removed a link regarding Evopedia archive because (1) the link to the format description seemed dead (2) I'm not sure this is well tested (3) I'm not sur this is still so pertinent. That said not problem to reintroduce that link (with no dead link).