### PR TITLE
WIP: Add native asset caching to Service Worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -23,38 +23,49 @@
  */
 'use strict';
 
-self.addEventListener('install', function(event) {
+var CACHE = 'kiwixjs-cache';
+
+self.addEventListener('install', function (event) {
     event.waitUntil(self.skipWaiting());
 });
 
-self.addEventListener('activate', function(event) {
+self.addEventListener('activate', function (event) {
     // "Claiming" the ServiceWorker is necessary to make it work right away,
     // without the need to reload the page.
     // See https://developer.mozilla.org/en-US/docs/Web/API/Clients/claim
     event.waitUntil(self.clients.claim());
 });
 
-var regexpRemoveUrlParameters = new RegExp(/([^?#]+)[?#].*$/);
-
-// This function is duplicated from uiUtil.js
-// because using requirejs would force to add the 'fetch' event listener
-// after the initial evaluation of this script, which is not supported any more
-// in recent versions of the browsers.
-// Cf https://bugzilla.mozilla.org/show_bug.cgi?id=1181127
-// TODO : find a way to avoid this duplication
-
-/**
- * Removes parameters and anchors from a URL
- * @param {type} url
- * @returns {String} same URL without its parameters and anchors
- */
-function removeUrlParameters(url) {
-    return url.replace(regexpRemoveUrlParameters, "$1");
-}
-
 var outgoingMessagePort = null;
 var fetchCaptureEnabled = false;
-self.addEventListener('fetch', fetchEventListener);
+
+self.addEventListener('fetch', function (event) {
+    if (fetchCaptureEnabled &&
+        regexpZIMUrlWithNamespace.test(event.request.url) &&
+        event.request.method === "GET") {
+
+        // The ServiceWorker will handle this request
+        // Let's ask app.js for the content
+
+        event.respondWith(
+            // First see if the content is in the cache
+            fromCache(event.request).then(
+                function (response) {
+                    // The response was found in the cache so we respond with it 
+                    console.log('[SW] Supplying ' + event.request.url + ' from CACHE...');
+                    return response;
+                },
+                function () {
+                    // The response was not found in the cache so we look for it in the ZIM
+                    // and add it to the cache if it is an asset type (css or js)
+                    return fetchEventListener(event);
+                }
+            )
+        );
+    }
+    // If event.respondWith() isn't called because this wasn't a request that we want to handle,
+    // then the default request/response behavior will automatically be used.
+});
 
 self.addEventListener('message', function (event) {
     if (event.data.action === 'init') {
@@ -73,67 +84,109 @@ self.addEventListener('message', function (event) {
 // In our case, there is also the ZIM file name, used as a prefix in the URL
 var regexpZIMUrlWithNamespace = /(?:^|\/)([^\/]+\/)([-ABIJMUVWX])\/(.+)/;
 
-function fetchEventListener(event) {
-    if (fetchCaptureEnabled) {
-        if (regexpZIMUrlWithNamespace.test(event.request.url)) {
-            // The ServiceWorker will handle this request
-            // Let's ask app.js for that content
-            event.respondWith(new Promise(function(resolve, reject) {
-                var nameSpace;
-                var title;
-                var titleWithNameSpace;
-                var regexpResult = regexpZIMUrlWithNamespace.exec(event.request.url);
-                var prefix = regexpResult[1];
-                nameSpace = regexpResult[2];
-                title = regexpResult[3];
+/**
+ * Handles fetch events that need to be extracted from the ZIM and adds them to the cache
+ * if they are specified asset types (currently css and js)
+ * 
+ * @param {Event} fetchEvent The fetch event to be processed
+ * @returns {Promise} A resolved or rejected Promise for the Response
+ */
+function fetchEventListener(fetchEvent) {
+    return new Promise(function (resolve, reject) {
+        var nameSpace;
+        var title;
+        var titleWithNameSpace;
+        var regexpResult = regexpZIMUrlWithNamespace.exec(fetchEvent.request.url);
+        var prefix = regexpResult[1];
+        nameSpace = regexpResult[2];
+        title = regexpResult[3];
 
-                // We need to remove the potential parameters in the URL
-                title = removeUrlParameters(decodeURIComponent(title));
+        // We need to remove the potential parameters in the URL
+        title = removeUrlParameters(decodeURIComponent(title));
 
-                titleWithNameSpace = nameSpace + '/' + title;
+        titleWithNameSpace = nameSpace + '/' + title;
 
-                // Let's instanciate a new messageChannel, to allow app.s to give us the content
-                var messageChannel = new MessageChannel();
-                messageChannel.port1.onmessage = function(event) {
-                    if (event.data.action === 'giveContent') {
-                        // Content received from app.js
-                        var contentLength = event.data.content ? event.data.content.byteLength : null;
-                        var contentType = event.data.mimetype;
-                        var headers = new Headers ();
-                        if (contentLength) headers.set('Content-Length', contentLength);
-                        if (contentType) headers.set('Content-Type', contentType);
-                        // Test if the content is a video or audio file
-                        // See kiwix-js #519 and openzim/zimwriterfs #113 for why we test for invalid types like "mp4" or "webm" (without "video/")
-                        // The full list of types produced by zimwriterfs is in https://github.com/openzim/zimwriterfs/blob/master/src/tools.cpp
-                        if (contentLength >= 1 && /^(video|audio)|(^|\/)(mp4|webm|og[gmv]|mpeg)$/i.test(contentType)) {
-                            // In case of a video (at least), Chrome and Edge need these HTTP headers else seeking doesn't work
-                            // (even if we always send all the video content, not the requested range, until the backend supports it)
-                            headers.set('Accept-Ranges', 'bytes');
-                            headers.set('Content-Range', 'bytes 0-' + (contentLength-1) + '/' + contentLength);
-                        }
-                        var responseInit = {
-                            status: 200,
-                            statusText: 'OK',
-                            headers: headers
-                        };
-
-                        var httpResponse = new Response(event.data.content, responseInit);
-
-                        // Let's send the content back from the ServiceWorker
-                        resolve(httpResponse);
-                    }
-                    else if (event.data.action === 'sendRedirect') {
-                        resolve(Response.redirect(prefix + event.data.redirectUrl));
-                    }
-                    else {
-                        console.error('Invalid message received from app.js for ' + titleWithNameSpace, event.data);
-                        reject(event.data);
-                    }
+        // Let's instanciate a new messageChannel, to allow app.s to give us the content
+        var messageChannel = new MessageChannel();
+        messageChannel.port1.onmessage = function (msgPortEvent) {
+            if (msgPortEvent.data.action === 'giveContent') {
+                // Content received from app.js
+                var contentLength = msgPortEvent.data.content ? msgPortEvent.data.content.byteLength : null;
+                var contentType = msgPortEvent.data.mimetype;
+                var headers = new Headers();
+                if (contentLength) headers.set('Content-Length', contentLength);
+                if (contentType) headers.set('Content-Type', contentType);
+                // Test if the content is a video or audio file
+                // See kiwix-js #519 and openzim/zimwriterfs #113 for why we test for invalid types like "mp4" or "webm" (without "video/")
+                // The full list of types produced by zimwriterfs is in https://github.com/openzim/zimwriterfs/blob/master/src/tools.cpp
+                if (contentLength >= 1 && /^(video|audio)|(^|\/)(mp4|webm|og[gmv]|mpeg)$/i.test(contentType)) {
+                    // In case of a video (at least), Chrome and Edge need these HTTP headers else seeking doesn't work
+                    // (even if we always send all the video content, not the requested range, until the backend supports it)
+                    headers.set('Accept-Ranges', 'bytes');
+                    headers.set('Content-Range', 'bytes 0-' + (contentLength - 1) + '/' + contentLength);
+                }
+                var responseInit = {
+                    status: 200,
+                    statusText: 'OK',
+                    headers: headers
                 };
-                outgoingMessagePort.postMessage({'action': 'askForContent', 'title': titleWithNameSpace}, [messageChannel.port2]);
-            }));
-        }
-        // If event.respondWith() isn't called because this wasn't a request that we want to handle,
-        // then the default request/response behavior will automatically be used.
-    }
+
+                var httpResponse = new Response(msgPortEvent.data.content, responseInit);
+
+                // Add css or js assets to CACHE (or update their cache entries)
+                if (/(text|application)\/(css|javascript)/i.test(contentType)) {
+                    fetchEvent.waitUntil(updateCache(fetchEvent.request, httpResponse.clone()));
+                }
+
+                // Let's send the content back from the ServiceWorker
+                resolve(httpResponse);
+            } else if (msgPortEvent.data.action === 'sendRedirect') {
+                resolve(Response.redirect(prefix + msgPortEvent.data.redirectUrl));
+            } else {
+                console.error('Invalid message received from app.js for ' + titleWithNameSpace, msgPortEvent.data);
+                reject(msgPortEvent.data);
+            }
+        };
+        outgoingMessagePort.postMessage({
+            'action': 'askForContent',
+            'title': titleWithNameSpace
+        }, [messageChannel.port2]);
+    });
+}
+
+/**
+ * Removes parameters and anchors from a URL
+ * @param {type} url The URL to be processed
+ * @returns {String} The same URL without its parameters and anchors
+ */
+function removeUrlParameters(url) {
+    return url.replace(/([^?#]+)[?#].*$/, '$1');
+}
+
+/**
+ * Looks up a Request in CACHE and returns a Promise for the matched Response
+ * @param {Request} request The Request to fulfill from CACHE
+ * @returns {Response} The cached Response (as a Promise) 
+ */
+function fromCache(request) {
+    return caches.open(CACHE).then(function (cache) {
+        return cache.match(request).then(function (matching) {
+            if (!matching || matching.status === 404) {
+                return Promise.reject("no-match");
+            }
+            return matching;
+        });
+    });
+}
+
+/**
+ * Stores or updates in CACHE the given Request/Response pair
+ * @param {Request} request The original Request object
+ * @param {Response} response The Response received from the server/ZIM
+ * @returns {Promise} A Promise for the update action
+ */
+function updateCache(request, response) {
+    return caches.open(CACHE).then(function (cache) {
+        return cache.put(request, response);
+    });
 }


### PR DESCRIPTION
This addresses #441. It adds the native Cache API to `service-worker.js` for the caching of css and js assets. It significantly speeds up SW mode. The cached entries can be checked in the Cache entry of devtools in Chromium or Edge (I didin't try with Firefox). Example of running this on the most recent Ray Charles is shown in the image below (Ifrom Chromium / Edge 78). This is not for merging yet, but I would appreciate testing and any comments.

![image](https://user-images.githubusercontent.com/4304337/63449072-37cdf280-c437-11e9-8453-422ee6115da6.png)
