### PR TITLE
Implement a theming system (dark theme / night mode)

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -111,7 +111,7 @@ iframe._invert, iframe._mwInvert {
 
 /* End of content themes */
 
-.hidden {
+.appThemeInfo {
     display: none;
     margin: 5px;
 }

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -91,7 +91,7 @@
 }
 
 .dark header, .dark #cachingAssets, .dark #about, .dark #configuration, .dark #welcomeText, .dark #articleListWithHeader,
-.dark #alertBoxHeader, .dark footer, iframe._invert {
+.dark #alertBoxHeader, .dark footer, iframe._invert, iframe._mwInvert {
     filter: invert(1) hue-rotate(180deg);
 }
 
@@ -101,6 +101,11 @@
 
 .dark body {
     background: #171717;
+}
+
+.hidden {
+    display: none;
+    padding-top: 5px;
 }
 
 .articleIFrame {

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -90,6 +90,8 @@
     margin: 0 1rem;
 }
 
+/* App theme: dark */
+
 .dark header, .dark #cachingAssets, .dark #about, .dark #configuration, .dark #welcomeText, .dark #articleListWithHeader,
 .dark #alertBoxHeader, .dark footer, iframe._invert, iframe._mwInvert {
     filter: invert(1) hue-rotate(180deg);
@@ -103,9 +105,11 @@
     background: #171717;
 }
 
+/* End of app theme: dark */
+
 .hidden {
     display: none;
-    padding-top: 5px;
+    margin: 5px;
 }
 
 .articleIFrame {

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -95,6 +95,10 @@
     filter: invert(1) hue-rotate(180deg);
 }
 
+.dark img {
+    filter: invert(1) hue-rotate(180deg);
+}
+
 .dark body {
     background: #171717;
 }

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -75,6 +75,7 @@
     padding-left: 12px;
     padding-right: 12px;
     background: lightblue;
+    z-index: 1;
 }
 
 #articleList a:hover, #articleList a.hover {
@@ -87,6 +88,15 @@
 
 #configuration {
     margin: 0 1rem;
+}
+
+.dark header, .dark #cachingAssets, .dark #about, .dark #configuration, .dark #welcomeText, .dark #articleListWithHeader,
+.dark #alertBoxHeader, .dark footer, iframe._invert {
+    filter: invert(1) hue-rotate(180deg);
+}
+
+.dark body {
+    background: #171717;
 }
 
 .articleIFrame {

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -93,11 +93,7 @@
 /* App theme: dark */
 
 .dark header, .dark #cachingAssets, .dark #about, .dark #configuration, .dark #welcomeText, .dark #articleListWithHeader,
-.dark #alertBoxHeader, .dark footer, iframe._invert, iframe._mwInvert {
-    filter: invert(1) hue-rotate(180deg);
-}
-
-.dark img {
+.dark #alertBoxHeader, .dark footer, .dark img {
     filter: invert(1) hue-rotate(180deg);
 }
 
@@ -106,6 +102,14 @@
 }
 
 /* End of app theme: dark */
