### PR TITLE
Extract images sequentially in jQuery mode

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1377,19 +1377,32 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         }
         
         function loadImagesJQuery() {
-            var images = iframeArticleContent.contentDocument.querySelectorAll('img[data-kiwixurl]');
-            Array.prototype.slice.call(images).forEach(function (image) {
+            // Make an array from the images that need to be processed
+            var images = Array.prototype.slice.call(iframeArticleContent.contentDocument.querySelectorAll('img[data-kiwixurl]'));
+            // DEV: This self-invoking function is recursive, calling itself only when an image has been fully processed into a
+            // blob: or data: URI (or returns an error). This ensures that images are processed sequentially from the top of the
+            // DOM, making for a better user experience (because images above the fold are extracted first)
+            (function extractImage() {
+                if (!images.length || images.busy) return;
+                images.busy = true;
+                // Extract the image at the top of the images array and remove it from the array
+                var image = images.shift();
                 var imageUrl = image.getAttribute('data-kiwixurl');
                 var title = decodeURIComponent(imageUrl);
                 selectedArchive.getDirEntryByTitle(title).then(function (dirEntry) {
                     selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
                         var mimetype = dirEntry.getMimetype();
-                        uiUtil.feedNodeWithBlob(image, 'src', content, mimetype);
+                        uiUtil.feedNodeWithBlob(image, 'src', content, mimetype, function() {
+                            images.busy = false;
+                            extractImage();
+                        });
                     });
                 }).catch(function (e) {
                     console.error("could not find DirEntry for image:" + title, e);
+                    images.busy = false;
+                    extractImage();
                 });
-            });
+            })();
         }
 
         function loadNoScriptTags() {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1395,7 +1395,6 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                     selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
                         var mimetype = dirEntry.getMimetype();
                         uiUtil.feedNodeWithBlob(image, 'src', content, mimetype, function() {
-                            console.log('Extracted image #' + images.length);
                             images.busy = false;
                             extractImage();
                         });

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -32,13 +32,7 @@ if (webpMachine) {
 }
 
 define(rqDef, function() {
-
-    /**
-     * A queue for WebP images to be decoded by the single-threaded WebpMachine
-     * @type Array
-     */
-    var webpQueue = [];
-    
+  
     /**
      * Creates either a blob: or data: URI from the given content
      * The given attribute of the DOM node (nodeAttribute) is then set to this URI

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -40,41 +40,38 @@ define(rqDef, function() {
     var webpQueue = [];
     
     /**
-     * Creates a BLOB from the given content, then a blob: or data: URI from this BLOB
+     * Creates either a blob: or data: URI from the given content
      * The given attribute of the DOM node (nodeAttribute) is then set to this URI
      * 
-     * This is useful to inject images (and other dependencies) inside an article
+     * This is used to inject images (and other dependencies) into the article DOM
      * 
-     * @param {Object} node The node to which the BLOB data should be added
-     * @param {String} nodeAttribute The attribute to set to the BLOB URI
-     * @param {Uint8Array} content The binary content to convert to a BLOB URI
+     * @param {Object} node The node to which the URI should be added
+     * @param {String} nodeAttribute The attribute to set to the URI
+     * @param {Uint8Array} content The binary content to convert to a URI
      * @param {String} mimeType The MIME type of the content
+     * @param {Function} callback An optional function to call with the URI
      */
-    function feedNodeWithBlob(node, nodeAttribute, content, mimeType) {
+    function feedNodeWithBlob(node, nodeAttribute, content, mimeType, callback) {
         // Decode WebP data if the browser does not support WebP and the mimeType is webp
         if (webpMachine && /image\/webp/i.test(mimeType)) {
-            // Queue WebP images to be decoded (the WebP polyfill is single-threaded and will reject a job if it is busy)
-            webpQueue.push({ 'node': node, 'nodeAttribute': nodeAttribute, 'content': content });
-            (function decodeImage() {
-                if (!webpQueue.length || webpQueue.busy) return;
-                webpQueue.busy = true;
-                var img = webpQueue.shift();
-                webpMachine.decode(img.content).then(function (url) {
-                    // DEV: WebpMachine.decode() returns a Data URI
-                    img.node.setAttribute(img.nodeAttribute, url);
-                    webpQueue.busy = false;
-                    decodeImage();
-                }).catch(function (err) {
-                    console.error('There was an error decoding image in WebpMachine', err);
-                    webpQueue.busy = false;
-                    decodeImage();
-                });
-            })();
+            // DEV: Note that webpMachine is single threaded and will reject an image if it is busy
+            // However, the loadImagesJQuery() function in app.js is sequential (it waits for a callback
+            // before processing another image) so we do not need to queue WebP images here
+            webpMachine.decode(content).then(function (uri) {
+                // DEV: WebpMachine.decode() returns a data: URI
+                // We callback before the node is set so that we don't incur slow DOM rewrites before processing more images
+                if (callback) callback(uri);
+                node.setAttribute(nodeAttribute, uri);
+            }).catch(function (err) {
+                console.error('There was an error decoding image in WebpMachine', err);
+                if (callback) callback();
+            });
         } else {
             var blob = new Blob([content], {
                 type: mimeType
             });
             var url = URL.createObjectURL(blob);
+            if (callback) callback(url);
             node.addEventListener('load', function () {
                 URL.revokeObjectURL(url);
             });


### PR DESCRIPTION
This implements #671 and #505 in jQuery mode. I have removed the WebP image queue from `uiUtil.js` and have transferred the same self-invoking recursive function to the `loadImagesJQuery()` function in `app.js`.

This greatly improves UX on long articles with lots of images, since it ensures that images are loaded from the top of the page, sequentially. The images extracted first are those in the visible area ("above the fold").

Additionally, this PR partially implements #426 for jQuery mode image assets, cancelling extraciton of images if a user navigates away from the page. This is a side-effect of a need to avoid an error if the `images` array is not redefined cleanly. Cancellation does not occur at a very low level, but is still relatively effective (tested with a console log, removed in the latest commit).

I have also implemented a callback (necessary for this PR) which will help in implementing #674 once #672 is complete.




