### PR TITLE
Do not assume urlPtrPos is just after mimeList when reading it

### DIFF
--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -216,12 +216,16 @@ define(['xzdec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'], function(xz, util,
      * @param {File} file The ZIM file (or first file in array of files) from which the MIME type list 
      *      is to be extracted
      * @param {Integer} mimeListPos The offset in <file> at which the MIME type list is found
-     * @param {Integer} urlPtrPos The offset of the byte after the end of the MIME type list in <file>
+     * @param {Integer} urlPtrPos The offset of URL Pointer List in the archive
      * @returns {Promise} A promise for the MIME Type list as a Map
      */
     function readMimetypeMap(file, mimeListPos, urlPtrPos) {
         var typeMap = new Map;
         var size = urlPtrPos - mimeListPos;
+        // ZIM archives produced since May 2020 relocate the URL Pointer List to the end of the archive
+        // so we limit the slice size to max 1024 bytes in order to prevent reading the entire archive into an array buffer
+        // See https://github.com/openzim/libzim/issues/353
+        size = size > 1024 ? 1024 : size;
         return util.readFileSlice(file, mimeListPos, size).then(function (data) {
             if (data.subarray) {
                 var i = 0;


### PR DESCRIPTION
This PR is a fix for #628 and #629 (partially) and #621 . It restores the ability of the app to read the MIME type list in newer ZIMs which have relocated the urlPtrPos to the end of the archive. The same solution has been adopted in libZim - see https://github.com/openzim/libzim/issues/353. The solution is to limit the maximum size of the slice being searched for the MIME type list to 1024 bytes. If the ZIM reports it as being less than that, then the lower value is accepted.

