### PR TITLE
Add a low level block cache

### DIFF
--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -63,6 +63,7 @@ define(['q'], function(Q) {
         this.moveToTop(entry);
         return entry.value;
     };
+    
     /**
      * Stores a value in the cache by id and prunes the least recently used entry if the cache is larger than MAX_CACHE_SIZE
      * @param {String} id The key under which to store the value (consists of filename + file number)

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -51,7 +51,9 @@ define(['q'], function(Q) {
 
     /**
      * Tries to retrieve an element by its namespace and id. If it is not present in the cache,
-     * returns undefined.
+     * returns undefined
+     * @param {Integer} id The block cache entry id
+     * @returns {Uint8Array|undefined} The requested cache data or undefined 
      */
     LRUCache.prototype.get = function(id) {
         var entry = this._entries[id]; 
@@ -114,7 +116,10 @@ define(['q'], function(Q) {
     /**
      * Read a certain byte range in the given file, breaking the range into chunks that go through the cache
      * If a read of more than blocksize (bytes) is requested, do not use the cache
-     * @return {Promise} promise that resolves to the correctly concatenated data.
+     * @param {Object} file The requested file to read from
+     * @param {Integer} begin The byte from which to start reading
+     * @param {Integer} end The last byte to read
+     * @return {Promise<Uint8Array>} A Promise that resolves to the correctly concatenated data
      */
     var read = function(file, begin, end) {
         // Read large chunks bypassing the block cache because we would have to

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -161,7 +161,9 @@ define(['q'], function(Q) {
     };
     var readInternal = function (file, begin, end) {
         if ('arrayBuffer' in Blob.prototype) {
-            // DEV: This method uses the Native FS handle if available
+            // DEV: This method uses the native arrayBuffer method of Blob, if available, as it eliminates
+            // the need to use FileReader and set up event listeners; it also uses the method's native Promise
+            // rather than setting up potentially hundreds of new Q promises for small byte range reads
             return file.slice(begin, end).arrayBuffer().then(function (buffer) {
                 return new Uint8Array(buffer);
             });

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -50,9 +50,9 @@ define(['q'], function(Q) {
     }
 
     /**
-     * Tries to retrieve an element by its id. If it is not present in the cache,
-     * returns undefined
-     * @param {Integer} id The block cache entry id
+     * Tries to retrieve an element by its id. If it is not present in the cache, returns undefined; if it is present,
+     * then the value is returned and the entry is moved to the top of the cache
+     * @param {String} id The block cache entry key
      * @returns {Uint8Array|undefined} The requested cache data or undefined 
      */
     LRUCache.prototype.get = function(id) {
@@ -63,6 +63,11 @@ define(['q'], function(Q) {
         this.moveToTop(entry);
         return entry.value;
     };
+    /**
+     * Stores a value in the cache by id and prunes the least recently used entry if the cache is larger than MAX_CACHE_SIZE
+     * @param {String} id The key under which to store the value (consists of filename + file number)
+     * @param {Uint16Array} value The value to store in the cache 
+     */
     LRUCache.prototype.store = function(id, value) {
         var entry = this._entries[id];
         if (entry === undefined) {
@@ -80,6 +85,11 @@ define(['q'], function(Q) {
             this.moveToTop(entry);
         }
     };
+
+    /**
+     * Delete a cache entry
+     * @param {String} entry The entry to delete 
+     */
     LRUCache.prototype.unlink = function(entry) {
         if (entry.next === null) {
             this._last = entry.prev;
@@ -92,6 +102,11 @@ define(['q'], function(Q) {
             entry.prev.next = entry.next;
         }
     };
+
+    /**
+     * Insert a cache entry at the top of the cache
+     * @param {String} entry The entry to insert 
+     */
     LRUCache.prototype.insertAtTop = function(entry) {
         if (this._first === null) {
             this._first = this._last = entry;
@@ -101,6 +116,11 @@ define(['q'], function(Q) {
             this._first = entry;
         }
     };
+
+    /**
+     * Move a cache entry to the top of the cache
+     * @param {String} entry The entry to move 
+     */
     LRUCache.prototype.moveToTop = function(entry) {
         this.unlink(entry);
         this.insertAtTop(entry);

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -153,7 +153,7 @@ define(['q', 'util'], function(Q, util) {
             for (var i = Math.floor(begin / BLOCK_SIZE) * BLOCK_SIZE; i < end; i += BLOCK_SIZE) {
                 var b = Math.max(i, begin) - i;
                 var e = Math.min(end, i + BLOCK_SIZE) - i;
-                result.set(blocks[i].subarray(b, e), pos);
+                if (blocks[i].subarray) result.set(blocks[i].subarray(b, e), pos);
                 pos += e - b;
             }
             return result;

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -124,7 +124,7 @@ define(['q', 'util'], function(Q, util) {
     var read = function(file, begin, end) {
         // Read large chunks bypassing the block cache because we would have to
         // stitch together too many blocks and would clog the cache
-        if (end - begin > BLOCK_SIZE * 2) return util.readFileSlice(file, begin, end);
+        if (end - begin > BLOCK_SIZE * 2) return readInternal(file, begin, end);
         var readRequests = [];
         var blocks = {};
         for (var i = Math.floor(begin / BLOCK_SIZE) * BLOCK_SIZE; i < end; i += BLOCK_SIZE) {

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -20,7 +20,7 @@
  * along with Kiwix JS (file LICENSE).  If not, see <http://www.gnu.org/licenses/>
  */
 'use strict';
-define(['q', 'util'], function(Q, util) {
+define(['q'], function(Q) {
     /**
      * Set maximum number of cache blocks of BLOCK_SIZE bytes each
      * Maximum size of cache in bytes = MAX_CACHE_SIZE * BLOCK_SIZE

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -26,13 +26,13 @@ define(['q'], function(Q) {
      * Maximum size of cache in bytes = MAX_CACHE_SIZE * BLOCK_SIZE
      * @type {Integer}
      */
-    var MAX_CACHE_SIZE = 4000;
+    const MAX_CACHE_SIZE = 4000;
 
     /**
      * The maximum blocksize to read or store via the block cache (bytes)
      * @type {Integer}
     */
-    var BLOCK_SIZE = 4096;
+    const BLOCK_SIZE = 4096;
 
     /**
      * Creates a new cache with max size limit

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -1,0 +1,179 @@
+﻿/**
+ * filecache.js: Generic least-recently-used-cache used for reading file chunks.
+ *
+ * Copyright 2020 Mossroy, peter-x, jaifroid and contributors
+ * License GPL v3:
+ *
+ * This file is part of Kiwix.
+ *
+ * Kiwix JS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kiwix JS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kiwix JS (file LICENSE).  If not, see <http://www.gnu.org/licenses/>
+ */
+'use strict';
+define(['q'], function(Q) {
+    /**
+     * Set maximum number of cache blocks of BLOCK_SIZE bytes each
+     * Maximum size of cache in bytes = MAX_CACHE_SIZE * BLOCK_SIZE
+     * @type {Integer}
+     */
+    var MAX_CACHE_SIZE = 4000;
+
+    /**
+     * The maximum blocksize to read or store via the block cache (bytes)
+     * @type {Integer}
+    */
+    var BLOCK_SIZE = 4096;
+
+    /**
+     * Creates a new cache with max size limit
+     * @param {Integer} limit The maximum number of 2048-byte blocks to be cached
+     */
+    function LRUCache(limit) {
+        console.log("Creating cache of size " + limit);
+        this._limit = limit;
+        this._size = 0;
+        // Mapping from id to {value: , prev: , next: }
+        this._entries = {};
+        // linked list of entries
+        this._first = null;
+        this._last = null;
+    }
+
+    /**
+     * Tries to retrieve an element by its namespace and id. If it is not present in the cache,
+     * returns undefined.
+     */
+    LRUCache.prototype.get = function(id) {
+        var entry = this._entries[id]; 
+        if (entry === undefined) {
+            return entry;
+        }
+        this.moveToTop(entry);
+        return entry.value;
+    };
+    LRUCache.prototype.store = function(id, value) {
+        var entry = this._entries[id];
+        if (entry === undefined) {
+            entry = this._entries[id] = {id: id, prev: null, next: null, value: value};
+            this.insertAtTop(entry);
+            if (this._size >= this._limit) {
+                var e = this._last;
+                this.unlink(e);
+                delete this._entries[e.id];
+            } else {
+                this._size++;
+            }
+        } else {
+            entry.value = value;
+            this.moveToTop(entry);
+        }
+    };
+    LRUCache.prototype.unlink = function(entry) {
+        if (entry.next === null) {
+            this._last = entry.prev;
+        } else {
+            entry.next.prev = entry.prev;
+        }
+        if (entry.prev === null) {
+            this._first = null;
+        } else {
+            entry.prev.next = entry.next;
+        }
+    };
+    LRUCache.prototype.insertAtTop = function(entry) {
+        if (this._first === null) {
+            this._first = this._last = entry;
+        } else {
+            this._first.prev = entry;
+            entry.next = this._first;
+            this._first = entry;
+        }
+    };
+    LRUCache.prototype.moveToTop = function(entry) {
+        this.unlink(entry);
+        this.insertAtTop(entry);
+    };
+
+    // Create a new cache
+    var cache = new LRUCache(MAX_CACHE_SIZE);
+    
+    // Counters for reporting only
+    var hits = 0;
+    var misses = 0;
+
+    /**
+     * Read a certain byte range in the given file, breaking the range into chunks that go through the cache
+     * If a read of more than blocksize (bytes) is requested, do not use the cache
+     * @return {Promise} promise that resolves to the correctly concatenated data.
+     */
+    var read = function(file, begin, end) {
+        // Read large chunks bypassing the block cache because we would have to
+        // stitch together too many blocks and would clog the cache
+        if (end - begin > BLOCK_SIZE * 2) return readInternal(file, begin, end);
+        var readRequests = [];
+        var blocks = {};
+        for (var i = Math.floor(begin / BLOCK_SIZE) * BLOCK_SIZE; i < end; i += BLOCK_SIZE) {
+            var block = cache.get(file.name + i);
+            if (block === undefined) {
+                misses++;
+                readRequests.push(function(offset) {
+                    return readInternal(file, offset, offset + BLOCK_SIZE).then(function(result) {
+                        cache.store(file.name + offset, result);
+                        blocks[offset] = result;
+                    });
+                }(i));
+            } else {
+                hits++;
+                blocks[i] = block;
+            }
+        }
+        if (misses + hits > 2000) {
+            console.log("** Block cache hit rate: " + Math.round(hits / (hits + misses) * 1000) / 10 + "% [ hits:" + hits + " / misses:" + misses + " ]");
+            hits = 0;
+            misses = 0;
+        }
+        return Q.all(readRequests).then(function() {
+            var result = new Uint8Array(end - begin);
+            var pos = 0;
+            for (var i = Math.floor(begin / BLOCK_SIZE) * BLOCK_SIZE; i < end; i += BLOCK_SIZE) {
+                var b = Math.max(i, begin) - i;
+                var e = Math.min(end, i + BLOCK_SIZE) - i;
+                result.set(blocks[i].subarray(b, e), pos);
+                pos += e - b;
+            }
+            return result;
+        });
+    };
+    var readInternal = function (file, begin, end) {
+        if ('arrayBuffer' in Blob.prototype) {
+            // DEV: This method uses the Native FS handle if available
+            return file.slice(begin, end).arrayBuffer().then(function (buffer) {
+                return new Uint8Array(buffer);
+            });
+        } else {
+            return Q.Promise(function (resolve, reject) {
+                var reader = new FileReader();
+                reader.readAsArrayBuffer(file.slice(begin, end));
+                reader.addEventListener('load', function (e) {
+                    resolve(new Uint8Array(e.target.result));
+                });
+                reader.addEventListener('error', reject);
+                reader.addEventListener('abort', reject);
+            });
+        }
+    };
+
+    return {
+        read: read
+    };
+});

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -36,7 +36,7 @@ define(['q'], function(Q) {
 
     /**
      * Creates a new cache with max size limit
-     * @param {Integer} limit The maximum number of 2048-byte blocks to be cached
+     * @param {Integer} limit The maximum number of blocks of BLOCK_SIZE to be cached
      */
     function LRUCache(limit) {
         console.log("Creating cache of size " + limit);
@@ -50,7 +50,7 @@ define(['q'], function(Q) {
     }
 
     /**
-     * Tries to retrieve an element by its namespace and id. If it is not present in the cache,
+     * Tries to retrieve an element by its id. If it is not present in the cache,
      * returns undefined
      * @param {Integer} id The block cache entry id
      * @returns {Uint8Array|undefined} The requested cache data or undefined 

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -50,7 +50,7 @@ define(['q'], function (Q) {
     /**
      * Tries to retrieve an element by its id. If it is not present in the cache, returns undefined; if it is present,
      * then the value is returned and the entry is moved to the top of the cache
-     * @param {Integer} key The block cache entry key (byte offset)
+     * @param {String} key The block cache entry key (file.id + ':' + byte offset)
      * @returns {Uint8Array|undefined} The requested cache data or undefined 
      */
     LRUCache.prototype.get = function (key) {
@@ -64,7 +64,7 @@ define(['q'], function (Q) {
 
     /**
      * Stores a value in the cache by id and prunes the least recently used entry if the cache is larger than MAX_CACHE_SIZE
-     * @param {Integer} key The key under which to store the value (byte offset from start of ZIM archive)
+     * @param {String} key The key under which to store the value (file.id + ':' + byte offset from start of ZIM archive)
      * @param {Uint16Array} value The value to store in the cache 
      */
     LRUCache.prototype.store = function (key, value) {
@@ -158,13 +158,13 @@ define(['q'], function (Q) {
         var blocks = {};
         // Look for the requested data in the blocks: we may need to stitch together data from two or more blocks
         for (var id = Math.floor(begin / BLOCK_SIZE) * BLOCK_SIZE; id < end; id += BLOCK_SIZE) {
-            var block = cache.get(id);
+            var block = cache.get(file.id + ':' + id);
             if (block === undefined) {
                 // Data not in cache, so read from archive
                 misses++;
                 readRequests.push(function (offset) {
                     return file._readSplitSlice(offset, offset + BLOCK_SIZE).then(function (result) {
-                        cache.store(offset, result);
+                        cache.store(file.id + ':' + offset, result);
                         blocks[offset] = result;
                     });
                 }(id));

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -96,13 +96,12 @@ define(['q'], function (Q) {
             } else {
                 // IE11 doesn't support the keys iterator, so we have to do forEach loop through all 4000 entries
                 // to get the oldest values. To prevent excessive iterations, we delete 25% at a time.
-                var that = this;
-                var q = Math.floor(0.25 * that.capacity);
+                var q = Math.floor(0.25 * this.capacity);
                 var c = 0;
                 console.log('Deleteing ' + q + ' cache entries');
-                this.cache.forEach(function(v, k) {
+                this.cache.forEach(function(v, k, map) {
                     if (c > q) return;
-                    that.cache.delete(k);
+                    map.delete(k);
                     c++;
                 });
             }

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -45,7 +45,7 @@ define(['q'], function (Q) {
      * @property {Number} capacity The maximum number of entries in the cache 
      * @property {Map} cache A map to store the cache keys and data
      */
-    
+
     /**
      * Creates a new cache with max size limit of MAX_CACHE_SIZE blocks
      * LRUCache implemnentation with Map adapted from https://markmurray.co/blog/lru-cache/
@@ -99,7 +99,7 @@ define(['q'], function (Q) {
                 var q = Math.floor(0.25 * this.capacity);
                 var c = 0;
                 console.log('Deleteing ' + q + ' cache entries');
-                this.cache.forEach(function(v, k, map) {
+                this.cache.forEach(function (v, k, map) {
                     if (c > q) return;
                     map.delete(k);
                     c++;

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -59,16 +59,15 @@ define(['q'], function (Q) {
      */
     function LRUCache() {
         console.log('Creating cache of size ' + MAX_CACHE_SIZE + ' * ' + BLOCK_SIZE + ' bytes');
+        // Initialize persistent Cache properties
         this._limit = MAX_CACHE_SIZE;
-        // Initialize linked list of entries
-        this._first = null;
-        this._last = null;
+        this._entries = new Map();
     }
 
     /**
      * Tries to retrieve an element by its id. If it is not present in the cache, returns undefined; if it is present,
      * then the value is returned and the entry is moved to the top of the cache
-     * @param {String} key The block cache entry key (byte file.id + ':' + offset)
+     * @param {String} key The block cache entry key (file.id + ':' + byte offset)
      * @returns {Uint8Array|undefined} The requested cache data or undefined 
      */
     LRUCache.prototype.get = function (key) {
@@ -82,7 +81,7 @@ define(['q'], function (Q) {
 
     /**
      * Stores a value in the cache by id and prunes the least recently used entry if the cache is larger than MAX_CACHE_SIZE
-     * @param {String} key The key under which to store the value (byte file.id + ':' + offset from start of ZIM archive)
+     * @param {String} key The key under which to store the value (file.id + ':' + byte offset from start of ZIM archive)
      * @param {Uint8Array} value The value to store in the cache 
      */
     LRUCache.prototype.store = function (key, value) {
@@ -159,10 +158,13 @@ define(['q'], function (Q) {
      */
     var init = function () {
         console.log('Initialize or reset FileCache');
-        // DEV: Technically, we do not need to void the FileCache object's Map, because each entry is marked with a 
+        // Initialize linked list of entries
+        cache._first = null;
+        cache._last = null;
+        // DEV: Technically, we do not need to clear the FileCache object's Map, because each entry is marked with a 
         // ZIM ID, but it should free up memory on new ZIM load, and should provide a slight performance advantage while
-        // the new Map is being populated
-        cache._entries = new Map();
+        // the Map is being re-populated
+        cache._entries.clear();
     };
 
     /**

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -136,7 +136,7 @@ define(['q'], function (Q) {
     /**
      * Initializes or resets the cache - this should be called whenever a new ZIM is loaded
      */
-    var reset = function () {
+    var init = function () {
         console.log('Initialize or reset FileCache');
         cache._entries = new Map();
     };
@@ -195,6 +195,6 @@ define(['q'], function (Q) {
 
     return {
         read: read,
-        reset: reset
+        init: init
     };
 });

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -65,7 +65,7 @@ define(['q'], function (Q) {
     /**
      * Tries to retrieve an element by its id. If it is not present in the cache, returns undefined; if it is present,
      * then the value is returned and the entry is moved to the top of the cache
-     * @param {String} key The block cache entry key (byte offset + '' + file.id)
+     * @param {String} key The block cache entry key (byte offset + ':' + file.id)
      * @returns {Uint8Array|undefined} The requested cache data or undefined 
      */
     LRUCache.prototype.get = function (key) {
@@ -79,7 +79,7 @@ define(['q'], function (Q) {
 
     /**
      * Stores a value in the cache by id and prunes the least recently used entry if the cache is larger than MAX_CACHE_SIZE
-     * @param {String} key The key under which to store the value (byte offset + '' + file.id from start of ZIM archive)
+     * @param {String} key The key under which to store the value (byte offset + ':' + file.id from start of ZIM archive)
      * @param {Uint8Array} value The value to store in the cache 
      */
     LRUCache.prototype.store = function (key, value) {
@@ -179,13 +179,13 @@ define(['q'], function (Q) {
         var blocks = {};
         // Look for the requested data in the blocks: we may need to stitch together data from two or more blocks
         for (var id = Math.floor(begin / BLOCK_SIZE) * BLOCK_SIZE; id < end; id += BLOCK_SIZE) {
-            var block = cache.get(id + '' + file.id);
+            var block = cache.get(id + ':' + file.id);
             if (block === undefined) {
                 // Data not in cache, so read from archive
                 misses++;
                 readRequests.push(function (offset) {
                     return file._readSplitSlice(offset, offset + BLOCK_SIZE).then(function (result) {
-                        cache.store(offset + '' + file.id, result);
+                        cache.store(offset + ':' + file.id, result);
                         blocks[offset] = result;
                     });
                 }(id));

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -90,7 +90,19 @@ define(['q'], function (Q) {
         // If we've exceeded the cache capacity, then delete the least recently accessed value, 
         // which will be the item at the top of the Map, i.e the first position
         if (this.cache.size > this.capacity) {
-            var firstKey = this.cache.keys().next().value;
+            var firstKey;
+            if (this.cache.keys) {
+                firstKey = this.cache.keys().next().value;
+            } else {
+                // IE11 doesn't support the keys iterator, so we have to do forEach loop through all 4000 entries
+                // to get the oldest value (which is the first one)
+                var s = false;
+                this.cache.forEach(function(v, k) {
+                    if (s) return;
+                    firstKey = k;
+                    s = true;
+                });
+            }
             this.cache.delete(firstKey);
         }
     };

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -26,19 +26,21 @@ define(['q'], function (Q) {
     /**
      * Set maximum number of cache blocks of BLOCK_SIZE bytes each
      * Maximum size of cache in bytes = MAX_CACHE_SIZE * BLOCK_SIZE
-     * @type {Integer}
+     * @constant
+     * @type {Number}
      */
     const MAX_CACHE_SIZE = 4000;
 
     /**
      * The maximum blocksize to read or store via the block cache (bytes)
-     * @type {Integer}
+     * @constant
+     * @type {Number}
      */
     const BLOCK_SIZE = 4096;
 
     /**
      * A Cache Entry
-     * @typedef CacheEntry
+     * @typedef {Object} CacheEntry
      * @property {String} id The cache key (stored also in the entry)
      * @property {CacheEntry} prev The previous linked cache entry
      * @property {CacheEntry} next The next linked cache entry
@@ -47,11 +49,11 @@ define(['q'], function (Q) {
 
     /**
      * A Block Cache employing a Least Recently Used caching strategy
-     * @typedef BlockCache
-     * @property {Integer} _limit The maximum number of entries in the cache 
+     * @typedef {Object} BlockCache
+     * @property {Number} _limit The maximum number of entries in the cache 
      * @property {Map} _entries A map to store the cache keys and data
      * @property {CacheEntry} _first The most recently used entry in the cache
-     * @property {CacheEntry} _last The least recedntly used entry in the cache
+     * @property {CacheEntry} _last The least recently used entry in the cache
      */
     
     /**
@@ -85,17 +87,21 @@ define(['q'], function (Q) {
      * @param {Uint8Array} value The value to store in the cache 
      */
     LRUCache.prototype.store = function (key, value) {
-        var entry = this.get(key);
-        if (entry === undefined) {
-            entry = {
+        if (!this._entries.has(key)) {
+            /**
+             * Define a new CacheEntry object in memory
+             * @type {CacheEntry}
+             */
+            var entry = {
                 id: key,
                 prev: null,
                 next: null,
                 value: value
             };
+            // Store a reference to the entry object in the Map
             this._entries.set(key, entry);
             this.insertAtTop(entry);
-            if (this._entries.size >= this._limit) {
+            if (this._entries.size > this._limit) {
                 var e = this._last;
                 this.unlink(e);
                 this._entries.delete(e.id);
@@ -171,8 +177,8 @@ define(['q'], function (Q) {
      * Read a certain byte range in the given file, breaking the range into chunks that go through the cache
      * If a read of more than BLOCK_SIZE * 2 (bytes) is requested, do not use the cache
      * @param {Object} file The requested ZIM archive to read from
-     * @param {Integer} begin The byte from which to start reading
-     * @param {Integer} end The byte at which to stop reading (end will not be read)
+     * @param {Number} begin The byte from which to start reading
+     * @param {Number} end The byte at which to stop reading (end will not be read)
      * @return {Promise<Uint8Array>} A Promise that resolves to the correctly concatenated data from the cache 
      *     or from the ZIM archive
      */

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -90,20 +90,22 @@ define(['q'], function (Q) {
         // If we've exceeded the cache capacity, then delete the least recently accessed value, 
         // which will be the item at the top of the Map, i.e the first position
         if (this.cache.size > this.capacity) {
-            var firstKey;
             if (this.cache.keys) {
-                firstKey = this.cache.keys().next().value;
+                var firstKey = this.cache.keys().next().value;
+                this.cache.delete(firstKey);
             } else {
                 // IE11 doesn't support the keys iterator, so we have to do forEach loop through all 4000 entries
-                // to get the oldest value (which is the first one)
-                var s = false;
+                // to get the oldest values. To prevent excessive iterations, we delete 10% at a time.
+                var that = this;
+                var q = Math.floor(0.1 * that.capacity);
+                var c = 0;
+                console.log('Deleteing ' + q + ' cache entries');
                 this.cache.forEach(function(v, k) {
-                    if (s) return;
-                    firstKey = k;
-                    s = true;
+                    if (c > 1000) return;
+                    that.cache.delete(k);
+                    c++;
                 });
             }
-            this.cache.delete(firstKey);
         }
     };
 

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -95,9 +95,9 @@ define(['q'], function (Q) {
                 this.cache.delete(firstKey);
             } else {
                 // IE11 doesn't support the keys iterator, so we have to do forEach loop through all 4000 entries
-                // to get the oldest values. To prevent excessive iterations, we delete 10% at a time.
+                // to get the oldest values. To prevent excessive iterations, we delete 25% at a time.
                 var that = this;
-                var q = Math.floor(0.1 * that.capacity);
+                var q = Math.floor(0.25 * that.capacity);
                 var c = 0;
                 console.log('Deleteing ' + q + ' cache entries');
                 this.cache.forEach(function(v, k) {

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -51,7 +51,8 @@ define(['q'], function (Q) {
      * LRUCache implemnentation with Map adapted from https://markmurray.co/blog/lru-cache/
      */
     function LRUCache() {
-        console.log('Creating cache of size ' + MAX_CACHE_SIZE + ' * ' + BLOCK_SIZE + ' bytes');
+        /** CACHE TUNING **/
+        // console.log('Creating cache of size ' + MAX_CACHE_SIZE + ' * ' + BLOCK_SIZE + ' bytes');
         // Initialize persistent Cache properties
         this.capacity = MAX_CACHE_SIZE;
         this.cache = new Map();
@@ -100,7 +101,7 @@ define(['q'], function (Q) {
                 // to get the oldest values. To prevent excessive iterations, we delete 25% at a time.
                 var q = Math.floor(0.25 * this.capacity);
                 var c = 0;
-                console.log('Deleteing ' + q + ' cache entries');
+                // console.log('Deleteing ' + q + ' cache entries');
                 this.cache.forEach(function (v, k, map) {
                     if (c > q) return;
                     map.delete(k);
@@ -116,9 +117,10 @@ define(['q'], function (Q) {
      */
     var cache = new LRUCache();
 
-    // Counters for reporting only
-    var hits = 0;
-    var misses = 0;
+    /** CACHE TUNING **/ 
+    // DEV: Uncomment this block and blocks below marked 'CACHE TUNING' to measure Cache hit and miss rates for different Cache sizes
+    // var hits = 0;
+    // var misses = 0;
 
     /**
      * Read a certain byte range in the given file, breaking the range into chunks that go through the cache
@@ -140,7 +142,8 @@ define(['q'], function (Q) {
             var block = cache.get(file.id + ':' + id);
             if (block === undefined) {
                 // Data not in cache, so read from archive
-                misses++;
+                /** CACHE TUNING **/
+                // misses++;
                 // DEV: This is a self-calling function, i.e. the function is called with an argument of <id> which then 
                 // becomes the <offset> parameter
                 readRequests.push(function (offset) {
@@ -150,15 +153,18 @@ define(['q'], function (Q) {
                     });
                 }(id));
             } else {
-                hits++;
+                /** CACHE TUNING **/
+                // hits++;
                 blocks[id] = block;
             }
         }
-        if (misses + hits > 2000) {
-            console.log("** Block cache hit rate: " + Math.round(hits / (hits + misses) * 1000) / 10 + "% [ hits:" + hits + " / misses:" + misses + " ]");
-            hits = 0;
-            misses = 0;
-        }
+        /** CACHE TUNING **/
+        // if (misses + hits > 2000) {
+        //     console.log('** Block cache hit rate: ' + Math.round(hits / (hits + misses) * 1000) / 10 + '% [ hits:' + hits + 
+        //         ' / misses:' + misses + ' ] Size: ' + cache.cache.size);
+        //     hits = 0;
+        //     misses = 0;
+        // }
         // Wait for all the blocks to be read either from the cache or from the archive
         return Q.all(readRequests).then(function () {
             var result = new Uint8Array(end - begin);

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -20,7 +20,7 @@
  * along with Kiwix JS (file LICENSE).  If not, see <http://www.gnu.org/licenses/>
  */
 'use strict';
-define(['q'], function(Q) {
+define(['q'], function (Q) {
     /**
      * Set maximum number of cache blocks of BLOCK_SIZE bytes each
      * Maximum size of cache in bytes = MAX_CACHE_SIZE * BLOCK_SIZE
@@ -31,7 +31,7 @@ define(['q'], function(Q) {
     /**
      * The maximum blocksize to read or store via the block cache (bytes)
      * @type {Integer}
-    */
+     */
     const BLOCK_SIZE = 4096;
 
     /**
@@ -55,24 +55,24 @@ define(['q'], function(Q) {
      * @param {String} id The block cache entry key
      * @returns {Uint8Array|undefined} The requested cache data or undefined 
      */
-    LRUCache.prototype.get = function(id) {
-        var entry = this._entries[id]; 
+    LRUCache.prototype.get = function (id) {
+        var entry = this._entries[id];
         if (entry === undefined) {
             return entry;
         }
         this.moveToTop(entry);
         return entry.value;
     };
-    
+
     /**
      * Stores a value in the cache by id and prunes the least recently used entry if the cache is larger than MAX_CACHE_SIZE
      * @param {String} id The key under which to store the value (consists of filename + file number)
      * @param {Uint16Array} value The value to store in the cache 
      */
-    LRUCache.prototype.store = function(id, value) {
+    LRUCache.prototype.store = function (id, value) {
         var entry = this._entries[id];
         if (entry === undefined) {
-            entry = this._entries[id] = {id: id, prev: null, next: null, value: value};
+            entry = this._entries[id] = { id: id, prev: null, next: null, value: value };
             this.insertAtTop(entry);
             if (this._size >= this._limit) {
                 var e = this._last;
@@ -91,7 +91,7 @@ define(['q'], function(Q) {
      * Delete a cache entry
      * @param {String} entry The entry to delete 
      */
-    LRUCache.prototype.unlink = function(entry) {
+    LRUCache.prototype.unlink = function (entry) {
         if (entry.next === null) {
             this._last = entry.prev;
         } else {
@@ -108,7 +108,7 @@ define(['q'], function(Q) {
      * Insert a cache entry at the top of the cache
      * @param {String} entry The entry to insert 
      */
-    LRUCache.prototype.insertAtTop = function(entry) {
+    LRUCache.prototype.insertAtTop = function (entry) {
         if (this._first === null) {
             this._first = this._last = entry;
         } else {
@@ -122,14 +122,14 @@ define(['q'], function(Q) {
      * Move a cache entry to the top of the cache
      * @param {String} entry The entry to move 
      */
-    LRUCache.prototype.moveToTop = function(entry) {
+    LRUCache.prototype.moveToTop = function (entry) {
         this.unlink(entry);
         this.insertAtTop(entry);
     };
 
     // Create a new cache
     var cache = new LRUCache(MAX_CACHE_SIZE);
-    
+
     // Counters for reporting only
     var hits = 0;
     var misses = 0;
@@ -142,7 +142,7 @@ define(['q'], function(Q) {
      * @param {Integer} end The byte at which to stop reading (end will not be read)
      * @return {Promise<Uint8Array>} A Promise that resolves to the correctly concatenated data from the split ZIM file set
      */
-    var read = function(file, begin, end) {
+    var read = function (file, begin, end) {
         // Read large chunks bypassing the block cache because we would have to
         // stitch together too many blocks and would clog the cache
         if (end - begin > BLOCK_SIZE * 2) return file._readSplitSlice(begin, end);
@@ -152,8 +152,8 @@ define(['q'], function(Q) {
             var block = cache.get(file.name + i);
             if (block === undefined) {
                 misses++;
-                readRequests.push(function(offset) {
-                    return file._readSplitSlice(offset, offset + BLOCK_SIZE).then(function(result) {
+                readRequests.push(function (offset) {
+                    return file._readSplitSlice(offset, offset + BLOCK_SIZE).then(function (result) {
                         cache.store(file.name + offset, result);
                         blocks[offset] = result;
                     });
@@ -168,7 +168,7 @@ define(['q'], function(Q) {
             hits = 0;
             misses = 0;
         }
-        return Q.all(readRequests).then(function() {
+        return Q.all(readRequests).then(function () {
             var result = new Uint8Array(end - begin);
             var pos = 0;
             for (var i = Math.floor(begin / BLOCK_SIZE) * BLOCK_SIZE; i < end; i += BLOCK_SIZE) {

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -101,7 +101,7 @@ define(['q'], function (Q) {
                 var c = 0;
                 console.log('Deleteing ' + q + ' cache entries');
                 this.cache.forEach(function(v, k) {
-                    if (c > 1000) return;
+                    if (c > q) return;
                     that.cache.delete(k);
                     c++;
                 });

--- a/www/js/lib/filecache.js
+++ b/www/js/lib/filecache.js
@@ -80,12 +80,14 @@ define(['q'], function (Q) {
      * @param {Uint8Array} value The value to store in the cache 
      */
     LRUCache.prototype.store = function (key, value) {
+        // We get the existing entry's object for memory-management purposes; if it exists, it will contain identical data
+        // to <value>, but <entry> is strongly referenced by the Map. (It should be rare that two async Promises attempt to
+        // store the same data in the Cache, once the Cache is sufficiently populated.)
         var entry = this.cache.get(key);
-        // If the key already exists, delete it so that it will be added
+        // If the key already exists, delete it and re-insert it, so that it will be added
         // to the bottom of the Map (bottom = most recent)
         if (entry) this.cache.delete(key);
         else entry = value;
-        // Store a reference to the entry in the Map
         this.cache.set(key, entry);
         // If we've exceeded the cache capacity, then delete the least recently accessed value, 
         // which will be the item at the top of the Map, i.e the first position
@@ -94,7 +96,7 @@ define(['q'], function (Q) {
                 var firstKey = this.cache.keys().next().value;
                 this.cache.delete(firstKey);
             } else {
-                // IE11 doesn't support the keys iterator, so we have to do forEach loop through all 4000 entries
+                // IE11 doesn't support the keys iterator, so we have to do a forEach loop through all 4000 entries
                 // to get the oldest values. To prevent excessive iterations, we delete 25% at a time.
                 var q = Math.floor(0.25 * this.capacity);
                 var c = 0;

--- a/www/js/lib/util.js
+++ b/www/js/lib/util.js
@@ -20,7 +20,7 @@
  * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
  */
 'use strict';
-define(['q'], function(Q) {
+define(['q', 'filecache'], function(Q, FileCache) {
 
     /**
      * A Regular Expression to match the first letter of a word even if preceded by Unicode punctuation
@@ -204,14 +204,7 @@ define(['q'], function(Q) {
      * @returns {Promise<Uint8Array>} A Promise for an array buffer with the read data 
      */
     function readFileSlice(file, begin, size) {
-        return Q.Promise(function (resolve, reject) {
-            var reader = new FileReader();
-            reader.onload = function (e) {
-                resolve(new Uint8Array(e.target.result));
-            };
-            reader.onerror = reader.onabort = reject;
-            reader.readAsArrayBuffer(file.slice(begin, begin + size));
-        });
+        return FileCache.read(file, begin, begin + size);
     }
 
     /**

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -281,7 +281,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
                     var zf = new ZIMFile(fileArray);
                     // Line below provides an abstracted filename in case the ZIM file is split into multiple parts;
                     // it greatly simplifies coding of the block cache, as it can store and respond to offsets from the start of the file set
-                    zf.name = fileArray[0].name.replace(/(\.zim)[a-z]{2}$/i, '$1');
+                    zf.name = fileArray[0].name.replace(/(\.zim)\w\w$/i, '$1');
                     zf.articleCount = readInt(header, 24, 4);
                     zf.clusterCount = readInt(header, 28, 4);
                     zf.urlPtrPos = urlPtrPos;

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -99,12 +99,16 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry'],
             // Wait until all are resolved and concatenate.
             console.log("CONCAT");
             return Q.all(readRequests).then(function(arrays) {
-                var concatenated = new Uint8Array(size);
-                var sizeSum = 0;
-                for (var i = 0; i < arrays.length; ++i) {
-                    concatenated.set(new Uint8Array(arrays[i]), sizeSum);
-                    sizeSum += arrays[i].byteLength;
-                }
+                var length = 0;
+                arrays.forEach(function (item) {
+                    length += item.byteLength;
+                });
+                var concatenated = new Uint8Array(length);
+                var offset = 0;
+                arrays.forEach(function (item) {
+                    concatenated.set(new Uint8Array(item), offset);
+                    offset += item.byteLength;
+                });
                 return concatenated;
             });
         }

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -66,10 +66,8 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
      * @param {Integer} size
      * @returns {Integer}
      */
-    ZIMFile.prototype._readInteger = function(offset, size)
-    {
-        return this._readSlice(offset, size).then(function(data)
-        {
+    ZIMFile.prototype._readInteger = function (offset, size) {
+        return this._readSlice(offset, size).then(function (data) {
             return readInt(data, 0, size);
         });
     };

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -228,7 +228,6 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
      * Reads the whole MIME type list and returns it as a populated Map
      * The mimeTypeMap is extracted once after the user has picked the ZIM file
      * and is stored as ZIMFile.mimeTypes
-     * 
      * @param {File} file The ZIM file (or first file in array of files) from which the MIME type list 
      *      is to be extracted
      * @param {Integer} mimeListPos The offset in <file> at which the MIME type list is found

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -291,7 +291,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
                     zf.layoutPage = readInt(header, 68, 4);
                     zf.mimeTypes = data;
                     // Initialize or reset the FileCache
-                    FileCache.reset();
+                    FileCache.init();
                     return zf;
                 });
             });

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -70,7 +70,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
     };
 
     /**
-     * Read a slice from the ZIM set starting at offset for size of bytes
+     * Read a slice from the FileCache or ZIM set, starting at offset for size of bytes
      * @param {Integer} offset The absolute offset from the start of the ZIM file or file set at which to start reading
      * @param {Integer} size The number of bytes to read
      * @returns {Promise<Uint8Array>} A Promise for a Uint8Array containing the requested data
@@ -105,7 +105,6 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
             return readRequests[0];
         } else {
             // Wait until all are resolved and concatenate.
-            console.log("CONCAT");
             return Q.all(readRequests).then(function (arrays) {
                 var concatenated = new Uint8Array(end - begin);
                 var offset = 0;

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -23,9 +23,8 @@
 define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 'filecache'], function(xz, zstd, util, utf8, Q, zimDirEntry, FileCache) {
 
     /**
-     * A variable to keep track of changes in the loaded ZIM archive
-     * The ID is temporary and is reset to zero at each session start
-     * It is incremented by 1 each time a new ZIM is loaded
+     * A variable to keep track of the currently loaded ZIM archive, e.g., for labelling cache entries
+     * The ID is temporary and is reset to 0 at each session start; it is incremented by 1 each time a new ZIM is loaded
      * @type {Integer} 
      */
     var tempFileId = 0;
@@ -46,15 +45,15 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
      * 
      * @typedef ZIMFile
      * @property {Array<File>} _files Array of ZIM files
-     * @property {String} name Abstract name of ZIM file set
-     * @property {Integer} articleCount total number of articles
-     * @property {Integer} clusterCount total number of clusters
-     * @property {Integer} urlPtrPos position of the directory pointerlist ordered by URL
-     * @property {Integer} titlePtrPos position of the directory pointerlist ordered by title
-     * @property {Integer} clusterPtrPos position of the cluster pointer list
-     * @property {Integer} mimeListPos position of the MIME type list (also header size)
-     * @property {Integer} mainPage main page or 0xffffffff if no main page
-     * @property {Integer} layoutPage layout page or 0xffffffffff if no layout page
+     * @property {Integer} id Arbitrary numeric ZIM id used to track the currently loaded archive
+     * @property {Integer} articleCount Total number of articles
+     * @property {Integer} clusterCount Total number of clusters
+     * @property {Integer} urlPtrPos Position of the directory pointerlist ordered by URL
+     * @property {Integer} titlePtrPos Position of the directory pointerlist ordered by title
+     * @property {Integer} clusterPtrPos Position of the cluster pointer list
+     * @property {Integer} mimeListPos Position of the MIME type list (also header size)
+     * @property {Integer} mainPage Main page or 0xffffffff if no main page
+     * @property {Integer} layoutPage Layout page or 0xffffffffff if no layout page
      */
     
     /**

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -22,6 +22,14 @@
 'use strict';
 define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 'filecache'], function(xz, zstd, util, utf8, Q, zimDirEntry, FileCache) {
 
+    /**
+     * A variable to keep track of changes in the loaded ZIM archive
+     * The ID is temporary and is reset to zero at each session start
+     * It is incremented by 1 each time a new ZIM is loaded
+     * @type {Integer} 
+     */
+    var tempFileId = 0;
+
     var readInt = function (data, offset, size) {
         var r = 0;
         for (var i = 0; i < size; i++) {
@@ -278,9 +286,8 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
                 var urlPtrPos = readInt(header, 32, 8);
                 return readMimetypeMap(fileArray[0], mimeListPos, urlPtrPos).then(function (data) {
                     var zf = new ZIMFile(fileArray);
-                    // Line below provides an abstracted filename in case the ZIM file is split into multiple parts;
-                    // it greatly simplifies coding of the block cache, as it can store and respond to offsets from the start of the file set
-                    zf.name = fileArray[0].name.replace(/(\.zim)\w\w$/i, '$1');
+                    // Line below provides a temporary, per-session numeric ZIM ID used in filecache.js
+                    zf.id = tempFileId++;
                     zf.articleCount = readInt(header, 24, 4);
                     zf.clusterCount = readInt(header, 28, 4);
                     zf.urlPtrPos = urlPtrPos;

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -262,7 +262,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
 
     return {
         /**
-         * @param {Array.<File>} fileArray An array of picked archive files
+         * @param {Array<File>} fileArray An array of picked archive files
          * @returns {Promise<Object>} A Promise for the ZimFile Object
          */
         fromFileArray: function (fileArray) {

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -43,7 +43,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
      * 
      * See https://wiki.openzim.org/wiki/ZIM_file_format#Header
      * 
-     * @typedef ZIMFile
+     * @typedef {Object} ZIMFile
      * @property {Array<File>} _files Array of ZIM files
      * @property {Integer} id Arbitrary numeric ZIM id used to track the currently loaded archive
      * @property {Integer} articleCount Total number of articles

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -290,6 +290,8 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
                     zf.mainPage = readInt(header, 64, 4);
                     zf.layoutPage = readInt(header, 68, 4);
                     zf.mimeTypes = data;
+                    // Initialize or reset the FileCache
+                    FileCache.reset();
                     return zf;
                 });
             });

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -126,7 +126,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
     };
 
     /**
-     * Read and parse a a Directory Entry at the given archive offset
+     * Read and parse a Directory Entry at the given archive offset
      * @param {Integer} offset The offset at which the DirEntry is located
      * @returns {Promise<DirEntry>} A Promise for the requested DirEntry
      */


### PR DESCRIPTION
As discussed in #595, this PR implements #619 and revives #183. It is almost entirely @peter-x's code. I have simply tuned the cache size based on my experience running this in KJSW, and have added a faster method of reading an arrayBuffer from the updated Blob API that elminates the need to use FileReader (for those browsers that support the new method).

Apart from Edge (Chromium), I have tested very quickly on Firefox OS simulator (working) and on IE11 (working).

I have left in a console log output that shows the block cache hits and misses, as well as the percentage hit rate. Below is from IE11 console log when running the full 96GB English Wikipedia and searching for "the second world war". You can clearly see here the number of file reads that are avoided and an impressive 100% hit rate for some 6,000 dirEntry reads, and above 74% for the initial 3,400 reads.

![image](https://user-images.githubusercontent.com/4304337/96335855-66fbe600-1073-11eb-8d1e-17b7655b926d.png)
