### PR TITLE
Updated cookie to ensure samesite is set as Strict.

### DIFF
--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -62,10 +62,10 @@ define([], function () {
       localStorageTest = false;
     }
     // Now test for document.cookie API support
-    document.cookie = 'tempKiwixCookieTest=working;expires=Fri, 31 Dec 9999 23:59:59 GMT;samesite=Strict';
+    document.cookie = 'tempKiwixCookieTest=working;expires=Fri, 31 Dec 9999 23:59:59 GMT; SameSite=Strict';
     var kiwixCookieTest = /tempKiwixCookieTest=working/.test(document.cookie);
     // Remove test value by expiring the key
-    document.cookie = 'tempKiwixCookieTest=;expires=Thu, 01 Jan 1970 00:00:00 GMT;samesite=Strict';
+    document.cookie = 'tempKiwixCookieTest=;expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Strict';
     if (kiwixCookieTest) type = 'cookie';
     // Prefer localStorage if supported due to some platforms removing cookies once the session ends in some contexts
     if (localStorageTest) type = 'local_storage';

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -62,10 +62,10 @@ define([], function () {
       localStorageTest = false;
     }
     // Now test for document.cookie API support
-    document.cookie = 'tempKiwixCookieTest=working;expires=Fri, 31 Dec 9999 23:59:59 GMT; SameSite=Strict';
+    document.cookie = 'tempKiwixCookieTest=working; expires=Fri, 31 Dec 9999 23:59:59 GMT; SameSite=Strict';
     var kiwixCookieTest = /tempKiwixCookieTest=working/.test(document.cookie);
     // Remove test value by expiring the key
-    document.cookie = 'tempKiwixCookieTest=;expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Strict';
+    document.cookie = 'tempKiwixCookieTest=; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Strict';
     if (kiwixCookieTest) type = 'cookie';
     // Prefer localStorage if supported due to some platforms removing cookies once the session ends in some contexts
     if (localStorageTest) type = 'local_storage';

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -62,10 +62,10 @@ define([], function () {
       localStorageTest = false;
     }
     // Now test for document.cookie API support
-    document.cookie = 'tempKiwixCookieTest=working;expires=Fri, 31 Dec 9999 23:59:59 GMT';
+    document.cookie = 'tempKiwixCookieTest=working;expires=Fri, 31 Dec 9999 23:59:59 GMT;samesite=Strict';
     var kiwixCookieTest = /tempKiwixCookieTest=working/.test(document.cookie);
     // Remove test value by expiring the key
-    document.cookie = 'tempKiwixCookieTest=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    document.cookie = 'tempKiwixCookieTest=;expires=Thu, 01 Jan 1970 00:00:00 GMT;samesite=Strict';
     if (kiwixCookieTest) type = 'cookie';
     // Prefer localStorage if supported due to some platforms removing cookies once the session ends in some contexts
     if (localStorageTest) type = 'local_storage';


### PR DESCRIPTION
Fixes #627 . I used strict as I couldn't find any reason or code to use Lax. The cookie is set only for this and doesn't need to set to any other value.