+
+/* Content themes: _invert, _mwInvert */
+
+iframe._invert, iframe._mwInvert {
+    filter: invert(1) hue-rotate(180deg);
+}
+
+/* End of content themes */
 
 .hidden {
     display: none;

--- a/www/css/kiwixJS_invert.css
+++ b/www/css/kiwixJS_invert.css
@@ -1,0 +1,23 @@
+﻿/**
+ * This is a generic stylesheet that re-inverts images and videos so that they do not look like photographic negatives.
+ * The actual inversion is done by applying an inversion to the element in the outer document (e.g. iframe) that contains
+ * the embedded article. It could also be effected by adding the 'html' selector to the first rule, but this causes flashes
+ * to white between article loads.
+ *
+ * Two non-generic exceptions are applied to WikiMedia ZIMs: MathML embedded equations (which must be rendered inverted
+ * in order to be visible inline) and SVG drawings which are rendered with a soft-white background so that they are visible
+ * This mirrors proposals in https://github.com/openzim/mwoffliner/issues/1026
+ */
+
+img:not([class*="mwe-math-fallback-image"]),
+video {
+    filter: invert(1) hue-rotate(180deg);
+}
+
+img[data-file-type*="drawing"] {
+    background: #ddd !important;
+}
+
+body {
+    background: black !important;
+}

--- a/www/css/kiwixJS_invert.css
+++ b/www/css/kiwixJS_invert.css
@@ -1,14 +1,14 @@
-/*!
+﻿/*!
  * kiwixJS_invert.css
  * License GPL v3:
  *
  * Stylesheet for applying a content theme to articles extracted from a ZIM archive by Kiwix JS.
  * 
- * This is a purely generic stylesheet for inverting the display of content extracted from any ZIM.
- * The actual inversion is done in app.css by applying a filter inversion to the element in the outer document (e.g. iframe)
+ * This is a pure generic stylesheet for inverting the display of content extracted from any ZIM.
+ * The actual inversion is done in app.css by applying an inversion filter to the element in the outer document (e.g. iframe)
  * that contains the embedded article. This stylesheet re-inverts images and videos so that they do not look like
  * photographic negatives. In principle, inversion could be achieved by adding the 'html' selector to the first rule below,
- * but this causes non-WAI-compliant flashes (to white) between article loads.
+ * but this causes non-WAI-compliant flashes (to white) between article loads in Service Worker mode.
  *
  * This file is part of Kiwix.
  *

--- a/www/css/kiwixJS_invert.css
+++ b/www/css/kiwixJS_invert.css
@@ -1,27 +1,32 @@
-﻿/**
- * This is a generic stylesheet that re-inverts images and videos so that they do not look like photographic negatives.
- * The actual inversion is done by applying an inversion to the element in the outer document (e.g. iframe) that contains
- * the embedded article. It could also be effected by adding the 'html' selector to the first rule below, but this causes
- * non-WAI-compliant flashes (to white) between article loads.
+/*!
+ * kiwixJS_invert.css
+ * License GPL v3:
  *
- * Some non-generic exceptions are applied to WikiMedia ZIMs: MathML embedded equations (which must be rendered inverted
- * in order to be visible inline) and SVG drawings which are rendered with a soft-white background so that they are visible
- * This mirrors proposals in https://github.com/openzim/mwoffliner/issues/1026
- */ 
+ * Stylesheet for applying a content theme to articles extracted from a ZIM archive by Kiwix JS.
+ * 
+ * This is a purely generic stylesheet for inverting the display of content extracted from any ZIM.
+ * The actual inversion is done in app.css by applying a filter inversion to the element in the outer document (e.g. iframe)
+ * that contains the embedded article. This stylesheet re-inverts images and videos so that they do not look like
+ * photographic negatives. In principle, inversion could be achieved by adding the 'html' selector to the first rule below,
+ * but this causes non-WAI-compliant flashes (to white) between article loads.
+ *
+ * This file is part of Kiwix.
+ *
+ * Kiwix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kiwix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
+ */
 
-img:not([class|="mwe-math-fallback-image"]),
+img,
 video {
     filter: invert(1) hue-rotate(180deg);
-}
-
-img[data-file-type^="drawing"] {
-    background: #ddd !important;
-}
-
-/* Unfortunately, mw-offliner hard-codes a 'background: black' rule into its mobile stylesheet, which gets inverted to white by this
-filter and produces a jarring effect. This rule restores a black background (white will be inverted to black) */
-
-body[class*="mw-"] #container,
-body[class*="mw-"] #content {
-    background: white !important;
 }

--- a/www/css/kiwixJS_invert.css
+++ b/www/css/kiwixJS_invert.css
@@ -1,6 +1,6 @@
 ﻿/*!
  * kiwixJS_invert.css
- * License GPL v3:
+ * Licence GPL v3:
  *
  * Stylesheet for applying a content theme to articles extracted from a ZIM archive by Kiwix JS.
  * 
@@ -13,16 +13,16 @@
  * This file is part of Kiwix.
  *
  * Kiwix is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public Licence as published by
+ * the Free Software Foundation, either version 3 of the Licence, or
  * (at your option) any later version.
  *
  * Kiwix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public Licence for more details.
  *
- * You should have received a copy of the GNU General Public License
+ * You should have received a copy of the GNU General Public Licence
  * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
  */
 

