### PR TITLE
Update Q and deprecated Promise patterns and methods

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -862,7 +862,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'cookies','abstractFilesystemAcc
      * @returns {Promise<Blob>} A promise for the requested file (blob)
      */
     function readRemoteArchive(url) {
-        // DEV: This deferred can't be standardized to an ES6 Promise pattern (using Q) because
+        // DEV: This deferred can't be standardized to a Promise/A+ pattern (using Q) because
         // IE11 is unable to scope the callbacks inside the Promise correctly. See [kiwix.js #589]
         var deferred = Q.defer();
         var request = new XMLHttpRequest();
@@ -879,8 +879,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'cookies','abstractFilesystemAcc
                 }
             }
         };
-        request.onabort = deferred.reject;
-        request.onerror = deferred.reject;
+        request.onabort = request.onerror = deferred.reject;
         request.send();
         return deferred.promise;
     }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -26,8 +26,8 @@
 // This uses require.js to structure javascript:
 // http://requirejs.org/docs/api.html#define
 
-define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFilesystemAccess','q'],
- function($, zimArchiveLoader, util, uiUtil, cookies, abstractFilesystemAccess, q) {
+define(['jquery', 'zimArchiveLoader', 'uiUtil', 'cookies','abstractFilesystemAccess','q'],
+ function($, zimArchiveLoader, uiUtil, cookies, abstractFilesystemAccess, Q) {
      
     /**
      * Maximum number of articles to display in a search
@@ -378,7 +378,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
      * @returns {Promise<Object>} A Promise for an object with cache attributes 'type', 'description', and 'count'
      */
     function getCacheAttributes() {
-        return q.Promise(function (resolve, reject) {
+        return Q.Promise(function (resolve, reject) {
             if (contentInjectionMode === 'serviceworker') {
                 // Create a Message Channel
                 var channel = new MessageChannel();
@@ -858,44 +858,46 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
      * Reads a remote archive with given URL, and returns the response in a Promise.
      * This function is used by setRemoteArchives below, for UI tests
      * 
-     * @param url The URL of the archive to read
-     * @returns {Promise}
+     * @param {String} url The URL of the archive to read
+     * @returns {Promise<Blob>} A promise for the requested file (blob)
      */
     function readRemoteArchive(url) {
-        var deferred = q.defer();
+        // DEV: This deferred can't be standardized to an ES6 Promise pattern (using Q) because
+        // IE11 is unable to scope the callbacks inside the Promise correctly. See [kiwix.js #589]
+        var deferred = Q.defer();
         var request = new XMLHttpRequest();
-        request.open("GET", url, true);
+        request.open("GET", url);
         request.responseType = "blob";
         request.onreadystatechange = function () {
             if (request.readyState === XMLHttpRequest.DONE) {
-                if ((request.status >= 200 && request.status < 300) || request.status === 0) {
+                if (request.status >= 200 && request.status < 300 || request.status === 0) {
                     // Hack to make this look similar to a file
                     request.response.name = url;
                     deferred.resolve(request.response);
-                }
-                else {
+                } else {
                     deferred.reject("HTTP status " + request.status + " when reading " + url);
                 }
             }
         };
-        request.onabort = function (e) {
-            deferred.reject(e);
-        };
-        request.send(null);
+        request.onabort = deferred.reject;
+        request.onerror = deferred.reject;
+        request.send();
         return deferred.promise;
     }
     
     /**
      * This is used in the testing interface to inject remote archives
+     * @returns {Promise<Array>} A Promise for an array of archives  
      */
-    window.setRemoteArchives = function() {
+    window.setRemoteArchives = function () {
         var readRequests = [];
-        var i;
-        for (i = 0; i < arguments.length; i++) {
-            readRequests[i] = readRemoteArchive(arguments[i]);
-        }
-        return q.all(readRequests).then(function(arrayOfArchives) {
+        Array.prototype.slice.call(arguments).forEach(function (arg) {
+            readRequests.push(readRemoteArchive(arg));
+        });
+        return Q.all(readRequests).then(function (arrayOfArchives) {
             setLocalArchiveFromFileList(arrayOfArchives);
+        }).catch(function (e) {
+            console.error('Unable to load remote archive(s)', e);
         });
     };
 
@@ -1136,7 +1138,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                         });
                     }
                 };
-                selectedArchive.getDirEntryByTitle(title).then(readFile).fail(function () {
+                selectedArchive.getDirEntryByTitle(title).then(readFile).catch(function () {
                     messagePort.postMessage({ 'action': 'giveContent', 'title': title, 'content': new UInt8Array() });
                 });
             } else {
@@ -1317,7 +1319,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                         var mimetype = dirEntry.getMimetype();
                         uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
                     });
-                }).fail(function (e) {
+                }).catch(function (e) {
                     console.error("could not find DirEntry for image:" + title, e);
                 });
             });
@@ -1370,7 +1372,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                                 renderIfCSSFulfilled(fileDirEntry.url);
                             }
                         );
-                    }).fail(function (e) {
+                    }).catch(function (e) {
                         console.error("could not find DirEntry for CSS : " + title, e);
                         cssCount--;
                         renderIfCSSFulfilled();
@@ -1410,7 +1412,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                             uiUtil.feedNodeWithBlob(script, 'src', content, 'text/javascript');
                         });
                     }
