### PR TITLE
tests: Remove redundant xzdec.js include

### DIFF
--- a/tests.html
+++ b/tests.html
@@ -31,7 +31,6 @@
              js files. This loads "main.js", which in turn can load other
              files, all handled by require.js:
              http://requirejs.org/docs/api.html#jsfiles -->
-        <script type="text/javascript" src="www/js/lib/xzdec.js"></script>
         <script type="text/javascript"
                 data-main="tests/init.js"
         src="www/js/lib/require.js"></script>


### PR DESCRIPTION
Follows-up 0c530101573cf95b, which removed this from www/index.html, but it was still present in the test suite.

This is now loaded automatically by RequireJS.

-------

/cc @Jaifroid per https://github.com/kiwix/kiwix-js/pull/672/files/20229d190570f25a1bbed0353881579a394be221#r528327775

-------

This supersedes the fork-PR at https://github.com/kiwix/kiwix-js/pull/675.