--- a/www/css/kiwixJS_invert.css
+++ b/www/css/kiwixJS_invert.css
@@ -9,11 +9,11 @@
  * This mirrors proposals in https://github.com/openzim/mwoffliner/issues/1026
  */
 
-img:not([class*="mwe-math-fallback-image"]),
+img:not([class|="mwe-math-fallback-image"]),
 video {
     filter: invert(1) hue-rotate(180deg);
 }
 
-img[data-file-type^="drawing"] {
+img[data-file-type~="drawing"] {
     background: #ddd !important;
 }

--- a/www/css/kiwixJS_invert.css
+++ b/www/css/kiwixJS_invert.css
@@ -18,6 +18,6 @@ img[data-file-type*="drawing"] {
     background: #ddd !important;
 }
 
-body {
+/* body {
     background: black !important;
-}
+} */

--- a/www/css/kiwixJS_invert.css
+++ b/www/css/kiwixJS_invert.css
@@ -1,19 +1,27 @@
 ﻿/**
  * This is a generic stylesheet that re-inverts images and videos so that they do not look like photographic negatives.
  * The actual inversion is done by applying an inversion to the element in the outer document (e.g. iframe) that contains
- * the embedded article. It could also be effected by adding the 'html' selector to the first rule, but this causes flashes
- * to white between article loads.
+ * the embedded article. It could also be effected by adding the 'html' selector to the first rule below, but this causes
+ * non-WAI-compliant flashes (to white) between article loads.
  *
- * Two non-generic exceptions are applied to WikiMedia ZIMs: MathML embedded equations (which must be rendered inverted
+ * Some non-generic exceptions are applied to WikiMedia ZIMs: MathML embedded equations (which must be rendered inverted
  * in order to be visible inline) and SVG drawings which are rendered with a soft-white background so that they are visible
  * This mirrors proposals in https://github.com/openzim/mwoffliner/issues/1026
- */
+ */ 
 
 img:not([class|="mwe-math-fallback-image"]),
 video {
     filter: invert(1) hue-rotate(180deg);
 }
 
-img[data-file-type~="drawing"] {
+img[data-file-type^="drawing"] {
     background: #ddd !important;
+}
+
+/* Unfortunately, mw-offliner hard-codes a 'background: black' rule into its mobile stylesheet, which gets inverted to white by this
+filter and produces a jarring effect. This rule restores a black background (white will be inverted to black) */
+
+body[class*="mw-"] #container,
+body[class*="mw-"] #content {
+    background: white !important;
 }

--- a/www/css/kiwixJS_invert.css
+++ b/www/css/kiwixJS_invert.css
@@ -14,10 +14,6 @@ video {
     filter: invert(1) hue-rotate(180deg);
 }
 
-img[data-file-type*="drawing"] {
+img[data-file-type^="drawing"] {
     background: #ddd !important;
 }
-
-/* body {
-    background: black !important;
-} */

--- a/www/css/kiwixJS_mwInvert.css
+++ b/www/css/kiwixJS_mwInvert.css
@@ -1,0 +1,47 @@
+﻿/*!
+ * kiwixJS_mwInvert.css
+ * License GPL v3:
+ *
+ * Stylesheet for applying a content theme to articles extracted from a ZIM archive by Kiwix JS.
+ * 
+ * This is an inversion stylesheet with workarounds intended to improve the readability of dark-themed content from
+ * Wikimedia ZIMs. The stylesheet re-inverts images and videos so that they do not look like photographic negatives.
+ * For more information about the inversion process, see kiwixJS_invert.css in this folder.
+ *
+ * Some non-generic exceptions are applied to WikiMedia ZIMs: fallback images for MathML embedded equations (which must
+ * be rendered inverted in order to be visible inline) and SVG drawings which are rendered with a soft-white background
+ * so that they are visible. This mirrors proposals in https://github.com/openzim/mwoffliner/issues/1026 .
+ * If you are viewing a ZIM which has already implemented those proposals, try the generic inversion filter instead.
+ *
+ * This file is part of Kiwix.
+ *
+ * Kiwix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kiwix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
+ */
+
+img:not([class|="mwe-math-fallback-image"]),
+video {
+    filter: invert(1) hue-rotate(180deg);
+}
+
+img[data-file-type^="drawing"] {
+    background: #ddd !important;
+}
+
+/* mw-offliner hard-codes a 'background: black' rule into its mobile stylesheet, which gets inverted to white by this
+filter and produces a jarring effect. This rule restores a black background (white will be inverted to black) */
+
+#container,
+#content {
+    background: white !important;
+}

--- a/www/css/kiwixJS_mwInvert.css
+++ b/www/css/kiwixJS_mwInvert.css
@@ -9,8 +9,8 @@
  * For more information about the inversion process, see kiwixJS_invert.css in this folder.
  *
  * Some non-generic exceptions are applied to WikiMedia ZIMs: fallback images for MathML embedded equations (which must
- * be rendered inverted in order to be visible inline) and SVG drawings which are rendered with a soft-white background
- * so that they are visible. This mirrors proposals in https://github.com/openzim/mwoffliner/issues/1026 .
+ * be rendered inverted in order to be visible inline) and drawings and figures which are rendered with an off-white
+ * background so that they are visible. This mirrors proposals in https://github.com/openzim/mwoffliner/issues/1026 .
  * If you are viewing a ZIM which has already implemented those proposals, try the generic inversion filter instead.
  *
  * This file is part of Kiwix.
@@ -34,7 +34,9 @@ video {
     filter: invert(1) hue-rotate(180deg);
 }
 
-img[data-file-type^="drawing"] {
+/* Add an off-white background to drawings and figures */
+
+img[data-file-type^="drawing"], figure-inline img {
     background: #ddd !important;
 }
 
@@ -43,5 +45,5 @@ filter and produces a jarring effect. This rule restores a black background (whi
 
 #container,
 #content {
-    background: white !important;
+    background: transparent !important;
 }

--- a/www/css/kiwixJS_mwInvert.css
+++ b/www/css/kiwixJS_mwInvert.css
@@ -1,6 +1,6 @@
 ﻿/*!
  * kiwixJS_mwInvert.css
- * License GPL v3:
+ * Licence GPL v3:
  *
  * Stylesheet for applying a content theme to articles extracted from a ZIM archive by Kiwix JS.
  * 
@@ -16,16 +16,16 @@
  * This file is part of Kiwix.
  *
  * Kiwix is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
+ * it under the terms of the GNU General Public Licence as published by
+ * the Free Software Foundation, either version 3 of the Licence, or
  * (at your option) any later version.
  *
  * Kiwix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public Licence for more details.
  *
- * You should have received a copy of the GNU General Public License
+ * You should have received a copy of the GNU General Public Licence
  * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
  */
 

--- a/www/css/kiwixJS_mwInvert.css
+++ b/www/css/kiwixJS_mwInvert.css
@@ -41,7 +41,7 @@ img[data-file-type^="drawing"], figure-inline img {
 }
 
 /* mw-offliner hard-codes a 'background: black' rule into its mobile stylesheet, which gets inverted to white by this
-filter and produces a jarring effect. This rule restores a black background (white will be inverted to black) */
+filter and produces a jarring effect. This rule removes the background, leaving a black base (after inversion). */
 
 #container,
 #content {

--- a/www/index.html
+++ b/www/index.html
@@ -255,8 +255,11 @@
                                     <select class="form-control" id="appThemeSelect">
                                         <option value="light">Light</option>
                                         <option value="dark">Dark (app only)</option>
-                                        <option value="dark_invert">Dark + invert content</option>
+                                        <option value="dark_invert">Dark + invert (generic)</option>
+                                        <option value="dark_mwInvert">Dark + invert (Wikimedia)*</option>
                                     </select>
+                                    <p id="dark_mwInvert-help" class="hidden form-text text-muted">* Implements workarounds specific to Wikimedia ZIMs. Try generic option if there are display errors with recent ZIMs.</p>
+                                    <a id="viewArticle" class="hidden form-text" href="#">[&nbsp;Show article with applied theme&nbsp;]</a id="viewArticle" class="hidden form-text text-muted">
                                 </div>
                             </div>
                         </div>

--- a/www/index.html
+++ b/www/index.html
@@ -258,8 +258,8 @@
                                         <option value="dark_invert">Dark + invert (generic)</option>
                                         <option value="dark_mwInvert">Dark + invert (Wikimedia)*</option>
                                     </select>
-                                    <p id="dark_mwInvert-help" class="hidden form-text text-muted">* Implements workarounds specific to Wikimedia ZIMs. Try generic option if there are display errors with recent ZIMs.</p>
-                                    <a id="viewArticle" class="hidden form-text" href="#">[&nbsp;Show article with applied theme&nbsp;]</a id="viewArticle" class="hidden form-text text-muted">
+                                    <p id="dark_mwInvert-help" class="appThemeInfo form-text text-muted">* Implements workarounds specific to Wikimedia ZIMs. Try generic option if there are display errors with recent ZIMs.</p>
+                                    <a id="viewArticle" class="appThemeInfo form-text" href="#">[&nbsp;Show article with applied theme&nbsp;]</a>
                                 </div>
                             </div>
                         </div>

--- a/www/index.html
+++ b/www/index.html
@@ -248,6 +248,16 @@
                                         <strong>Animate transition between app pages</strong>
                                     </label>
                                 </div>
+                                <div class="form-group">
+                                    <label>
+                                        <b>Select app theme</b> (content inversion is experimental):
+                                    </label>
+                                    <select class="form-control" id="appThemeSelect">
+                                        <option value="light">Light</option>
+                                        <option value="dark">Dark (app only)</option>
+                                        <option value="dark_invert">Dark + invert content</option>
+                                    </select>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -65,15 +65,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
      */
     var selectedArchive = null;
     
-    /**
-     * A global parameter object for storing variables that need to be remembered between page loads
-     * or across different functions
-     * 
-     * @type Object
-     */
-    var params = {};
-
     // Set parameters and associated UI elements from cookie
+    // DEV: The params global variable is declared in init.js so that it is available to modules
     params['hideActiveContentWarning'] = cookies.getItem('hideActiveContentWarning') === 'true';
     params['showUIAnimations'] = cookies.getItem('showUIAnimations') ? cookies.getItem('showUIAnimations') === 'true' : true;
     document.getElementById('hideActiveContentWarningCheck').checked = params.hideActiveContentWarning;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -81,7 +81,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     // A global parameter that turns caching on or off and deletes the cache (it defaults to true unless explicitly turned off in UI)
     params['useCache'] = cookies.getItem('useCache') !== 'false';
     // A parameter to set the app theme and, if necessary, the CSS theme for article content (defaults to 'light')
-    params['appTheme'] = cookies.getItem('appTheme') || 'light'; // Currently implemented values: light|dark|dark_invert
+    params['appTheme'] = cookies.getItem('appTheme') || 'light'; // Currently implemented: light|dark|dark_invert|dark_mwInvert
     document.getElementById('appThemeSelect').value = params.appTheme;
     uiUtil.applyAppTheme(params.appTheme);
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -80,7 +80,11 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     document.getElementById('showUIAnimationsCheck').checked = params.showUIAnimations;
     // A global parameter that turns caching on or off and deletes the cache (it defaults to true unless explicitly turned off in UI)
     params['useCache'] = cookies.getItem('useCache') !== 'false';
-    
+    // A parameter to set the app theme and, if necessary, the CSS theme for article content (defaults to 'light')
+    params['appTheme'] = cookies.getItem('appTheme') || 'light'; // Currently implemented values: light|dark|dark_invert
+    document.getElementById('appThemeSelect').value = params.appTheme;
+    uiUtil.applyAppTheme(params.appTheme);
+
     // Define globalDropZone (universal drop area) and configDropZone (highlighting area on Config page)
     var globalDropZone = document.getElementById('search-article');
     var configDropZone = document.getElementById('configuration');
@@ -310,6 +314,11 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     $('input:checkbox[name=showUIAnimations]').on('change', function (e) {
         params.showUIAnimations = this.checked ? true : false;
         cookies.setItem('showUIAnimations', params.showUIAnimations, Infinity);
+    });
+    document.getElementById('appThemeSelect').addEventListener('change', function (e) {
+        params.appTheme = e.target.value;
+        cookies.setItem('appTheme', params.appTheme, Infinity);
+        uiUtil.applyAppTheme(params.appTheme);
     });
     document.getElementById('cachedAssetsModeRadioTrue').addEventListener('change', function (e) {
         if (e.target.checked) {
@@ -1032,6 +1041,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 $("#cachingAssets").html("Caching assets...");
                 $("#cachingAssets").hide();
                 $("#searchingArticles").hide();
+                // Set the requested appTheme
+                uiUtil.applyAppTheme(params.appTheme);
                 // Display the iframe content
                 $("#articleContent").show();
                 // Deflect drag-and-drop of ZIM file on the iframe to Config
@@ -1197,7 +1208,8 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 docBody.addEventListener('dragover', handleIframeDragover);
                 docBody.addEventListener('drop', handleIframeDrop);
             }
-
+            // Set the requested appTheme
+            uiUtil.applyAppTheme(params.appTheme);
             // Allow back/forward in browser history
             pushBrowserHistoryState(dirEntry.namespace + "/" + dirEntry.url);
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -66,7 +66,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
     var selectedArchive = null;
     
     // Set parameters and associated UI elements from cookie
-    // DEV: The params global variable is declared in init.js so that it is available to modules
+    // DEV: The params global object is declared in init.js so that it is available to modules
     params['hideActiveContentWarning'] = cookies.getItem('hideActiveContentWarning') === 'true';
     params['showUIAnimations'] = cookies.getItem('showUIAnimations') ? cookies.getItem('showUIAnimations') === 'true' : true;
     document.getElementById('hideActiveContentWarningCheck').checked = params.hideActiveContentWarning;

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -22,6 +22,14 @@
  */
 'use strict';
 
+/**
+ * A global parameter object for storing variables that need to be remembered between page loads,
+ * or across different functions and modules
+ * 
+ * @type Object
+ */
+var params = {};
+
 require.config({
     baseUrl: 'js/lib',
     paths: {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -354,7 +354,7 @@ define([], function() {
             // Use an absolute reference because Service Worker needs this (if an article loaded in SW mode is in a ZIM
             // subdirectory, then relative links injected into the article will not work as expected)
             // Note that location.pathname returns the path plus the filename, but is useful because it removes any query string
-            var prefix = document.location.origin + document.location.pathname.replace(/\/[^/]*$/, '');
+            var prefix = (window.location.protocol + '//' + window.location.hostname + window.location.pathname).replace(/\/[^/]*$/, '');
             if (doc) {
                 var link = doc.createElement('link');
                 link.setAttribute('id', 'kiwixJSTheme');

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -350,10 +350,11 @@ define([], function() {
             }
         }
         // Apply the requested ContentTheme (if not already attached)
-        if (contentTheme && (!kiwixJSSheet || !~kiwixJSSheet.href.search(contentTheme))) {
+        if (contentTheme && (!kiwixJSSheet || !~kiwixJSSheet.href.search('kiwixJS' + contentTheme + '.css'))) {
             iframe.classList.add(contentTheme);
-            // Use an absolute reference becuase Service Worker needs this
-            var prefix = document.location.href.replace(/index\.html(?:$|[#?].*$)/, '');
+            // Use an absolute reference because Service Worker needs this (if an article loaded in SW mode is in a ZIM
+            // subdirectory, then relative links injected into the article will not work as expected)
+            var prefix = document.location.origin + document.location.pathname;
             if (doc) {
                 var link = doc.createElement('link');
                 link.setAttribute('id', 'kiwixJSTheme');
@@ -364,8 +365,9 @@ define([], function() {
             }
         }
         // If we are in Config and a real document has been loaded already, expose return link so user can see the result of the change
-        if (/active/.test(document.getElementById('liConfigureNav').classList) &&
-            !/Placeholder\sfor\sinjecting\san\sarticle/.test(doc.title)) {
+        // DEV: The Placeholder string below matches the dummy article.html that is loaded before any articles are loaded
+        if (document.getElementById('liConfigureNav').classList.contains('active') &&
+            doc.title !== "Placeholder for injecting an article into the iframe") {
             showReturnLink();
         }
     }

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -311,7 +311,7 @@ define([], function() {
      * 
      * A <theme> string consists of two parts, the appTheme (theme to apply to the app shell only), and an optional
      * contentTheme beginning with an underscore: e.g. 'dark_invert' = 'dark' (appTheme) + '_invert' (contentTheme)
-     * Currently supported themes are: light, dark, dark_invert, but code below is written for extensibility
+     * Current themes are: light, dark, dark_invert, dark_mwInvert but code below is written for extensibility
      * For each appTheme (except the default 'light'), a corresponding set of rules must be present in app.css
      * For each contentTheme, a stylesheet must be provided in www/css that is named 'kiwixJS' + contentTheme
      * A rule may additionally be needed in app.css for full implementation of contentTheme

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -354,7 +354,7 @@ define([], function() {
             // Use an absolute reference because Service Worker needs this (if an article loaded in SW mode is in a ZIM
             // subdirectory, then relative links injected into the article will not work as expected)
             // Note that location.pathname returns the path plus the filename, but is useful because it removes any query string
-            var prefix = (window.location.protocol + '//' + window.location.hostname + window.location.pathname).replace(/\/[^/]*$/, '');
+            var prefix = (window.location.protocol + '//' + window.location.host + window.location.pathname).replace(/\/[^/]*$/, '');
             if (doc) {
                 var link = doc.createElement('link');
                 link.setAttribute('id', 'kiwixJSTheme');

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -305,7 +305,6 @@ define([], function() {
         }
     }
 
-
     /**
      * Applies the requested app and content theme
      * 
@@ -354,13 +353,14 @@ define([], function() {
             iframe.classList.add(contentTheme);
             // Use an absolute reference because Service Worker needs this (if an article loaded in SW mode is in a ZIM
             // subdirectory, then relative links injected into the article will not work as expected)
-            var prefix = document.location.origin + document.location.pathname;
+            // Note that location.pathname returns the path plus the filename, but is useful because it removes any query string
+            var prefix = document.location.origin + document.location.pathname.replace(/\/[^/]*$/, '');
             if (doc) {
                 var link = doc.createElement('link');
                 link.setAttribute('id', 'kiwixJSTheme');
                 link.setAttribute('rel', 'stylesheet');
                 link.setAttribute('type', 'text/css');
-                link.setAttribute('href', prefix + 'css/kiwixJS' + contentTheme + '.css');
+                link.setAttribute('href', prefix + '/css/kiwixJS' + contentTheme + '.css');
                 doc.head.appendChild(link);
             }
         }
@@ -380,13 +380,17 @@ define([], function() {
             e.preventDefault();
             document.getElementById('liConfigureNav').classList.remove('active');
             document.getElementById('liHomeNav').classList.add('active');
-            document.getElementById('configuration').style.display = 'none';
+            removeAnimationClasses();
+            if (params.showUIAnimations) { 
+                applyAnimationToSection('home');
+            } else {
+                document.getElementById('configuration').style.display = 'none';
+                document.getElementById('articleContent').style.display = 'block';
+            }
             document.getElementById('formArticleSearch').style.display = 'block';
-            document.getElementById('articleContent').style.display = 'block';
             viewArticle.style.display = 'none';
         });
     }
-
 
     /**
      * Functions and classes exposed by this module

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -334,6 +334,12 @@ define([], function() {
         if (appTheme) htmlEl.classList.add(appTheme);
         // Embed a reference to applied theme, so we can remove it generically in the future
         htmlEl.dataset.theme = theme;
+        // Hide any previously displayed help
+        var oldHelp = document.getElementById(oldTheme + '-help');
+        if (oldHelp) oldHelp.style.display = 'none';
+        // Show any specific help for selected contentTheme
+        var help = document.getElementById(theme + '-help');
+        if (help) help.style.display = 'block';
         
         // If there is no ContentTheme or we are applying a different ContentTheme, remove any previously applied ContentTheme
         if (oldContentTheme && oldContentTheme !== contentTheme) {
@@ -357,6 +363,26 @@ define([], function() {
                 doc.head.appendChild(link);
             }
         }
+        // If we are in Config and a real document has been loaded already, expose return link so user can see the result of the change
+        if (/active/.test(document.getElementById('liConfigureNav').classList) &&
+            !/Placeholder\sfor\sinjecting\san\sarticle/.test(doc.title)) {
+            showReturnLink();
+        }
+    }
+
+    // Displays the return link and handles click event. Called by applyAppTheme()
+    function showReturnLink() {
+        var viewArticle = document.getElementById('viewArticle');
+        viewArticle.style.display = 'block';
+        viewArticle.addEventListener('click', function(e) {
+            e.preventDefault();
+            document.getElementById('liConfigureNav').classList.remove('active');
+            document.getElementById('liHomeNav').classList.add('active');
+            document.getElementById('configuration').style.display = 'none';
+            document.getElementById('formArticleSearch').style.display = 'block';
+            document.getElementById('articleContent').style.display = 'block';
+            viewArticle.style.display = 'none';
+        });
     }
 
 

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -316,7 +316,7 @@ define([], function() {
      * For each contentTheme, a stylesheet must be provided in www/css that is named 'kiwixJS' + contentTheme
      * A rule may additionally be needed in app.css for full implementation of contentTheme
      * 
-     * @param {String} theme The theme to apply (light|dark[_invert])
+     * @param {String} theme The theme to apply (light|dark[_invert|_mwInvert])
      */
     function applyAppTheme(theme) {
         var htmlEl = document.getElementsByTagName('html')[0];


### PR DESCRIPTION
This backports (but with much improved and generic coding) a dark theme as described in #265.

I have implemented this as a generic theming system, though only three themes are currently implemented: `light` (the current default); `dark` (a theme for the app shell only); and `dark_invert` (a theme for the app shell and the content in the iframe). The screenshots below shows the `dark_invert` theme.

The app shell themes do not touch the document loaded in the iframe. the content theme of course has to attach a stylesheet, using DOM methods, after the document has loaded. It works in both jQuey and Service Worker modes.

Inversion is carried out by adding a simple inversion filter to the iframe element (`articleContent`), but we have to attach a stylesheet to the iframe document to re-invert images and videos (generically) so that they do not look like photographic negatives. There are two non-generic rules that are specific to Wikimedia ZIMs (the vast majority). This is practically inevitable: for discussion see https://github.com/openzim/mwoffliner/issues/1026 . If that proposal is implemented in the ZIM, it may be possible to remove one of the non-generic rules for future ZIMs. If a JS API is added to the ZIMs in the future, it will be possible to remove both non-generic rules.

**Image rendering**

![image](https://user-images.githubusercontent.com/4304337/71743057-7a7aef00-2e5b-11ea-8edd-6fedd70ccf89.png)


**Configuration**

![image](https://user-images.githubusercontent.com/4304337/71742645-58cd3800-2e5a-11ea-965b-9446ce6d7c16.png)


**Screenshot showing equations and search**

![image](https://user-images.githubusercontent.com/4304337/71742577-26233f80-2e5a-11ea-9a30-3e9841d88823.png)

**Stackexchange**

![image](https://user-images.githubusercontent.com/4304337/71743004-50c1c800-2e5b-11ea-8cc9-51754b27ffd6.png)

