### PR TITLE
changed title of page according to the title of the ZIM

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1244,6 +1244,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'cookies','abstractFilesystemAcc
             //loadJavaScriptJQuery();
             loadCSSJQuery();
             insertMediaBlobsJQuery();
+            if (articleContent.getElementsByTagName("body")[0].classList[0] == "tags")
+                document.getElementsByTagName("title")[0].innerHTML = articleContent.getElementsByClassName("title")[0].innerText;
         };
      
         // Load the blank article to clear the iframe (NB iframe onload event runs *after* this)


### PR DESCRIPTION
Please check the changes. Now the title of the page changes according to the ZIM file viewed by the user...This is illustration of  the issue -The window title should be set to the article title (coming from the iframe) (#280)