### PR TITLE
Exempt articleId assignment from Active Content Warning

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1227,12 +1227,11 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     var regexpTagsWithZimUrl = /(<(?:img|script|link|track)\b[^>]*?\s)(?:src|href)(\s*=\s*["'])(?:\.\.\/|\/)+(?=[-IJ]\/)/ig;
     // Regex below tests the html of an article for active content [kiwix-js #466]
     // It inspects every <script> block in the html and matches in the following cases: 1) the script loads a UI application called app.js;
-    // 2) the script block has inline content that does not contain "importScript()" or "toggleOpenSection" (these strings are used widely
-    // in our fully supported wikimedia ZIMs, so they are excluded); 3) the script block is not of type "math" (these are MathJax markup
-    // scripts used extensively in Stackexchange ZIMs). Note that the regex will match ReactJS <script type="text/html"> markup, which is
-    // common in unsupported packaged UIs, e.g. PhET ZIMs.
-    var regexpActiveContent = /<script\b(?:(?![^>]+src\b)|(?=[^>]+src\b=["'][^"']+?app\.js))(?!>[^<]+(?:importScript\(\)|toggleOpenSection))(?![^>]+type\s*=\s*["'](?:math\/|[^"']*?math))/i;
-    
+    // 2) the script block has inline content that does not contain "importScript()", "toggleOpenSection" or an "articleId" assignment
+    // (these strings are used widely in our fully supported wikimedia ZIMs, so they are excluded); 3) the script block is not of type "math" 
+    // (these are MathJax markup scripts used extensively in Stackexchange ZIMs). Note that the regex will match ReactJS <script type="text/html">
+    // markup, which is common in unsupported packaged UIs, e.g. PhET ZIMs.
+    var regexpActiveContent = /<script\b(?:(?![^>]+src\b)|(?=[^>]+src\b=["'][^"']+?app\.js))(?!>[^<]+(?:importScript\(\)|toggleOpenSection|articleId\s?=\s?['"]))(?![^>]+type\s*=\s*["'](?:math\/|[^"']*?math))/i;
     // DEV: The regex below matches ZIM links (anchor hrefs) that should have the html5 "donwnload" attribute added to 
     // the link. This is currently the case for epub and pdf files in Project Gutenberg ZIMs -- add any further types you need
     // to support to this regex. The "zip" has been added here as an example of how to support further filetypes


### PR DESCRIPTION
Fixes #667 for latest WikiMed ZIMs. The warning is triggered because a new inline script block has been added to the landing page that looks like this:

`<script>let articleId = 'Wikipedia:WikiProject_Medicine/Open_Textbook_of_Medicine2'</script>`

The fix is to add another exemption to our `regexpActiveContent`. The full amended regex is:

`var regexpActiveContent = /<script\b(?:(?![^>]+src\b)|(?=[^>]+src\b=["'][^"']+?app\.js))(?!>[^<]+(?:importScript\(\)|toggleOpenSection|articleId\s?=\s?['"]))(?![^>]+type\s*=\s*["'](?:math\/|[^"']*?math))/i;`

And the added code is: `|articleId\s?=\s?['"]`. This expands the negative lookahead so that any inline script that contains `articleId = '` will **not** match, and so will not trigger the Active Content Warning. I have made it as generic as possible (no spaces around the `=`, or different quotation style will also not match).

The Regex has been tested in RegexBuddy and the PR has been tested quickly on the new WikiMed ZIM. It works as intended.