### PR TITLE
Add native asset caching to Service Worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -140,7 +140,7 @@ function fetchRequestFromZIM(fetchEvent) {
                 // See kiwix-js #519 and openzim/zimwriterfs #113 for why we test for invalid types like "mp4" or "webm" (without "video/")
                 // The full list of types produced by zimwriterfs is in https://github.com/openzim/zimwriterfs/blob/master/src/tools.cpp
                 if (contentLength >= 1 && /^(video|audio)|(^|\/)(mp4|webm|og[gmv]|mpeg)$/i.test(contentType)) {
-                    // In case of a video (at least), Chrome and Edge need these HTTP headers else seeking doesn't work
+                    // In case of a video (at least), Chrome and Edge need these HTTP headers or else seeking doesn't work
                     // (even if we always send all the video content, not the requested range, until the backend supports it)
                     headers.set('Accept-Ranges', 'bytes');
                     headers.set('Content-Range', 'bytes 0-' + (contentLength - 1) + '/' + contentLength);

--- a/service-worker.js
+++ b/service-worker.js
@@ -23,38 +23,58 @@
  */
 'use strict';
 
-self.addEventListener('install', function(event) {
+var CACHE = 'kiwixjs-cache';
+
+self.addEventListener('install', function (event) {
     event.waitUntil(self.skipWaiting());
 });
 
-self.addEventListener('activate', function(event) {
+self.addEventListener('activate', function (event) {
     // "Claiming" the ServiceWorker is necessary to make it work right away,
     // without the need to reload the page.
     // See https://developer.mozilla.org/en-US/docs/Web/API/Clients/claim
     event.waitUntil(self.clients.claim());
 });
 
-var regexpRemoveUrlParameters = new RegExp(/([^?#]+)[?#].*$/);
-
-// This function is duplicated from uiUtil.js
-// because using requirejs would force to add the 'fetch' event listener
-// after the initial evaluation of this script, which is not supported any more
-// in recent versions of the browsers.
-// Cf https://bugzilla.mozilla.org/show_bug.cgi?id=1181127
-// TODO : find a way to avoid this duplication
-
-/**
- * Removes parameters and anchors from a URL
- * @param {type} url
- * @returns {String} same URL without its parameters and anchors
- */
-function removeUrlParameters(url) {
-    return url.replace(regexpRemoveUrlParameters, "$1");
-}
-
 var outgoingMessagePort = null;
 var fetchCaptureEnabled = false;
-self.addEventListener('fetch', fetchEventListener);
+
+self.addEventListener('fetch', function (event) {
+    if (fetchCaptureEnabled &&
+        regexpZIMUrlWithNamespace.test(event.request.url) &&
+        event.request.method === "GET") {
+
+        // The ServiceWorker will handle this request either from CACHE or from app.js
+
+        event.respondWith(
+            // First see if the content is in the cache
+            fromCache(event.request).then(
+                function (response) {
+                    // The response was found in the cache so we respond with it 
+                    console.log('[SW] Supplying ' + event.request.url + ' from CACHE...');
+                    return response;
+                },
+                function () {
+                    // The response was not found in the cache so we look for it in the ZIM
+                    // and add it to the cache if it is an asset type (css or js)
+                    return fetchRequestFromZIM(event).then(function(response) {
+                        // Add css or js assets to CACHE (or update their cache entries)
+                        if (/(text|application)\/(css|javascript)/i.test(response.headers.get('Content-Type'))) {
+                            console.log('[SW] Adding ' + event.request.url + ' to CACHE');
+                            event.waitUntil(updateCache(event.request, response.clone()));
+                        }
+                        return response;
+                    }).catch(function(msgPortData, title) {
+                        console.error('Invalid message received from app.js for ' + title, msgPortData);
+                        return msgPortData;
+                    });
+                }
+            )
+        );
+    }
+    // If event.respondWith() isn't called because this wasn't a request that we want to handle,
+    // then the default request/response behavior will automatically be used.
+});
 
 self.addEventListener('message', function (event) {
     if (event.data.action === 'init') {
@@ -73,67 +93,102 @@ self.addEventListener('message', function (event) {
 // In our case, there is also the ZIM file name, used as a prefix in the URL
 var regexpZIMUrlWithNamespace = /(?:^|\/)([^\/]+\/)([-ABIJMUVWX])\/(.+)/;
 
-function fetchEventListener(event) {
-    if (fetchCaptureEnabled) {
-        if (regexpZIMUrlWithNamespace.test(event.request.url)) {
-            // The ServiceWorker will handle this request
-            // Let's ask app.js for that content
-            event.respondWith(new Promise(function(resolve, reject) {
-                var nameSpace;
-                var title;
-                var titleWithNameSpace;
-                var regexpResult = regexpZIMUrlWithNamespace.exec(event.request.url);
-                var prefix = regexpResult[1];
-                nameSpace = regexpResult[2];
-                title = regexpResult[3];
+/**
+ * Handles fetch events that need to be extracted from the ZIM
+ * 
+ * @param {Event} fetchEvent The fetch event to be processed
+ * @returns {Promise} A Promise for the Response or the rejected invalid message port data
+ */
+function fetchRequestFromZIM(fetchEvent) {
+    return new Promise(function (resolve, reject) {
+        var nameSpace;
+        var title;
+        var titleWithNameSpace;
+        var regexpResult = regexpZIMUrlWithNamespace.exec(fetchEvent.request.url);
+        var prefix = regexpResult[1];
+        nameSpace = regexpResult[2];
+        title = regexpResult[3];
 
-                // We need to remove the potential parameters in the URL
-                title = removeUrlParameters(decodeURIComponent(title));
+        // We need to remove the potential parameters in the URL
+        title = removeUrlParameters(decodeURIComponent(title));
 
-                titleWithNameSpace = nameSpace + '/' + title;
+        titleWithNameSpace = nameSpace + '/' + title;
 
-                // Let's instanciate a new messageChannel, to allow app.s to give us the content
-                var messageChannel = new MessageChannel();
-                messageChannel.port1.onmessage = function(event) {
-                    if (event.data.action === 'giveContent') {
-                        // Content received from app.js
-                        var contentLength = event.data.content ? event.data.content.byteLength : null;
-                        var contentType = event.data.mimetype;
-                        var headers = new Headers ();
-                        if (contentLength) headers.set('Content-Length', contentLength);
-                        if (contentType) headers.set('Content-Type', contentType);
-                        // Test if the content is a video or audio file
-                        // See kiwix-js #519 and openzim/zimwriterfs #113 for why we test for invalid types like "mp4" or "webm" (without "video/")
-                        // The full list of types produced by zimwriterfs is in https://github.com/openzim/zimwriterfs/blob/master/src/tools.cpp
-                        if (contentLength >= 1 && /^(video|audio)|(^|\/)(mp4|webm|og[gmv]|mpeg)$/i.test(contentType)) {
-                            // In case of a video (at least), Chrome and Edge need these HTTP headers else seeking doesn't work
-                            // (even if we always send all the video content, not the requested range, until the backend supports it)
-                            headers.set('Accept-Ranges', 'bytes');
-                            headers.set('Content-Range', 'bytes 0-' + (contentLength-1) + '/' + contentLength);
-                        }
-                        var responseInit = {
-                            status: 200,
-                            statusText: 'OK',
-                            headers: headers
-                        };
-
-                        var httpResponse = new Response(event.data.content, responseInit);
-
-                        // Let's send the content back from the ServiceWorker
-                        resolve(httpResponse);
-                    }
-                    else if (event.data.action === 'sendRedirect') {
-                        resolve(Response.redirect(prefix + event.data.redirectUrl));
-                    }
-                    else {
-                        console.error('Invalid message received from app.js for ' + titleWithNameSpace, event.data);
-                        reject(event.data);
-                    }
+        // Let's instantiate a new messageChannel, to allow app.js to give us the content
+        var messageChannel = new MessageChannel();
+        messageChannel.port1.onmessage = function (msgPortEvent) {
+            if (msgPortEvent.data.action === 'giveContent') {
+                // Content received from app.js
+                var contentLength = msgPortEvent.data.content ? msgPortEvent.data.content.byteLength : null;
+                var contentType = msgPortEvent.data.mimetype;
+                var headers = new Headers();
+                if (contentLength) headers.set('Content-Length', contentLength);
+                if (contentType) headers.set('Content-Type', contentType);
+                // Test if the content is a video or audio file
+                // See kiwix-js #519 and openzim/zimwriterfs #113 for why we test for invalid types like "mp4" or "webm" (without "video/")
+                // The full list of types produced by zimwriterfs is in https://github.com/openzim/zimwriterfs/blob/master/src/tools.cpp
+                if (contentLength >= 1 && /^(video|audio)|(^|\/)(mp4|webm|og[gmv]|mpeg)$/i.test(contentType)) {
+                    // In case of a video (at least), Chrome and Edge need these HTTP headers else seeking doesn't work
+                    // (even if we always send all the video content, not the requested range, until the backend supports it)
+                    headers.set('Accept-Ranges', 'bytes');
+                    headers.set('Content-Range', 'bytes 0-' + (contentLength - 1) + '/' + contentLength);
+                }
+                var responseInit = {
+                    status: 200,
+                    statusText: 'OK',
+                    headers: headers
                 };
-                outgoingMessagePort.postMessage({'action': 'askForContent', 'title': titleWithNameSpace}, [messageChannel.port2]);
-            }));
-        }
-        // If event.respondWith() isn't called because this wasn't a request that we want to handle,
-        // then the default request/response behavior will automatically be used.
-    }
+
+                var httpResponse = new Response(msgPortEvent.data.content, responseInit);
+
+                // Let's send the content back from the ServiceWorker
+                resolve(httpResponse);
+            } else if (msgPortEvent.data.action === 'sendRedirect') {
+                resolve(Response.redirect(prefix + msgPortEvent.data.redirectUrl));
+            } else {
+                reject(msgPortEvent.data, titleWithNameSpace);
+            }
+        };
+        outgoingMessagePort.postMessage({
+            'action': 'askForContent',
+            'title': titleWithNameSpace
+        }, [messageChannel.port2]);
+    });
+}
+
+/**
+ * Removes parameters and anchors from a URL
+ * @param {type} url The URL to be processed
+ * @returns {String} The same URL without its parameters and anchors
+ */
+function removeUrlParameters(url) {
+    return url.replace(/([^?#]+)[?#].*$/, '$1');
+}
+
+/**
+ * Looks up a Request in CACHE and returns a Promise for the matched Response
+ * @param {Request} request The Request to fulfill from CACHE
+ * @returns {Response} The cached Response (as a Promise) 
+ */
+function fromCache(request) {
+    return caches.open(CACHE).then(function (cache) {
+        return cache.match(request).then(function (matching) {
+            if (!matching || matching.status === 404) {
+                return Promise.reject("no-match");
+            }
+            return matching;
+        });
+    });
+}
+
+/**
+ * Stores or updates in CACHE the given Request/Response pair
+ * @param {Request} request The original Request object
+ * @param {Response} response The Response received from the server/ZIM
+ * @returns {Promise} A Promise for the update action
+ */
+function updateCache(request, response) {
+    return caches.open(CACHE).then(function (cache) {
+        return cache.put(request, response);
+    });
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -30,6 +30,7 @@ var cachedContentTypesRegexp = /text\/css|text\/javascript|application\/javascri
 // DEV: add any URL schemata that should be excluded from caching with the Cache API to the regex below
 // As of 08-2019 the chrome-extension: schema is incompatible with the Cache API
 // 'example-extension' is included to show how to add another schema if necessary
+// See equivalent regex in app.js function refreshCacheStatus() and ensure both are the same
 var excludedURLSchema = /^(?:chrome-extension|example-extension):/i;
 
 // Pattern for ZIM file namespace - see https://wiki.openzim.org/wiki/ZIM_file_format#Namespaces

--- a/service-worker.js
+++ b/service-worker.js
@@ -139,7 +139,7 @@ self.addEventListener('message', function (event) {
  * Handles fetch events that need to be extracted from the ZIM
  * 
  * @param {Event} fetchEvent The fetch event to be processed
- * @returns {Response} A Promise for the Response or the rejected invalid message port data
+ * @returns {Promise<Response>} A Promise for the Response or the rejected invalid message port data
  */
 function fetchRequestFromZIM(fetchEvent) {
     return new Promise(function (resolve, reject) {
@@ -210,7 +210,7 @@ function removeUrlParameters(url) {
 /**
  * Looks up a Request in CACHE and returns a Promise for the matched Response
  * @param {Request} request The Request to fulfill from CACHE
- * @returns {Response} A Promise for the cached Response 
+ * @returns {Promise<Response>} A Promise for the cached Response 
  */
 function fromCache(request) {
     // Prevents use of Cache API if user has disabled it
@@ -245,7 +245,7 @@ function updateCache(request, response) {
  * Tests the caching strategy available to this app and if it is Cache API, count the
  * number of assets in CACHE
  * @param {String} url A URL to test against excludedURLSchema
- * @returns {Array} A Promise for an array of format [cacheType, cacheDescription, assetCount]
+ * @returns {Promise<Array>} A Promise for an array of format [cacheType, cacheDescription, assetCount]
  */
 function testCacheAndCountAssets(url) {
     if (regexpExcludedURLSchema.test(url)) return Promise.resolve(['custom', 'Custom', '-']);

--- a/service-worker.js
+++ b/service-worker.js
@@ -25,6 +25,10 @@
 
 var CACHE = 'kiwixjs-cache';
 
+// Pattern for ZIM file namespace - see https://wiki.openzim.org/wiki/ZIM_file_format#Namespaces
+// In our case, there is also the ZIM file name, used as a prefix in the URL
+var regexpZIMUrlWithNamespace = /(?:^|\/)([^\/]+\/)([-ABIJMUVWX])\/(.+)/;
+
 self.addEventListener('install', function (event) {
     event.waitUntil(self.skipWaiting());
 });
@@ -88,10 +92,6 @@ self.addEventListener('message', function (event) {
         fetchCaptureEnabled = false;
     }
 });
-
-// Pattern for ZIM file namespace - see https://wiki.openzim.org/wiki/ZIM_file_format#Namespaces
-// In our case, there is also the ZIM file name, used as a prefix in the URL
-var regexpZIMUrlWithNamespace = /(?:^|\/)([^\/]+\/)([-ABIJMUVWX])\/(.+)/;
 
 /**
  * Handles fetch events that need to be extracted from the ZIM

--- a/service-worker.js
+++ b/service-worker.js
@@ -139,7 +139,7 @@ self.addEventListener('message', function (event) {
  * Handles fetch events that need to be extracted from the ZIM
  * 
  * @param {Event} fetchEvent The fetch event to be processed
- * @returns {Promise<Response>} A Promise for the Response or the rejected invalid message port data
+ * @returns {Promise<Response>} A Promise for the Response, or rejects with the invalid message port data
  */
 function fetchRequestFromZIM(fetchEvent) {
     return new Promise(function (resolve, reject) {
@@ -210,8 +210,7 @@ function removeUrlParameters(url) {
 /**
  * Looks up a Request in CACHE_NAME and returns a Promise for the matched Response
  * @param {Request} request The Request to fulfill from CACHE_NAME
- * @returns {Promise<Response>} A Promise for the cached Response
- * @throws {Promise<String>} A rejected Promise with strings 'disabled' or 'no-match'
+ * @returns {Promise<Response>} A Promise for the cached Response, or rejects with strings 'disabled' or 'no-match'
  */
 function fromCache(request) {
     // Prevents use of Cache API if user has disabled it

--- a/service-worker.js
+++ b/service-worker.js
@@ -52,8 +52,11 @@ var regexpCachedContentTypes = /text\/css|text\/javascript|application\/javascri
  */
 var regexpExcludedURLSchema = /^(?:chrome-extension|example-extension):/i;
 
-// Pattern for ZIM file namespace - see https://wiki.openzim.org/wiki/ZIM_file_format#Namespaces
-// In our case, there is also the ZIM file name, used as a prefix in the URL
+/** 
+ * Pattern for ZIM file namespace: see https://wiki.openzim.org/wiki/ZIM_file_format#Namespaces
+ * In our case, there is also the ZIM file name used as a prefix in the URL
+ * @type {RegExp}
+ */
 var regexpZIMUrlWithNamespace = /(?:^|\/)([^\/]+\/)([-ABIJMUVWX])\/(.+)/;
 
 self.addEventListener('install', function (event) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -31,14 +31,14 @@
 var CACHE_NAME;
 
 /**
- * A global Boolean that governs whether CACHE will be used
+ * A global Boolean that governs whether CACHE_NAME will be used
  * Caching is on by default but can be turned off by the user in Configuration
  * @type {Boolean}
  */
 var useCache = true;
 
 /**  
- * A regular expression that matches the Content-Types of assets that may be stored in CACHE
+ * A regular expression that matches the Content-Types of assets that may be stored in CACHE_NAME
  * Add any further Content-Types you wish to cache to the regexp, separated by '|'
  * @type {RegExp}
  */
@@ -78,7 +78,7 @@ self.addEventListener('fetch', function (event) {
         regexpZIMUrlWithNamespace.test(event.request.url) &&
         event.request.method === "GET") {
 
-        // The ServiceWorker will handle this request either from CACHE or from app.js
+        // The ServiceWorker will handle this request either from CACHE_NAME or from app.js
 
         event.respondWith(
             // First see if the content is in the cache
@@ -91,7 +91,7 @@ self.addEventListener('fetch', function (event) {
                     // The response was not found in the cache so we look for it in the ZIM
                     // and add it to the cache if it is an asset type (css or js)
                     return fetchRequestFromZIM(event).then(function (response) {
-                        // Add css or js assets to CACHE (or update their cache entries) unless the URL schema is not supported
+                        // Add css or js assets to CACHE_NAME (or update their cache entries) unless the URL schema is not supported
                         if (regexpCachedContentTypes.test(response.headers.get('Content-Type')) &&
                             !regexpExcludedURLSchema.test(event.request.url)) {
                             event.waitUntil(updateCache(event.request, response.clone()));
@@ -208,9 +208,10 @@ function removeUrlParameters(url) {
 }
 
 /**
- * Looks up a Request in CACHE and returns a Promise for the matched Response
- * @param {Request} request The Request to fulfill from CACHE
- * @returns {Promise<Response>} A Promise for the cached Response 
+ * Looks up a Request in CACHE_NAME and returns a Promise for the matched Response
+ * @param {Request} request The Request to fulfill from CACHE_NAME
+ * @returns {Promise<Response>} A Promise for the cached Response
+ * @throws {Promise<String>} A rejected Promise with strings 'disabled' or 'no-match'
  */
 function fromCache(request) {
     // Prevents use of Cache API if user has disabled it
@@ -218,16 +219,16 @@ function fromCache(request) {
     return caches.open(CACHE_NAME).then(function (cache) {
         return cache.match(request).then(function (matching) {
             if (!matching || matching.status === 404) {
-                return Promise.reject("no-match");
+                return Promise.reject('no-match');
             }
-            console.log('[SW] Supplying ' + request.url + ' from CACHE...');
+            console.log('[SW] Supplying ' + request.url + ' from ' + CACHE_NAME + '...');
             return matching;
         });
     });
 }
 
 /**
- * Stores or updates in CACHE the given Request/Response pair
+ * Stores or updates in CACHE_NAME the given Request/Response pair
  * @param {Request} request The original Request object
  * @param {Response} response The Response received from the server/ZIM
  * @returns {Promise} A Promise for the update action
@@ -236,14 +237,14 @@ function updateCache(request, response) {
     // Prevents use of Cache API if user has disabled it
     if (!useCache) return Promise.resolve();
     return caches.open(CACHE_NAME).then(function (cache) {
-        console.log('[SW] Adding ' + request.url + ' to CACHE');
+        console.log('[SW] Adding ' + request.url + ' to ' + CACHE_NAME + '...');
         return cache.put(request, response);
     });
 }
 
 /**
  * Tests the caching strategy available to this app and if it is Cache API, count the
- * number of assets in CACHE
+ * number of assets in CACHE_NAME
  * @param {String} url A URL to test against excludedURLSchema
  * @returns {Promise<Array>} A Promise for an array of format [cacheType, cacheDescription, assetCount]
  */

--- a/service-worker.js
+++ b/service-worker.js
@@ -227,7 +227,7 @@ function updateCache(request, response) {
  * @returns {Promise} A Promise that resolves with an array of format [cacheType, cacheDescription, assetCount]
  */
 function testCacheAndCountAssets(url) {
-    if (excludedURLSchema.test(url)) return Promise.resolve(['custom', 'Custom', 0]);
+    if (excludedURLSchema.test(url)) return Promise.resolve(['custom', 'Custom', '-']);
     if (!useCache) return Promise.resolve(['none', 'None', 0]);
     return caches.open(CACHE).then(function (cache) {
         return cache.keys().then(function (keys) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -23,7 +23,7 @@
  */
 'use strict';
 
-var CACHE = 'kiwixjs-cache';
+var CACHE = 'kiwixjs-assetCache';
 var useCache = true;
 // DEV: add any Content-Types you wish to cache to the regexp below, separated by '|'
 var cachedContentTypesRegexp = /text\/css|text\/javascript|application\/javascript/i;

--- a/www/index.html
+++ b/www/index.html
@@ -270,9 +270,6 @@
                                                     <p>Assets: <b id="assetsCount"></b></p>
                                                 </div>
                                             </div>
-                                            <div class="row">
-                                                <div id="clearCacheResult" class="col-sm-12"></div>
-                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/www/index.html
+++ b/www/index.html
@@ -232,6 +232,72 @@
                             </div>
                         </div>
                     </div>
+
+                    <div class="container">
+                        <div class="row">
+                            <h3>Performance and privacy settings</h3>
+                            <div class="column">
+                                <div class="panel" id="cacheSettingsDiv">
+                                    <div class="panel-heading">Speed up archive access</div>
+                                    <div class="panel-body">
+                                        <div class="row">
+                                            <div class="col-sm-6">
+                                                <div class="radio">
+                                                    <p>Kiwix JS can speed up the display of articles by caching assets:</p>
+                                                    <label>
+                                                        <input type="radio" name="cachedAssetsMode" value="true" id="cachedAssetsModeRadioTrue" checked>
+                                                        <strong>Cache assets</strong> (recommended)
+                                                    </label>
+                                                </div>
+                                                <div class="radio">
+                                                    <label>
+                                                        <input type="radio" name="cachedAssetsMode" value="false" id="cachedAssetsModeRadioFalse">
+                                                        <strong>Do not cache assets</strong> (empties caches: for low-memory devices)
+                                                    </label>
+                                                </div>
+                                            </div>
+                                            <div class="col-sm-6">
+                                                <div class="checkbox">
+                                                    <label>
+                                                        <input type="checkbox" name="rememberLastVisitedPage" value="true" id="rememberLastVisitedPageCheck" checked>
+                                                        <strong>Return to last visited page when you open an archive</strong>
+                                                        <p>You will still need to pick the archive</p>
+                                                    </label>
+                                                </div>
+                                                <div id="cacheStatusPanel" class="panel panel-footer" style="overflow: hidden">
+                                                    <div><p><b>Cache status:</b></p></div>
+                                                    <div id="cacheStatus"></div>
+                                                    <div id="clearCacheResult" class="col-xs-12"></div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="container">
+                        <div class="row">
+                            <h3>Expert Settings</h3>
+                            <div class="column">
+                                <div class="panel panel-danger" id="contentInjectionModeDiv">
+                                    <div class="panel-heading">Content injection mode</div>
+                                    <div class="panel-body">
+                                        <div class="radio">
+                                            <label>
+                                                <input type="radio" name="contentInjectionMode" value="jquery" id="jQueryModeRadio" checked>
+                                                <strong>JQuery</strong> (stable and safe)
+                                            </label>
+                                        </div>
+                                        <div class="radio">
+                                            <label>
+                                                <input type="radio" name="contentInjectionMode" value="serviceworker" id="serviceworkerModeRadio">
+                                                <strong>ServiceWorker</strong> (not available on all platforms, but supports more ZIM files)
+                                            </label>
+                                        </div>
+                                    </div>
+                    </div>
                     <br />
                     <div class="container">
                         <h3>Expert settings</h3>

--- a/www/index.html
+++ b/www/index.html
@@ -235,7 +235,7 @@
 
                     <div class="container">
                         <div class="row">
-                            <h3>Performance and privacy settings</h3>
+                            <h3>Performance settings</h3>
                             <div class="column">
                                 <div class="panel" id="cacheSettingsDiv">
                                     <div class="panel-heading">Speed up archive access</div>
@@ -257,13 +257,6 @@
                                                 </div>
                                             </div>
                                             <div class="col-sm-6">
-                                                <div class="checkbox">
-                                                    <label>
-                                                        <input type="checkbox" name="rememberLastVisitedPage" value="true" id="rememberLastVisitedPageCheck" checked>
-                                                        <strong>Return to last visited page when you open an archive</strong>
-                                                        <p>You will still need to pick the archive</p>
-                                                    </label>
-                                                </div>
                                                 <div id="cacheStatusPanel" class="panel panel-footer" style="overflow: hidden">
                                                     <div><p><b>Cache status:</b></p></div>
                                                     <div id="cacheStatus"></div>
@@ -279,7 +272,7 @@
                     
                     <div class="container">
                         <div class="row">
-                            <h3>Expert Settings</h3>
+                            <h3>Expert settings</h3>
                             <div class="column">
                                 <div class="panel panel-danger" id="contentInjectionModeDiv">
                                     <div class="panel-heading">Content injection mode</div>

--- a/www/index.html
+++ b/www/index.html
@@ -47,8 +47,8 @@
         <!-- Status indicators -->
         <div id="searchingArticles" style="display: none;" class="status">
             <div class="loader"></div>
-            <div id="cachingCSS" style="display: none;" class="message">
-                Caching styles...
+            <div id="cachingAssets" style="display: none;" class="message">
+                Caching assets...
             </div>
         </div>
         <section id="search-article" role="region">

--- a/www/index.html
+++ b/www/index.html
@@ -232,64 +232,52 @@
                             </div>
                         </div>
                     </div>
-
+                    <br />
                     <div class="container">
-                        <div class="row">
-                            <h3>Performance settings</h3>
-                            <div class="column">
-                                <div class="panel" id="cacheSettingsDiv">
-                                    <div class="panel-heading">Speed up archive access</div>
-                                    <div class="panel-body">
-                                        <div class="row">
-                                            <div class="col-sm-6">
-                                                <div class="radio">
-                                                    <p>Kiwix JS can speed up the display of articles by caching assets:</p>
-                                                    <label>
-                                                        <input type="radio" name="cachedAssetsMode" value="true" id="cachedAssetsModeRadioTrue" checked>
-                                                        <strong>Cache assets</strong> (recommended)
-                                                    </label>
+                        <h3>Performance settings</h3>
+                        <div class="card card-warning" id="cacheSettingsDiv">
+                            <div class="card-header">Speed up archive access</div>
+                            <div class="card-body">
+                                <div class="row">
+                                    <div class="col-sm-6">
+                                        <div class="radio">
+                                            <p>Kiwix JS can speed up the display of articles by caching assets:</p>
+                                            <label>
+                                                <input type="radio" name="cachedAssetsMode" value="true"
+                                                    id="cachedAssetsModeRadioTrue" checked>
+                                                <strong>Cache assets</strong> (recommended)
+                                            </label>
+                                        </div>
+                                        <div class="radio">
+                                            <label>
+                                                <input type="radio" name="cachedAssetsMode" value="false"
+                                                    id="cachedAssetsModeRadioFalse">
+                                                <strong>Do not cache assets</strong> (empties caches: for low-memory
+                                                devices)
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="col-sm-6">
+                                        <div id="cacheStatusPanel" class="card card-footer" style="overflow: hidden">
+                                            <div>
+                                                <p><b>Cache status:</b></p>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-7">
+                                                    <p>Cache used: <b id="cacheUsed"></b></p>
                                                 </div>
-                                                <div class="radio">
-                                                    <label>
-                                                        <input type="radio" name="cachedAssetsMode" value="false" id="cachedAssetsModeRadioFalse">
-                                                        <strong>Do not cache assets</strong> (empties caches: for low-memory devices)
-                                                    </label>
+                                                <div class="col-5">
+                                                    <p>Assets: <b id="assetsCount"></b></p>
                                                 </div>
                                             </div>
-                                            <div class="col-sm-6">
-                                                <div id="cacheStatusPanel" class="panel panel-footer" style="overflow: hidden">
-                                                    <div><p><b>Cache status:</b></p></div>
-                                                    <div id="cacheStatus"></div>
-                                                    <div id="clearCacheResult" class="col-xs-12"></div>
-                                                </div>
+                                            <div class="row">
+                                                <div id="clearCacheResult" class="col-sm-12"></div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    
-                    <div class="container">
-                        <div class="row">
-                            <h3>Expert settings</h3>
-                            <div class="column">
-                                <div class="panel panel-danger" id="contentInjectionModeDiv">
-                                    <div class="panel-heading">Content injection mode</div>
-                                    <div class="panel-body">
-                                        <div class="radio">
-                                            <label>
-                                                <input type="radio" name="contentInjectionMode" value="jquery" id="jQueryModeRadio" checked>
-                                                <strong>JQuery</strong> (stable and safe)
-                                            </label>
-                                        </div>
-                                        <div class="radio">
-                                            <label>
-                                                <input type="radio" name="contentInjectionMode" value="serviceworker" id="serviceworkerModeRadio">
-                                                <strong>ServiceWorker</strong> (not available on all platforms, but supports more ZIM files)
-                                            </label>
-                                        </div>
-                                    </div>
                     </div>
                     <br />
                     <div class="container">

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -348,7 +348,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     }
 
     /**
-     * Queries Service Worker if possible to determine CACHE capability and returns an object with cache attributes
+     * Queries Service Worker if possible to determine cache capability and returns an object with cache attributes
      * If Service Worker is not available, the attributes of the memory cache are returned instead
      * @returns {Promise<Object>} A Promise for an object with cache attributes 'type', 'description', and 'count'
      */
@@ -363,7 +363,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     if (cache.error) reject(cache.error);
                     else resolve(cache);
                 };
-                // Ask Service Worker for its CACHE status and asset count
+                // Ask Service Worker for its cache status and asset count
                 navigator.serviceWorker.controller.postMessage({
                     'action': {
                         'useCache': params.useCache ? 'on' : 'off',
@@ -446,7 +446,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 messageChannel = null;
             }
             refreshAPIStatus();
-            // User has switched to jQuery mode, so no longer needs CACHE
+            // User has switched to jQuery mode, so no longer needs CACHE_NAME
             // We should empty it to prevent unnecessary space usage
             if ('caches' in window) caches.delete(CACHE_NAME);
         } else if (value === 'serviceworker') {
@@ -479,7 +479,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                             // and send the 'init' message to the ServiceWorker
                             initOrKeepAliveServiceWorker();
                             // We need to refresh cache status here on first activation because SW was inaccessible till now
-                            // We also initialize the CACHE constant in SW here
+                            // We also initialize the CACHE_NAME constant in SW here
                             refreshCacheStatus();
                         }
                     });

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -350,7 +350,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     /**
      * Queries Service Worker if possible to determine CACHE capability and returns an object with cache attributes
      * If Service Worker is not available, the attributes of the memory cache are returned instead
-     * @returns {Object} A Promise for an object with cache attributes 'type', 'description', and 'count'
+     * @returns {Promise<Object>} A Promise for an object with cache attributes 'type', 'description', and 'count'
      */
     function getCacheAttributes() {
         return q.Promise(function (resolve, reject) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -988,6 +988,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             var iframeArticleContent = document.getElementById('articleContent');
             iframeArticleContent.onload = function () {
                 // The content is fully loaded by the browser : we can hide the spinner
+                $("#cachingAssets").html("Caching assets...");
+                $("#cachingAssets").hide();
                 $("#searchingArticles").hide();
                 // Display the iframe content
                 $("#articleContent").show();
@@ -1061,6 +1063,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                             // Let's send the content to the ServiceWorker
                             var message = { 'action': 'giveContent', 'title': title, 'content': content.buffer, 'mimetype': mimetype };
                             messagePort.postMessage(message, [content.buffer]);
+                            updateCacheStatus(title);
                         });
                     }
                 };
@@ -1286,7 +1289,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     uiUtil.replaceCSSLinkWithInlineCSS(link, cssContent);
                     cssFulfilled++;
                 } else {
-                    if (params.useCache) $('#cachingCSS').show();
+                    if (params.useCache) $('#cachingAssets').show();
                     selectedArchive.getDirEntryByTitle(title)
                     .then(function (dirEntry) {
                         return selectedArchive.readUtf8File(dirEntry,
@@ -1311,15 +1314,14 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             // until all CSS content is available [kiwix-js #381]
             function renderIfCSSFulfilled(title) {
                 if (cssFulfilled >= cssCount) {
-                    $('#cachingCSS').html('Caching styles...');
-                    $('#cachingCSS').hide();
+                    $('#cachingAssets').html('Caching styles...');
+                    $('#cachingAssets').hide();
                     $('#searchingArticles').hide();
                     $('#articleContent').show();
                     // We have to resize here for devices with On Screen Keyboards when loading from the article search list
                     resizeIFrame();
-                } else if (title) {
-                    title = title.replace(/[^/]+\//g, '').substring(0,18);
-                    if (params.useCache) $('#cachingCSS').html('Caching ' + title + '...');
+                } else {
+                    updateCacheStatus(title);
                 }
             }
         }
@@ -1370,6 +1372,19 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     });
                 });
             });
+        }
+    }
+
+    /**
+     * Displays a message to the user that a style or other asset is being cached
+     * @param {String} title The title of the file to display in caching message block 
+     */
+    function updateCacheStatus(title) {
+        if (params.useCache && /\.css$|\.js$/i.test(title)) {
+            var cacheBlock = document.getElementById('cachingAssets');
+            cacheBlock.style.display = 'block';
+            title = title.replace(/[^/]+\//g, '').substring(0,18);
+            cacheBlock.innerHTML = 'Caching ' + title + '...';
         }
     }
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -50,7 +50,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
      * We need access to this constant in app.js in order to complete utility actions when Service Worker is not initialized 
      * @type {String}
      */
-    var CACHE = 'kiwixjs-assetCache';
+    var CACHE_NAME = 'kiwixjs-assetCache';
     
     /**
      * Memory cache for CSS styles contained in ZIM: it significantly speeds up subsequent page display
@@ -304,7 +304,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             params.useCache = false;
             // Delete all caches
             resetCssCache();
-            if ('caches' in window) caches.delete(CACHE);
+            if ('caches' in window) caches.delete(CACHE_NAME);
             refreshCacheStatus();
         }
     });
@@ -350,7 +350,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     /**
      * Queries Service Worker if possible to determine CACHE capability and returns an object with cache attributes
      * If Service Worker is not available, the attributes of the memory cache are returned instead
-     * @returns {Promise} A Promise for an object with cache attributes 'type', 'description', and 'count'
+     * @returns {Object} A Promise for an object with cache attributes 'type', 'description', and 'count'
      */
     function getCacheAttributes() {
         return q.Promise(function (resolve, reject) {
@@ -365,9 +365,11 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 };
                 // Ask Service Worker for its CACHE status and asset count
                 navigator.serviceWorker.controller.postMessage({
-                    'useCache': params.useCache ? 'on' : 'off',
-                    'cacheName': CACHE,
-                    'checkCache': window.location.href
+                    'action': {
+                        'useCache': params.useCache ? 'on' : 'off',
+                        'checkCache': window.location.href
+                    },
+                    'cacheName': CACHE_NAME
                 }, [channel.port2]);
             } else {
                 // No Service Worker has been established, so we resolve the Promise with cssCache details only
@@ -446,7 +448,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             refreshAPIStatus();
             // User has switched to jQuery mode, so no longer needs CACHE
             // We should empty it to prevent unnecessary space usage
-            if ('caches' in window) caches.delete(CACHE);
+            if ('caches' in window) caches.delete(CACHE_NAME);
         } else if (value === 'serviceworker') {
             if (!isServiceWorkerAvailable()) {
                 alert("The ServiceWorker API is not available on your device. Falling back to JQuery mode");

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -372,7 +372,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             var cacheInUse = params.cacheCapability === 'cacheAPI' ? 'CacheAPI' : params.cacheCapability === 'custom' ? 'Custom' : 'Memory';
             cacheInUse = params.useCache ? cacheInUse : 'None'; 
             document.getElementById('cacheUsed').innerHTML = cacheInUse;
-            document.getElementById('assetsCount').innerHTML = assetsCount[0] + assetsCount[1];
+            document.getElementById('assetsCount').innerHTML = params.cacheCapability === 'custom' ?
+                assetsCount[0] + assetsCount[1] || '-' : assetsCount[0] + assetsCount[1];
             var cacheSettings = document.getElementById('cacheSettingsDiv');
             var cacheStatusPanel = document.getElementById('cacheStatusPanel');
             [cacheSettings, cacheStatusPanel].forEach(function(card) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -372,7 +372,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             var cacheInUse = params.cacheCapability === 'cacheAPI' ? 'CacheAPI' : params.cacheCapability === 'custom' ? 'Custom' : 'Memory';
             cacheInUse = params.useCache ? cacheInUse : 'None'; 
             document.getElementById('cacheUsed').innerHTML = cacheInUse;
-            document.getElementById('assetsCount').innerHTML = params.cacheCapability === 'custom' ? '' : assetsCount[0] + assetsCount[1];
+            document.getElementById('assetsCount').innerHTML = assetsCount[0] + assetsCount[1];
             var cacheSettings = document.getElementById('cacheSettingsDiv');
             var cacheStatusPanel = document.getElementById('cacheStatusPanel');
             [cacheSettings, cacheStatusPanel].forEach(function(card) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -183,7 +183,6 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         goToRandomArticle();
         $("#welcomeText").hide();
         $('#articleListWithHeader').hide();
-        $("#searchingArticles").hide();
         $('.navbar-collapse').collapse('hide');
     });
     
@@ -1454,6 +1453,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 if (dirEntry.namespace === 'A') {
                     params.isLandingPage = false;
                     $('#activeContent').hide();
+                    $('#searchingArticles').show();
                     readArticle(dirEntry);
                 } else {
                     // If the random title search did not end up on an article,

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -45,8 +45,9 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     var DELAY_BETWEEN_KEEPALIVE_SERVICEWORKER = 30000;
 
     /**
-     * The name of the Cache API cache to use for caching Service Worker requests and responses
-     * This name will be passed to service-worker.js in messaging to avoid duplication
+     * The name of the Cache API cache to use for caching Service Worker requests and responses for certain asset types
+     * This name will be passed to service-worker.js in messaging to avoid duplication: see comment in service-worker.js
+     * We need access to this constant in app.js in order to complete utility actions when Service Worker is not initialized 
      * @type {String}
      */
     var CACHE = 'kiwixjs-assetCache';
@@ -472,6 +473,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                             // and send the 'init' message to the ServiceWorker
                             initOrKeepAliveServiceWorker();
                             // We need to refresh cache status here on first activation because SW was inaccessible till now
+                            // We also initialize the CACHE constant in SW here
                             refreshCacheStatus();
                         }
                     });
@@ -1321,7 +1323,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             // until all CSS content is available [kiwix-js #381]
             function renderIfCSSFulfilled(title) {
                 if (cssFulfilled >= cssCount) {
-                    $('#cachingAssets').html('Caching styles...');
+                    $('#cachingAssets').html('Caching assets...');
                     $('#cachingAssets').hide();
                     $('#searchingArticles').hide();
                     $('#articleContent').show();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -305,16 +305,6 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             });
         }
     });
-    document.getElementById('rememberLastVisitedPageCheck').addEventListener('change', function(e) {
-        var rememberLastPage = e.target.checked ? true : false;
-        cookies.setItem('rememberLastPage', rememberLastPage, Infinity);
-        if (!rememberLastPage) {
-            cache.clear('lastpages', refreshCacheStatus);
-        } else {
-            refreshCacheStatus();
-        }
-    });
-    
 
     /**
      * Displays or refreshes the API status shown to the user
@@ -396,8 +386,6 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             // Clear count of deleted assets
             document.getElementById('clearCacheResult').innerHTML = '';
             // Update radio buttons and checkbox
-            params.rememberLastPage = true;
-            document.getElementById('rememberLastVisitedPageCheck').checked = params.rememberLastPage;
             document.getElementById('cachedAssetsModeRadio' + (params.useCache ? 'True' : 'False')).checked = true;
             // Send a message to Service Worker to turn caching on or off
             if (contentInjectionMode === 'serviceworker')

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1067,7 +1067,6 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                             // Let's send the content to the ServiceWorker
                             var message = { 'action': 'giveContent', 'title': title, 'content': content.buffer, 'mimetype': mimetype };
                             messagePort.postMessage(message, [content.buffer]);
-                            updateCacheStatus(title);
                         });
                     }
                 };

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -344,7 +344,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
 
     }
 
-    // Determines cache capability and returns and array with the number of items in cssCache and CACHE
+    // Determines cache capability and returns an array with the number of items in cssCache and CACHE
     function checkCacheStatus() {
         params.cacheCapability = 'memory';
         var memCacheSize = cssCache ? cssCache.size : 0;
@@ -1377,7 +1377,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
 
     /**
      * Displays a message to the user that a style or other asset is being cached
-     * @param {String} title The title of the file to display in caching message block 
+     * @param {String} title The title of the file to display in the caching message block 
      */
     function updateCacheStatus(title) {
         if (params.useCache && /\.css$|\.js$/i.test(title)) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -53,7 +53,9 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     var CACHE = 'kiwixjs-assetCache';
     
     /**
-     * Cache for CSS styles contained in ZIM: it significantly speeds up subsequent page display
+     * Memory cache for CSS styles contained in ZIM: it significantly speeds up subsequent page display
+     * This cache is used by default in jQuery mode, but can be turned off in Configuration for low-memory devices
+     * In Service Worker mode, the Cache API will be used instead
      * @type {Map}
      */
     var cssCache = new Map();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -285,7 +285,6 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         if (e.target.checked) {
             cookies.setItem('useCache', true, Infinity);
             params.useCache = true;
-            document.getElementById('clearCacheResult').innerHTML = '';
             refreshCacheStatus();
         }
     });
@@ -293,15 +292,9 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         if (e.target.checked) {
             cookies.setItem('useCache', false, Infinity);
             params.useCache = false;
-            var result;
-            refreshCacheStatus().then(function (itemsCount) {
-                result = itemsCount[0] + itemsCount[1];
-                cssCache = new Map();
-                if ('caches' in window) caches.delete(CACHE);
-                refreshCacheStatus().then(function () {
-                    document.getElementById('clearCacheResult').innerHTML = 'Items cleared: <b>' + result + '</b>';
-                });
-            });
+            cssCache = new Map();
+            if ('caches' in window) caches.delete(CACHE);
+            refreshCacheStatus();
         }
     });
 
@@ -386,8 +379,6 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     card.classList.add('card-warning');
                 }
             });
-            // Clear count of deleted assets
-            document.getElementById('clearCacheResult').innerHTML = '';
             // Update radio buttons and checkbox
             document.getElementById('cachedAssetsModeRadio' + (params.useCache ? 'True' : 'False')).checked = true;
             // Send a message to Service Worker to turn caching on or off

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -357,9 +357,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 channel.port1.onmessage = function (event) {
                     var cache = event.data;
                     if (cache.error) reject(cache.error);
-                    else {
-                        resolve(cache);
-                    }
+                    else resolve(cache);
                 };
                 // Ask Service Worker for its CACHE status and asset count
                 navigator.serviceWorker.controller.postMessage({

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -368,19 +368,18 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         return checkCacheStatus().then(function(assetsCount) {
             var cacheInUse = params.cacheCapability === 'cacheAPI' ? 'CacheAPI' : 'Memory';
             cacheInUse = params.useCache ? cacheInUse : 'None'; 
-            document.getElementById('cacheStatus').innerHTML = '<div class="col-xs-8"><p>Cache used: <b>' + 
-                cacheInUse + '</b></p></div><div class="col-xs-4"><p>Assets: <b>' + 
-                (params.cacheCapability === 'memory' ? assetsCount[0] : assetsCount[1]) + '</b></p></div>';
+            document.getElementById('cacheUsed').innerHTML = cacheInUse;
+            document.getElementById('assetsCount').innerHTML = (params.cacheCapability === 'memory' ? assetsCount[0] : assetsCount[1]);
             var cacheSettings = document.getElementById('cacheSettingsDiv');
             var cacheStatusPanel = document.getElementById('cacheStatusPanel');
-            [cacheSettings, cacheStatusPanel].forEach(function(panel) {
+            [cacheSettings, cacheStatusPanel].forEach(function(card) {
                 // IE11 cannot remove more than one class from a list at a time
-                panel.classList.remove('panel-success');
-                panel.classList.remove('panel-warning');
+                card.classList.remove('card-success');
+                card.classList.remove('card-warning');
                 if (params.useCache) {
-                    panel.classList.add('panel-success');
+                    card.classList.add('card-success');
                 } else {
-                    panel.classList.add('panel-warning');
+                    card.classList.add('card-warning');
                 }
             });
             // Clear count of deleted assets

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -345,7 +345,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     }
 
     /**
-     * Determines CACHE capability and returns an array with the number of items in cssCache and CACHE
+     * Queries Service Worker if possible to determine CACHE capability and returns an object with cache attributes
      * @returns {Promise} A Promise for an object with keys for 'type', 'description', and 'count'
      */
     function checkCacheTypeAndCountAssets() {
@@ -358,7 +358,6 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                     var cache = event.data;
                     if (cache.error) reject(cache.error);
                     else {
-                        if (!cache.count && cache.type === 'custom') cache.count = '-';
                         resolve(cache);
                     }
                 };

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -48,7 +48,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
      * The name of the Cache API cache to use for caching Service Worker requests and responses
      * DEV: Make sure the same name is used at the head of service-worker.js
      */
-    var CACHE = 'kiwixjs-cache';
+    var CACHE = 'kiwixjs-assetCache';
     
     /**
      * @type ZIMArchive


### PR DESCRIPTION
This addresses ~~#441~~ #414. It adds the native Cache API to `service-worker.js` for the caching of css and js assets. It significantly speeds up SW mode. The cached entries can be checked in the Cache entry of devtools in Chromium or Edge (I didin't try with Firefox). Example of running this on the most recent Ray Charles is shown in the image below (from Chromium / Edge 78). This is not for merging yet, but I would appreciate testing and any comments.

![image](https://user-images.githubusercontent.com/4304337/63449072-37cdf280-c437-11e9-8453-422ee6115da6.png)

I think the main TODO is to provide a mechanism for deleting / pruning entries. We could just do it on change of ZIM, but as the quota on most devices is quite generous, and as the entries are unique to each ZIM, a more subtle mechanism could be found. We could provide usage statistics on the Configuration page and a button to clear the cache if it is quite large, for example. This would need to be decided.

Info for testing: To delete the cache and Service Worker after testing (in Chromium), delete `kiwixjs-cache` (right-click and delete) and unregister the Service Worker (under Application -> Service Workers ... ).

If there are code updates, a similar procedure would need to be followed, then a full page refresh (e.g. Ctrl-Shift-R), before testing again.
