### PR TITLE
Make Privacy Policy publicly accessible

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,21 @@
+# Kiwix JS Privacy Policy
+
+## Short version
+
+Kiwix JS works offline, and does not collect or record any of your personal data. It only remembers
+your browsing history for the duration of a session (for the purpose of returning to previously
+viewed pages). This history is lost on exiting the app and is not recorded in any way.
+
+## Longer version
+
+This application only reads the archive files that you explicitly select on your device together
+with files in its own package. Some ZIM archives contain active content (scripts) which may, in
+rare circumstances, attempt to contact external servers for incidental files such as fonts.
+These scripts will only run if you enable Service Worker mode in Configuration. Nevertheless, if
+you believe your Internet access is insecure, or is being observed or censored, we recommend
+that you completely shut down your Internet (Data or WiFi) access before using the application.
+
+Additionally, if you obtained this app from a vendor Store (including extensions), then the Store
+operator may track your usage of the app (e.g. download, install, uninstall, date and number of
+sessions) for the purpose of providing anonymous, aggregate usage statistics to developers. If
+this concerns you, you should check the relevant Store Privacy Policy for further information.


### PR DESCRIPTION
I need a publicly accessible Privacy Policy to publish our app in Edge Add-on Store, so I'm making it available on this branch, so I can reference it. But I think we could add it to master easily. It's just a copy of our current policy embedded in the app.