### PR TITLE
Add prefix checking before displaying list of matched articles

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -944,6 +944,16 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
      * @param {Array} dirEntryArray The array of dirEntries returned from the binary search
      */
     function populateListOfArticles(dirEntryArray) {
+        var prefixDisplayedInSearchBar = $('#prefix').val();
+        var testUrl = dirEntryArray.length > 0 ? dirEntryArray[0].url.toLowerCase() : null;
+        // Early return if dirEntryArray is not returned from previous search or the prefix displayed is empty.
+        if(!prefixDisplayedInSearchBar || (!testUrl && testUrl.startsWith(prefixDisplayedInSearchBar))) {
+            console.debug("Nonempty dirEntryArray is not returned by latest findDirEntriesWithPrefix, early return");
+            // Manually disable searchingArticles.
+            $('#searchingArticles').hide();
+            return;
+        }
+
         var articleListHeaderMessageDiv = $('#articleListHeaderMessage');
         var nbDirEntry = dirEntryArray ? dirEntryArray.length : 0;
 
@@ -1033,7 +1043,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
      * @param {DirEntry} dirEntry The directory entry of the article to read
      */
     function readArticle(dirEntry) {
-	    // Only update for expectedArticleURLToBeDisplayed.
+        // Only update for expectedArticleURLToBeDisplayed.
         expectedArticleURLToBeDisplayed = dirEntry.namespace + "/" + dirEntry.url;
         // We must remove focus from UI elements in order to deselect whichever one was clicked (in both jQuery and SW modes),
         // but we should not do this when opening the landing page (or else one of the Unit Tests fails, at least on Chrome 58)


### PR DESCRIPTION
Attempt to address the issue described in issue #184 .

Add an early return if either the follow conditions holds:

- The search prefix input box is empty. (Which prevents loading search result after redirecting)
- The dirEntry array is non-empty and is not the result from latest prefix search. (Will handle the empty array in the origin code)