### PR TITLE
Update Privacy Policy

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -118,11 +118,22 @@
                     <h4>Step 4 : enjoy Wikipedia offline!</h4>
                     <br />
                     <h3>Privacy policy</h3>
-                    <h4>Short answer :</h4>
-                    <p>This application works offline. We do not collect any of your personal data and don't even know what you are doing with this application.</p>
-                    <h4>Longer answer :</h4>
-                    <p>Anyway, if you think your Internet access can be watched and/or if you are paranoid, you should shut down your 3G and Wifi access before using the application.</p>
-                    <p>This application only reads the archive files of your device : it does not read any other files.</p>
+                    <h4>Short answer:</h4>
+                    <p>Kiwix JS works offline, and does not collect or record any of your personal data. It only remembers
+                        your browsing history for the duration of a session (for the purpose of returning to previously
+                        viewed pages). This history is lost on exiting the app and is not recorded in any way.</p>
+                    <h4>Longer answer:</h4>
+                    <p>This application only reads the archive files that you explicitly select on your device together
+                        with files in its own package. Some ZIM archives contain active content (scripts) which may, in
+                        rare circumstances, attempt to contact external servers for incidental files such as fonts.
+                        These scripts will only run if you enable Service Worker mode in Configuration. Nevertheless, if
+                        you believe your Internet access is insecure, or is being observed or censored, we recommend
+                        that you completely shut down your Internet (Data or WiFi) access before using the application.</p>
+                    <p>Additionally, if you obtained this app from a vendor Store (including extensions), then the Store
+                        operator may track your usage of the app (e.g. download, install, uninstall, date and number of
+                        sessions) for the purpose of providing anonymous, aggregate usage statistics to developers. If
+                        this concerns you, you should check the relevant Store Privacy Policy for further information.
+                    </p>
                     <h3>Feedback / helping / contributing</h3>
                     This application is still work in progress. There may be bugs and issues, and new features are planned.
                     Suggestions and patches/pull requests are welcome : the source code is on <a href="https://github.com/kiwix/kiwix-js" target="_blank">github</a>.


### PR DESCRIPTION
This addresses #548. Let me know what you think of the suggested text. As mentioned in the issue, the CSP should prevent most cases of scripts accessing external files, but we don't know all the contexts in which this app could run, and in some contexts it is definitely possible for scripts to access external servers (especially if the external server serves permissive CORS headers). So I believe the warning here is appropriate now that we execute scripts from ZIMs in SW mode.