-                }).fail(function (e) {
+                }).catch(function (e) {
                     console.error("could not find DirEntry for javascript : " + title, e);
                 });
             });
@@ -1510,7 +1512,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                 $('#activeContent').hide();
                 readArticle(dirEntry);
             }
-        }).fail(function(e) { alert("Error reading article with title " + title + " : " + e); });
+        }).catch(function(e) { alert("Error reading article with title " + title + " : " + e); });
     }
     
     function goToRandomArticle() {

--- a/www/js/lib/util.js
+++ b/www/js/lib/util.js
@@ -20,7 +20,7 @@
  * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
  */
 'use strict';
-define(['q'], function(q) {
+define(['q'], function(Q) {
 
     /**
      * Utility function : return true if the given string ends with the suffix
@@ -180,23 +180,21 @@ define(['q'], function(q) {
 
     /**
      * Reads a Uint8Array from the given file starting at byte offset begin and
-     * for given size.
-     * @param {File} file
-     * @param {Integer} begin
-     * @param {Integer} size
-     * @returns {Promise} Promise
+     * for given size
+     * @param {File} file The file object to be read
+     * @param {Integer} begin The offset in <File> at which to begin reading
+     * @param {Integer} size The number of bytes to read
+     * @returns {Promise<Uint8Array>} A Promise for an array buffer with the read data 
      */
     function readFileSlice(file, begin, size) {
-        var deferred = q.defer();
-        var reader = new FileReader();
-        reader.onload = function(e) {
-            deferred.resolve(new Uint8Array(e.target.result));
-        };
-        reader.onerror = reader.onabort = function(e) {
-            deferred.reject(e);
-        };
-        reader.readAsArrayBuffer(file.slice(begin, begin + size));
-        return deferred.promise;
+        return Q.Promise(function (resolve, reject) {
+            var reader = new FileReader();
+            reader.onload = function (e) {
+                resolve(new Uint8Array(e.target.result));
+            };
+            reader.onerror = reader.onabort = reject;
+            reader.readAsArrayBuffer(file.slice(begin, begin + size));
+        });
     }
 
     /**

--- a/www/js/lib/xzdec_wrapper.js
+++ b/www/js/lib/xzdec_wrapper.js
@@ -147,7 +147,7 @@ define(['q'], function(Q) {
      */
     Decompressor.prototype._fillInBufferIfNeeded = function() {
         if (!xzdec._input_empty(this._decHandle)) {
-            // DEV: When converting to ES6 Promise, use Promise.resolve(0) here
+            // DEV: When converting to Promise/A+, use Promise.resolve(0) here
             return Q.when(0);
         }
         var that = this;

--- a/www/js/lib/xzdec_wrapper.js
+++ b/www/js/lib/xzdec_wrapper.js
@@ -20,7 +20,7 @@
  * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
  */
 'use strict';
-define(['q'], function(q) {
+define(['q'], function(Q) {
     var xzdec = Module; //@todo including via requirejs seems to not work
     xzdec._init();
     
@@ -78,29 +78,25 @@ define(['q'], function(q) {
     };
     
     /**
-     * Read length bytes, offset into the decompressed stream.
-     * This function ensures that only one decompression runs at a time.
-     * 
-     * @param {Integer} offset
-     * @param {Integer} length
+     * Reads stream of data from file offset for length of bytes to send to the decompresor
+     * This function ensures that only one decompression runs at a time
+     * @param {Integer} offset The file offset at which to begin reading compressed data
+     * @param {Integer} length The amount of data to read
+     * @returns {Promise} A Promise for the read data
      */
-    Decompressor.prototype.readSliceSingleThread = function(offset, length) {
+    Decompressor.prototype.readSliceSingleThread = function (offset, length) {
         if (!busy) {
             return this.readSlice(offset, length);
-        }
-        else {
+        } else {
             // The decompressor is already in progress.
             // To avoid using too much memory, we wait until it has finished
-            // before using it for another decompression.
-            // Inspired by https://codereview.stackexchange.com/questions/145563/angularjs-recursive-function-call-with-timeout
+            // before using it for another decompression
             var that = this;
-            var deferred = q.defer();
-
-            setTimeout(function(){
-                that.readSliceSingleThread(offset, length).then(deferred.resolve, deferred.reject);
-            }, DELAY_WAITING_IDLE_DECOMPRESSOR);
-
-            return deferred.promise;
+            return Q.Promise(function (resolve, reject) {
+                setTimeout(function () {
+                    that.readSliceSingleThread(offset, length).then(resolve, reject);
+                }, DELAY_WAITING_IDLE_DECOMPRESSOR);
+            });
         }
     };
 
@@ -150,8 +146,10 @@ define(['q'], function(q) {
      * @returns {Promise}
      */
     Decompressor.prototype._fillInBufferIfNeeded = function() {
-        if (!xzdec._input_empty(this._decHandle))
-            return q.when(0);
+        if (!xzdec._input_empty(this._decHandle)) {
+            // DEV: When converting to ES6 Promise, use Promise.resolve(0) here
+            return Q.when(0);
+        }
         var that = this;
         return this._reader(this._inStreamPos, this._chunkSize).then(function(data) {
             if (data.length > that._chunkSize)

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -299,7 +299,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
                     callback(data);
                 });
             }
-        }).fail(function (e) {
+        }).catch(function (e) {
             console.warn("Metadata with key " + key + " not found in the archive", e);
             callback();
         });

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -257,12 +257,8 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
             fileArray.sort(function (a, b) {
                 var nameA = a.name.toUpperCase();
                 var nameB = b.name.toUpperCase();
-                if (nameA < nameB) {
-                    return -1;
-                }
-                if (nameA > nameB) {
-                    return 1;
-                }
+                if (nameA < nameB) return -1;
+                if (nameA > nameB) return 1;
                 return 0;
             });
             return util.readFileSlice(fileArray[0], 0, 80).then(function (header) {

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -214,7 +214,7 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
      * and is stored as ZIMFile.mimeTypes
      * 
      * @param {File} file The ZIM file (or first file in array of files) from which the MIME type list 
-*                      is to be extracted
+     *      is to be extracted
      * @param {Integer} mimeListPos The offset in <file> at which the MIME type list is found
      * @param {Integer} urlPtrPos The offset of the byte after the end of the MIME type list in <file>
      * @returns {Promise} A promise for the MIME Type list as a Map
@@ -222,13 +222,13 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
     function readMimetypeMap(file, mimeListPos, urlPtrPos) {
         var typeMap = new Map;
         var size = urlPtrPos - mimeListPos;
-        return util.readFileSlice(file, mimeListPos, size).then(function(data) {
+        return util.readFileSlice(file, mimeListPos, size).then(function (data) {
             if (data.subarray) {
                 var i = 0;
                 var pos = -1;
                 var mimeString;
                 while (pos < size) {
-                    pos++; 
+                    pos++;
                     mimeString = utf8.parse(data.subarray(pos), true);
                     // If the parsed data is an empty string, we have reached the end of the MIME type list, so break 
                     if (!mimeString) break;
@@ -241,35 +241,34 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
                 }
             }
             return typeMap;
-        }).fail(function(err) {
+        }).catch(function (err) {
             console.error('Unable to read MIME type list', err);
             return new Map;
         });
     }
-    
+
     return {
         /**
-         * 
-         * @param {Array.<File>} fileArray
-         * @returns {Promise}
+         * @param {Array.<File>} fileArray An array of picked archive files
+         * @returns {Promise<Object>} A Promise for the ZimFile Object
          */
-        fromFileArray: function(fileArray) {
+        fromFileArray: function (fileArray) {
             // Array of blob objects should be sorted by their name property
-            fileArray.sort(function(a, b) {
-                  var nameA = a.name.toUpperCase(); 
-                  var nameB = b.name.toUpperCase(); 
-                  if (nameA < nameB) {
+            fileArray.sort(function (a, b) {
+                var nameA = a.name.toUpperCase();
+                var nameB = b.name.toUpperCase();
+                if (nameA < nameB) {
                     return -1;
-                  }
-                  if (nameA > nameB) {
+                }
+                if (nameA > nameB) {
                     return 1;
-                  }
-                  return 0;
+                }
+                return 0;
             });
-            return util.readFileSlice(fileArray[0], 0, 80).then(function(header) {
+            return util.readFileSlice(fileArray[0], 0, 80).then(function (header) {
                 var mimeListPos = readInt(header, 56, 8);
                 var urlPtrPos = readInt(header, 32, 8);
-                return readMimetypeMap(fileArray[0], mimeListPos, urlPtrPos).then(function(data) {
+                return readMimetypeMap(fileArray[0], mimeListPos, urlPtrPos).then(function (data) {
                     var zf = new ZIMFile(fileArray);
                     zf.articleCount = readInt(header, 24, 4);
                     zf.clusterCount = readInt(header, 28, 4);


### PR DESCRIPTION
Implements #588 for almost all of the deprecated methods and patterns. I have not touched the patterns in `abstractFilesystemAccess.js` because they are FFOS-specific, and I guess this code will not be transferred to any ES6-webkit-npm version. I have kept Q, however, for backwards compatibility with old devices. To dispense with Q, we would simply need to change `Q.Promise()` patterns to `new Promise()`.

I have standardized on using Q with a capital letter (we have some variation).

There is one case of a `Q.when` which is not in the Promise spec. I haven't touched it (yet?) because I don't know what the difference is between when and then in Q.