### PR TITLE
Send article to new tab in jQuery mode

### DIFF
--- a/browser-tests/nightwatch_runner.js
+++ b/browser-tests/nightwatch_runner.js
@@ -107,6 +107,8 @@ module.exports = {
             .frame('articleContent')
             // Check the text in the article "Ray Charles"
             .useXpath()
+            // Let's pause for a second
+            .pause(1000)
             .waitForElementPresent("//div[@id='content']/div[@id='mw-content-text']/h2[@id='mweQ']", 40000)
             .assert.containsText("//div[@id='content']/div[@id='mw-content-text']/h2[@id='mweQ']", 'Life and career')
             // Wait for a particular image to be visible and check its size

--- a/browser-tests/nightwatch_runner.js
+++ b/browser-tests/nightwatch_runner.js
@@ -74,9 +74,9 @@ module.exports = {
         browser.click("//div[@id='articleList']/a[text()='Ray Charles']")
             .frame('articleContent')
             // Check the text in the article "Ray Charles"
-            .useXpath()
-            .waitForElementPresent("//div[@id='content']/div[@id='mw-content-text']/h2[@id='mweQ']", 40000)
-            .assert.containsText("//div[@id='content']/div[@id='mw-content-text']/h2[@id='mweQ']", 'Life and career')
+            // .useXpath()
+            // .waitForElementPresent("//div[@id='content']/div[@id='mw-content-text']/h2[@id='mweQ']", 40000)
+            // .assert.containsText("//div[@id='content']/div[@id='mw-content-text']/h2[@id='mweQ']", 'Life and career')
             // Wait for a particular image to be visible and check its size
             .useXpath()
             .waitForElementVisible("//td[@id='mwCA']/p/span/img", 20000)

--- a/browser-tests/nightwatch_runner.js
+++ b/browser-tests/nightwatch_runner.js
@@ -74,9 +74,9 @@ module.exports = {
         browser.click("//div[@id='articleList']/a[text()='Ray Charles']")
             .frame('articleContent')
             // Check the text in the article "Ray Charles"
-            // .useXpath()
-            // .waitForElementPresent("//div[@id='content']/div[@id='mw-content-text']/h2[@id='mweQ']", 40000)
-            // .assert.containsText("//div[@id='content']/div[@id='mw-content-text']/h2[@id='mweQ']", 'Life and career')
+            .useXpath()
+            .waitForElementPresent("//div[@id='content']/div[@id='mw-content-text']/h2[@id='mweQ']", 20000)
+            .assert.containsText("//div[@id='content']/div[@id='mw-content-text']/h2[@id='mweQ']", 'Life and career')
             // Wait for a particular image to be visible and check its size
             .useXpath()
             .waitForElementVisible("//td[@id='mwCA']/p/span/img", 20000)

--- a/nightwatch.js
+++ b/nightwatch.js
@@ -43,7 +43,13 @@ module.exports = {
         "enabled" : false
       },
       "globals": {
-        "waitForConditionTimeout": 600
+        "waitForConditionTimeout": 10000
+      },
+      // Configure when a request to the Selenium server should time out and optionally define the number of retries for a timed-out request
+      // See https://github.com/nightwatchjs/nightwatch/issues/1936
+      "request_timeout_options": {
+        "timeout": 100000,
+        "retry_attempts": 3
       }
     },
     "firefox45" : {
@@ -60,7 +66,8 @@ module.exports = {
         "browserName": "firefox",
         "javascriptEnabled": true,
         "acceptSslCerts": true,
-        "build": build
+        "build": build,
+        "extendedDebugging": true
       }
     },
     "chrome58" : {

--- a/www/article.html
+++ b/www/article.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <title>Placeholder for injecting an article into the iframe</title>
+        <meta name="description" content="Placeholder for injecting an article into the iframe or window">
     </head>
     <body></body>
 </html>

--- a/www/css/kiwixJS_invert.css
+++ b/www/css/kiwixJS_invert.css
@@ -26,6 +26,7 @@
  * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
  */
 
+html._invert,
 img,
 video {
     filter: invert(1) hue-rotate(180deg);

--- a/www/css/kiwixJS_mwInvert.css
+++ b/www/css/kiwixJS_mwInvert.css
@@ -29,6 +29,7 @@
  * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
  */
 
+html._mwInvert,
 img:not([class|="mwe-math-fallback-image"]),
 video {
     filter: invert(1) hue-rotate(180deg);

--- a/www/index.html
+++ b/www/index.html
@@ -404,6 +404,13 @@
                             <div class="card-body">
                                 <div class="checkbox">
                                     <label>
+                                        <input type="checkbox" name="rightClickOpensTab" id="rightClickOpensTabCheck">
+                                        <strong>Right-click / long-press opens links in new tab</strong>
+                                        <span class="form-text text-muted">You can always use Ctrl-click or middle-click instead. Only affects jQuery mode: handled natively in Service Worker mode.</span>
+                                    </label>
+                                </div>
+                                <div class="checkbox">
+                                    <label>
                                         <input type="checkbox" name="hideActiveContentWarning"
                                             id="hideActiveContentWarningCheck">
                                         <strong>Permanently hide active content warning</strong> (for

--- a/www/index.html
+++ b/www/index.html
@@ -569,7 +569,7 @@
                     </div>
                 </div>
                 <div id="pagePreview" style="padding: 0 50px;"></div>
-                <iframe id="articleContent" class="articleIFrame" src="article.html"></iframe>
+                <iframe id="articleContent" class="articleIFrame" src=""></iframe>
             </article>
             <footer>
                 <!-- Bootstrap alert box -->

--- a/www/index.html
+++ b/www/index.html
@@ -405,7 +405,7 @@
                                 <div class="checkbox" title="Tap three times for tab | window | off">
                                     <label>
                                         <input type="checkbox" name="windowOpener" id="windowOpenerCheck">
-                                        <strong>Open archive links in new [ <span id="windowOpenerState"></span> ]</strong>
+                                        <strong>Open archive links in new [ <span id="windowOpenerState"></span> ]</strong> <i><span id="tapHint"></span></i>
                                         <span id="windowOpenerHelp" class="form-text" hidden></span>
                                     </label>
                                 </div>

--- a/www/index.html
+++ b/www/index.html
@@ -402,11 +402,11 @@
                         <div class="card card-info" id="displaySettingsDiv">
                             <div class="card-header">Display options:</div>
                             <div class="card-body">
-                                <div class="checkbox">
+                                <div class="checkbox" title="Tap three times for tab | window | off">
                                     <label>
-                                        <input type="checkbox" name="rightClickOpensTab" id="rightClickOpensTabCheck">
-                                        <strong>Right-click / long-press opens links in new tab</strong>
-                                        <span class="form-text text-muted">You can always use Ctrl-click or middle-click instead. Only affects jQuery mode: handled natively in Service Worker mode.</span>
+                                        <input type="checkbox" name="windowOpener" id="windowOpenerCheck">
+                                        <strong>Open archive links in new [ <span id="windowOpenerState">tab</span> ]</strong>
+                                        <span id="windowOpenerHelp" class="form-text" hidden>Regardless of this option, you can always use Ctrl-click or middle-click instead.</span>
                                     </label>
                                 </div>
                                 <div class="checkbox">

--- a/www/index.html
+++ b/www/index.html
@@ -569,7 +569,7 @@
                     </div>
                 </div>
                 <div id="pagePreview" style="padding: 0 50px;"></div>
-                <iframe id="articleContent" class="articleIFrame" src=""></iframe>
+                <iframe id="articleContent" class="articleIFrame" src="article.html"></iframe>
             </article>
             <footer>
                 <!-- Bootstrap alert box -->

--- a/www/index.html
+++ b/www/index.html
@@ -402,13 +402,19 @@
                         <div class="card card-info" id="displaySettingsDiv">
                             <div class="card-header">Display options:</div>
                             <div class="card-body">
-                                <div class="checkbox" title="Tap three times for tab | window | off">
+                                <div class="checkbox" id="openInNewTab" title="Open article in new tab">
                                     <label>
-                                        <input type="checkbox" name="windowOpener" id="windowOpenerCheck">
-                                        <strong>Open archive links in new [ <span id="windowOpenerState"></span> ]</strong> <i><span id="tapHint"></span></i>
-                                        <span id="windowOpenerHelp" class="form-text" hidden></span>
+                                        <input type="checkbox" name="tabOpener" id="tabOpenerCheck">
+                                        <strong>Open ZIM links in new tab</strong> with right-click, ctrl-click, middle-click or long-press
                                     </label>
                                 </div>
+                                <div class="checkbox" id="openInNewWindow" hidden title="Open article in new window">
+                                    <label>
+                                        <input type="checkbox" name="windowOpener" id="winOpenerCheck">
+                                        <strong>Open in new window instead</strong>
+                                    </label>
+                                </div>
+                                <div id="winOpenerHelp" style="padding-bottom:1em;"></div>
                                 <div class="checkbox">
                                     <label>
                                         <input type="checkbox" name="hideActiveContentWarning"

--- a/www/index.html
+++ b/www/index.html
@@ -554,6 +554,10 @@
                     <div id="articleList" class="list-group">
                     </div>
                 </div>
+                <div id="systemAlert" style="display:none; margin: 0 50px;" class="alert alert-danger alert-dismissible fade show">
+                    <button type="button" class="close" data-hide="alert">&times;</button>
+                    <div id="alertContent"></div>
+                </div>
                 <!-- Bootstrap alert box -->
                 <div id="alertBoxHeader">
                     <div id="activeContent" style="display:none;" class="alert alert-warning alert-dismissible fade show">
@@ -564,6 +568,7 @@
                         if your platform supports it. &nbsp;[<a id="stop" href="#displaySettingsDiv" class="alert-link">Permanently hide</a>]
                     </div>
                 </div>
+                <div id="pagePreview" style="padding: 0 50px;"></div>
                 <iframe id="articleContent" class="articleIFrame" src="article.html"></iframe>
             </article>
             <footer>

--- a/www/index.html
+++ b/www/index.html
@@ -405,8 +405,8 @@
                                 <div class="checkbox" title="Tap three times for tab | window | off">
                                     <label>
                                         <input type="checkbox" name="windowOpener" id="windowOpenerCheck">
-                                        <strong>Open archive links in new [ <span id="windowOpenerState">tab</span> ]</strong>
-                                        <span id="windowOpenerHelp" class="form-text" hidden>Regardless of this option, you can always use Ctrl-click or middle-click instead.</span>
+                                        <strong>Open archive links in new [ <span id="windowOpenerState"></span> ]</strong>
+                                        <span id="windowOpenerHelp" class="form-text" hidden></span>
                                     </label>
                                 </div>
                                 <div class="checkbox">

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -386,6 +386,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 woHelp.innerHTML = params.windowOpener === 'tab' ?
                     'Use right-click / long-press / ctrl-click / middle-click. <i>May not work in mobile contexts.</i>' : 
                     'Use right-click / long-press. You may need to turn off popup blocking. <i>May not work in mobile contexts.</i>';
+                document.getElementById('tapHint').innerHTML = params.windowOpener === 'tab' ? '-> tap again for window mode' : '';
             }
         } else {
             woState.innerHTML = 'tab / window';

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1535,7 +1535,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 }
             });
             // Add event listeners to the main document so user can open current document in new tab or window
-            addListenersToLink(articleDocument, encodeURIComponent(dirEntry.url.replace(/[^/]+\//g, '')));
+            if (articleWindow.document.body) addListenersToLink(articleWindow.document.body, encodeURIComponent(dirEntry.url.replace(/[^/]+\//g, '')));
         }
 
         /**
@@ -1591,7 +1591,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             });
             // This detects the middle-click event
             a.addEventListener('mousedown', function (e) {
+                if (!params.windowOpener || a.launched) return; // Prevent double activations
                 if (e.which === 2 || e.button === 4) {
+                    e.stopPropagation();
                     e.preventDefault();
                     a.launched = true;
                     a.click();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1408,23 +1408,20 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             $('#articleListWithHeader').hide();
             $("#prefix").val("");
             if (appstate.target === 'iframe' && !articleContainer.contentDocument && window.location.protocol === 'file:') {
-                uiUtil.systemAlert("<p>You seem to be opening kiwix-js with the file:// protocol, which is blocked by your browser for security reasons.</p>"
-                    + "<p>The easiest way to run it is to download and run it as a browser extension (from the vendor store). "
-                    + "Alternatively, you can open it through a web server: either use a local one (http://localhost/...) "
-                    + "or a remote one. For example, you can try you ZIM out right now with our online version: "
-                    + "<a href='https://kiwix.github.io/kiwix-js/'>https://kiwix.github.io/kiwix-js/</a>.</p>"
-                    + "<p>Another option is to force your browser to accept file access (a potential security breach): "
-                    + "on Chrome, you can start it with <code>--allow-file-access-from-files</code> command-line argument; on Firefox, "
-                    + "you can set <code>privacy.file_unique_origin</code> to <code>false</code> in about:config.</p>"
-                    + "<p>If available, below is a basic unstyled preview of the article you were looking for.</p>");
-                var preview = htmlArticle.match(/<(body)[^>]*>((?:[^<]|<(?!\/\1))+)<\/\1>/);
-                preview = preview ? preview[2] : "<strong>No preview was available</strong>";
-                articleDocument = document.getElementById('pagePreview');
-                articleDocument.innerHTML = preview;
-                parseAnchorsJQuery();
-                loadImagesJQuery();
-                $('#searchingArticles').hide();
-                return;
+                uiUtil.systemAlert("<p>You seem to be opening kiwix-js with the file:// protocol, which blocks access to the app's iframe. "
+                + "We have tried to open your article in a separate window. You may be able to use it with limited functionality.</p>"
+                + "<p>The easiest way to run this app fully is to download and run it as a browser extension (from the vendor store). "
+                + "Alternatively, you can open it through a web server: either use a local one (http://localhost/...) "
+                + "or a remote one. For example, you can try you ZIM out right now with our online version of the app: "
+                + "<a href='https://kiwix.github.io/kiwix-js/'>https://kiwix.github.io/kiwix-js/</a>.</p>"
+                + "<p>Another option is to force your browser to accept file access (a potential security breach): "
+                + "on Chrome, you can start it with the <code>--allow-file-access-from-files</code> command-line argument; on Firefox, "
+                + "you can set <code>privacy.file_unique_origin</code> to <code>false</code> in about:config.</p>";
+                articleContainer = window.open('', dirEntry.title, 'toolbar=0,location=0,menubar=0,width=800,height=600,resizable=1,scrollbars=1');
+                params.windowOpener = 'window';
+                appstate.target = 'window';
+                articleContainer.kiwixType = appstate.target;
+                articleWindow = articleContainer;
             }
             
             // Ensure the window target is permanently stored as a property of the articleWindow (since appstate.target can change)
@@ -1489,7 +1486,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             // history manipulation, we'll know where to place the iframe contentWindow
             window.kiwixType = appstate.target;
             articleContainer.onload = windowLoaded;
-            articleContainer.src = '';
+            articleContainer.src = 'article.html';
         } else {
             // Attempt to establish an independent history record for windows
             articleWindow.onpopstate = historyPop;
@@ -1500,8 +1497,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         }
         
         function parseAnchorsJQuery() {
-            var currentProtocol = location.protocol;
-            var currentHost = location.host;
+            var currentProtocol = articleWindow.location.protocol;
+            currentProtocol === 'about:' ? currentProtocol = ':' : currentProtocol;
+            var currentHost = articleWindow.location.host;
             // Percent-encode dirEntry.url and add regex escape character \ to the RegExp special characters - see https://www.regular-expressions.info/characters.html;
             // NB dirEntry.url can also contain path separator / in some ZIMs (Stackexchange). } and ] do not need to be escaped as they have no meaning on their own. 
             var escapedUrl = encodeURIComponent(dirEntry.url).replace(/([\\$^.|?*+/()[{])/g, '\\$1');

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1412,11 +1412,11 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 + "We have tried to open your article in a separate window. You may be able to use it with limited functionality.</p>"
                 + "<p>The easiest way to run this app fully is to download and run it as a browser extension (from the vendor store). "
                 + "Alternatively, you can open it through a web server: either use a local one (http://localhost/...) "
-                + "or a remote one. For example, you can try you ZIM out right now with our online version of the app: "
+                + "or a remote one. For example, you can try your ZIM out right now with our online version of the app: "
                 + "<a href='https://kiwix.github.io/kiwix-js/'>https://kiwix.github.io/kiwix-js/</a>.</p>"
                 + "<p>Another option is to force your browser to accept file access (a potential security breach): "
                 + "on Chrome, you can start it with the <code>--allow-file-access-from-files</code> command-line argument; on Firefox, "
-                + "you can set <code>privacy.file_unique_origin</code> to <code>false</code> in about:config.</p>";
+                + "you can set <code>privacy.file_unique_origin</code> to <code>false</code> in about:config.</p>");
                 articleContainer = window.open('', dirEntry.title, 'toolbar=0,location=0,menubar=0,width=800,height=600,resizable=1,scrollbars=1');
                 params.windowOpener = 'window';
                 appstate.target = 'window';

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1408,10 +1408,19 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             $('#articleListWithHeader').hide();
             $("#prefix").val("");
             if (appstate.target === 'iframe' && !articleContainer.contentDocument && window.location.protocol === 'file:') {
-                alert("You seem to be opening kiwix-js with the file:// protocol, which is blocked by your browser for security reasons."
-                        + "\nThe easiest way to run it is to download and run it as a browser extension (from the vendor store)."
-                        + "\nElse you can open it through a web server : either through a local one (http://localhost/...) or through a remote one (but you need SSL : https://webserver/...)"
-                        + "\nAnother option is to force your browser to accept that (but you'll open a security breach) : on Chrome, you can start it with --allow-file-access-from-files command-line argument; on Firefox, you can set privacy.file_unique_origin to false in about:config");
+                uiUtil.systemAlert("<p>You seem to be opening kiwix-js with the file:// protocol, which is blocked by your browser for security reasons.</p>"
+                    + "<p>The easiest way to run it is to download and run it as a browser extension (from the vendor store). "
+                    + "Alternatively, you can open it through a web server: either use a local one (http://localhost/...) "
+                    + "or a remote one. For example, you can try you ZIM out rihgt now with our online version: "
+                    + "<a href='https://kiwix.github.io/kiwix-js/'>https://kiwix.github.io/kiwix-js/</a>.</p>"
+                    + "<p>Another option is to force your browser to accept file access (a potential security breach): "
+                    + "on Chrome, you can start it with <code>--allow-file-access-from-files</code> command-line argument; on Firefox, "
+                    + "you can set <code>privacy.file_unique_origin</code> to <code>false</code> in about:config.</p>"
+                    + "<p>If available, below is a preview of the landing page of your ZIM file without images.");
+                var preview = htmlArticle.match(/<(body)[^>]*>((?:[^<]|<(?!\/\1))+)<\/\1>/);
+                preview = preview ? preview[2] : "<strong>No preview was available</strong>";
+                if (preview) document.getElementById('pagePreview').innerHTML = preview;
+                $('#searchingArticles').hide();
                 return;
             }
             

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -382,11 +382,12 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             woState.innerHTML = params.windowOpener;
             woHelp.hidden = false;
             if (contentInjectionMode === 'serviceworker') {
-                woHelp.innerHTML = 'This setting has no effect in ServiceWorker mode because opening new tabs or windows (if supported by the context) is handled natively. Turn this setting off to hide this message.';
+                woHelp.innerHTML = 'This setting has no effect in ServiceWorker mode because opening new tabs or windows (if supported by the context) ' +
+                    'is handled natively with right-clcik or ctrl-click. Turn this setting off to hide this message.';
             } else {
                 woHelp.innerHTML = params.windowOpener === 'tab' ?
-                    'Regardless of this option, you can always use Ctrl-click or middle-click instead. <i>May not work in mobile contexts.</i>' : 
-                    'You may need to turn off popup blocking. Ctrl-click still opens tab in some browsers. <i>May not work in mobile contexts.</i>';
+                    'Use right-click / long-press / ctrl-click / middle-click. <i>May not work in mobile contexts.</i>' : 
+                    'Use right-click / long-press. You may need to turn off popup blocking. <i>May not work in mobile contexts.</i>';
             }
         } else {
             woState.innerHTML = 'tab / window';
@@ -402,7 +403,11 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     document.getElementById('appThemeSelect').addEventListener('change', function (e) {
         params.appTheme = e.target.value;
         settingsStore.setItem('appTheme', params.appTheme, Infinity);
-        uiUtil.applyAppTheme(params.appTheme, articleContainer);
+        uiUtil.applyAppTheme(params.appTheme, document.getElementById('articleContent'));
+        if (appstate.target === 'window') {
+            // We also need to remove old styles from the open window/tab
+            uiUtil.applyAppTheme(params.appTheme, articleContainer);
+        }
     });
     document.getElementById('cachedAssetsModeRadioTrue').addEventListener('change', function (e) {
         if (e.target.checked) {
@@ -1571,7 +1576,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 articleWindow = thisWindow;
                 articleContainer = thisContainer;
                 // This detects Ctrl-click, Command-click, the long-press event, and middle-click
-                if (e.ctrlKey || e.metaKey || touched || e.which === 2 || e.button === 4) {
+                if ((e.ctrlKey || e.metaKey || touched || e.which === 2 || e.button === 4) && params.windowOpener) {
                     // We open the new window immediately so that it is a direct result of user action (click)
                     // and we'll populate it later - this avoids most popup blockers
                     articleWindow = window.open('article.html', params.windowOpener === 'tab' ? '_blank' : a.title,

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1637,6 +1637,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             a.addEventListener('touchend', function () {
                 a.touched = false;
                 a.newcontainer = false;
+                loadingContainer = false;
             });
             // This detects right-click in all browsers (only if the option is enabled)
             a.addEventListener('contextmenu', function (e) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1411,15 +1411,18 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 uiUtil.systemAlert("<p>You seem to be opening kiwix-js with the file:// protocol, which is blocked by your browser for security reasons.</p>"
                     + "<p>The easiest way to run it is to download and run it as a browser extension (from the vendor store). "
                     + "Alternatively, you can open it through a web server: either use a local one (http://localhost/...) "
-                    + "or a remote one. For example, you can try you ZIM out rihgt now with our online version: "
+                    + "or a remote one. For example, you can try you ZIM out right now with our online version: "
                     + "<a href='https://kiwix.github.io/kiwix-js/'>https://kiwix.github.io/kiwix-js/</a>.</p>"
                     + "<p>Another option is to force your browser to accept file access (a potential security breach): "
                     + "on Chrome, you can start it with <code>--allow-file-access-from-files</code> command-line argument; on Firefox, "
                     + "you can set <code>privacy.file_unique_origin</code> to <code>false</code> in about:config.</p>"
-                    + "<p>If available, below is a preview of the landing page of your ZIM file without images.");
+                    + "<p>If available, below is a basic unstyled preview of the article you were looking for.</p>");
                 var preview = htmlArticle.match(/<(body)[^>]*>((?:[^<]|<(?!\/\1))+)<\/\1>/);
                 preview = preview ? preview[2] : "<strong>No preview was available</strong>";
-                if (preview) document.getElementById('pagePreview').innerHTML = preview;
+                articleDocument = document.getElementById('pagePreview');
+                articleDocument.innerHTML = preview;
+                parseAnchorsJQuery();
+                loadImagesJQuery();
                 $('#searchingArticles').hide();
                 return;
             }
@@ -1486,7 +1489,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             // history manipulation, we'll know where to place the iframe contentWindow
             window.kiwixType = appstate.target;
             articleContainer.onload = windowLoaded;
-            articleContainer.src = 'article.html';
+            articleContainer.src = '';
         } else {
             // Attempt to establish an independent history record for windows
             articleWindow.onpopstate = historyPop;
@@ -1600,7 +1603,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 if ((e.ctrlKey || e.metaKey || touched || e.which === 2 || e.button === 4) && params.windowOpener) {
                     // We open the new window immediately so that it is a direct result of user action (click)
                     // and we'll populate it later - this avoids most popup blockers
-                    articleContainer = window.open('article.html', params.windowOpener === 'tab' ? '_blank' : a.title,
+                    articleContainer = window.open('', params.windowOpener === 'tab' ? '_blank' : a.title,
                         params.windowOpener === 'window' ? 'toolbar=0,location=0,menubar=0,width=800,height=600,resizable=1,scrollbars=1' : null);
                     appstate.target = 'window';
                     articleContainer.kiwixType = appstate.target;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1624,6 +1624,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 if ((e.ctrlKey || e.metaKey || a.launched || e.which === 2 || e.button === 4) && params.windowOpener) {
                     // We open the new window immediately so that it is a direct result of user action (click)
                     // and we'll populate it later - this avoids most popup blockers
+                    loadingContainer = true;
                     articleContainer = window.open('article.html', params.windowOpener === 'tab' ? '_blank' : a.title,
                         params.windowOpener === 'window' ? 'toolbar=0,location=0,menubar=0,width=800,height=600,resizable=1,scrollbars=1' : null);
                     appstate.target = 'window';

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1547,7 +1547,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 }
             });
             // Add event listeners to the main document so user can open current document in new tab or window
-            // if (articleWindow.document.body) addListenersToLink(articleWindow.document.body, encodeURIComponent(dirEntry.url.replace(/[^/]+\//g, '')));
+            if (articleWindow.document.body) addListenersToLink(articleWindow.document.body, encodeURIComponent(dirEntry.url.replace(/[^/]+\//g, '')));
         }
 
         /**
@@ -1579,60 +1579,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             var kiwixTarget = appstate.target;
             var thisWindow = articleWindow;
             var thisContainer = articleContainer;
-            a.addEventListener('touchstart', function (e) {
-                if (!params.windowOpener || a.touched) return;
-                e.stopPropagation();
-                a.touched = true;
-                // The link will be clicked if the user long-presses for more than 600ms (if the option is enabled)
-                setTimeout(function () {
-                    if (!a.touched || a.launched) return;
-                    a.launched = true;
-                    a.click();
-                }, 600);
-            });
-            a.addEventListener('touchend', function () {
-                a.touched = false;
-                a.launched = false;
-            });
-            // This detects right-click in all browsers (only if the option is enabled)
-            a.addEventListener('contextmenu', function (e) {
-                console.log('contextmenu');
-                if (!params.windowOpener || a.launched) return;
-                e.preventDefault();
-                e.stopPropagation();
-                a.launched = true;
-                a.click();
-            });
-            // This traps the middle-click event before tha auxclick event fires
-            a.addEventListener('mousedown', function (e) {
-                console.log('mosuedown');
-                if (!params.windowOpener) return;
-                e.preventDefault();
-                e.stopPropagation();
-                if (a.launched) return; // Prevent double activations
-                if (e.ctrlKey || e.metaKey || e.which === 2 || e.button === 4) {
-                    a.launched = true;
-                    a.click();
-                } else {
-                    console.log('suppressed mousedown');
-                }
-            });
-            // This detects the middle-click event that opens a new tab in recent Firefox and Chrome
-            // See https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event
-            a.addEventListener('auxclick', function (e) {
-                console.log('auxclick');
-                if (!params.windowOpener) return;
-                e.preventDefault();
-                e.stopPropagation();
-            });
-            // The main click routine (called by other events above as well)
-            a.addEventListener('click', function (e) {
-                console.log('Click event', e);
-                // Prevent opening multiple windows
-                if (a.touched && !a.launched || loadingContainer) {
-                    e.preventDefault();
-                    return;
-                }
+            
+            var onDetectedClick = function (e) {
                 // Restore original values for this window/tab
                 appstate.target = kiwixTarget;
                 articleWindow = thisWindow;
@@ -1662,6 +1610,64 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                     a.launched = false;
                     loadingContainer = false;
                 }, 1400);
+            };
+            
+            a.addEventListener('touchstart', function (e) {
+                if (!params.windowOpener || a.touched) return;
+                e.stopPropagation();
+                a.touched = true;
+                // The link will be clicked if the user long-presses for more than 600ms (if the option is enabled)
+                setTimeout(function () {
+                    if (!a.touched || a.launched) return;
+                    a.launched = true;
+                    onDetectedClick(e);
+                }, 600);
+            });
+            a.addEventListener('touchend', function () {
+                a.touched = false;
+                a.launched = false;
+            });
+            // This detects right-click in all browsers (only if the option is enabled)
+            a.addEventListener('contextmenu', function (e) {
+                console.log('contextmenu');
+                if (!params.windowOpener || a.launched) return;
+                e.preventDefault();
+                e.stopPropagation();
+                a.launched = true;
+                onDetectedClick(e);
+            });
+            // This traps the middle-click event before tha auxclick event fires
+            a.addEventListener('mousedown', function (e) {
+                console.log('mosuedown');
+                if (!params.windowOpener) return;
+                e.preventDefault();
+                e.stopPropagation();
+                if (a.launched) return; // Prevent double activations
+                if (e.ctrlKey || e.metaKey || e.which === 2 || e.button === 4) {
+                    a.launched = true;
+                    onDetectedClick(e);
+                } else {
+                    console.log('suppressed mousedown');
+                }
+            });
+            // This detects the middle-click event that opens a new tab in recent Firefox and Chrome
+            // See https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event
+            a.addEventListener('auxclick', function (e) {
+                console.log('auxclick');
+                if (!params.windowOpener) return;
+                e.preventDefault();
+                e.stopPropagation();
+            });
+            // The main click routine (called by other events above as well)
+            a.addEventListener('click', function (e) {
+                console.log('Click event', e);
+                // Prevent opening multiple windows
+                if (a.touched && !a.launched || loadingContainer) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                } else {
+                    onDetectedClick(e);
+                }
             });
         }
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1546,6 +1546,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
          */
         function addListenersToLink(a, href) {
             var uriComponent = uiUtil.removeUrlParameters(href);
+            var loadingContainer = false;
             var contentType;
             var downloadAttrValue;
             // Some file types need to be downloaded rather than displayed (e.g. *.epub)
@@ -1583,7 +1584,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             });
             // This detects right-click in all browsers (only if the option is enabled)
             a.addEventListener('contextmenu', function (e) {
-                if (!params.windowOpener) return;
+                if (!params.windowOpener || a.launched) return;
                 e.preventDefault();
                 e.stopPropagation();
                 a.launched = true;
@@ -1602,7 +1603,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             // The main click routine (called by other events above as well)
             a.addEventListener('click', function (e) {
                 // Prevent opening multiple windows
-                if (a.touched && !a.launched) return;
+                if (a.touched && !a.launched || loadingContainer) return;
                 // Restore original values for this window/tab
                 appstate.target = kiwixTarget;
                 articleWindow = thisWindow;
@@ -1629,6 +1630,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                     // By delaying unblocking of the touch event, we prevent multiple touch events launching the same window
                     a.touched = false;
                     a.launched = false;
+                    loadingContainer = false;
                 }, 1400);
             });
         }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1435,6 +1435,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             loadNoScriptTags();
             //loadJavaScriptJQuery();
             insertMediaBlobsJQuery();
+            // Scroll to top
+            articleWindow.scrollTo(0,0);
 
             if (articleWindow.kiwixType === 'iframe') {
                 // Configure home key press to focus #prefix only if the feature is in active state

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1476,6 +1476,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             });
         // Load the dummy article if not already loaded in new window
         if (appstate.target === 'iframe') {
+            // Store the frame article's target in the top-level window, because so that when we retrieve the window with
+            // history back, we'll know where to place the iframe contentWindow
+            window.kiwixType = appstate.target;
             articleContainer.onload = windowLoaded;
             articleContainer.src = 'article.html';
         } else {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1361,7 +1361,6 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         var windowLoaded = function() {
             if (loaded) return;
             loaded = true;
-            articleDocument = articleWindow.document.documentElement;
             
             $("#articleList").empty();
             $('#articleListHeaderMessage').empty();
@@ -1375,7 +1374,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                         + "\nAnother option is to force your browser to accept that (but you'll open a security breach) : on Chrome, you can start it with --allow-file-access-from-files command-line argument; on Firefox, you can set privacy.file_unique_origin to false in about:config");
                 return;
             }
-            
+
             if (articleWindow.kiwixType === 'iframe') {
                 var docBody = articleDocument.querySelector('body');
                 if (docBody) {
@@ -1431,16 +1430,20 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         // during the document.write() process; and since the latter is synchronous, we get slow display rewrites before it is
         // effective if we do it after document.close().
         htmlArticle = htmlArticle.replace(/(<html\b[^>]*)>/i, '$1 hidden>');
+
         // Write article html to the article container
-        articleWindow.document.open('text/html', 'replace');
-        articleWindow.document.write(htmlArticle);
-        articleWindow.document.close();
+        // articleWindow.document.open('text/html', 'replace');
+        // articleWindow.document.write(htmlArticle);
+        // articleWindow.document.close();
+        articleDocument = articleWindow.document.documentElement;
+        articleDocument.innerHTML = htmlArticle;
+
         // Storing the window type at top level window helps us with history manipulation
         window.kiwixType = appstate.target;
         if (appstate.target === 'window') articleWindow.onpopstate = historyPop;
         // Ensure the target is permanently stored as a property of the articleWindow (since appstate.target can change)
         articleWindow.kiwixType = appstate.target;
-        articleWindow.onload = windowLoaded;
+        // articleWindow.onload = windowLoaded;
         // IE (and Edge Legacy) do not provide the onload event for newly opened windows/tabs. However, document.write()
         // followed by document.close() is synchronous in these browsers, so an event loader is unnecessary.
         setTimeout(function() {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1402,7 +1402,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         // Hide any alert box that was activated in uiUtil.displayFileDownloadAlert function
         $('#downloadAlert').hide();
 
-        // Code below will run after we have written the new article to the articleContainer
+        // Code below will run after we have loaded the dummy article into the articleContainer
         var windowLoaded = function() {
             $("#articleList").empty();
             $('#articleListHeaderMessage').empty();
@@ -1411,7 +1411,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             if (appstate.target === 'iframe' && !articleContainer.contentDocument && window.location.protocol === 'file:') {
                 if (!appstate.fileAccessWarning) {
                     uiUtil.systemAlert("<p>You seem to be opening kiwix-js with the file:// protocol, which blocks access to the app's iframe. "
-                    + "We have tried to open your article in a separate window. You may be able to use it with limited functionality.</p>"
+                    + "We have tried to open your article in a separate window. You may be able to use it with limited functionality. " 
+                    + "If you don't see it, check for a <b>blocked popup</b>, allow it, and try again (press the 'Home' button).</p>"
                     + "<p>The easiest way to run this app fully is to download and run it as a browser extension (from the vendor store). "
                     + "Alternatively, you can open it through a web server: either use a local one (http://localhost/...) "
                     + "or a remote one. For example, you can try your ZIM out right now with our online version of the app: "

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -142,6 +142,22 @@ define(rqDef, function() {
     }
 
     /**
+     * Displays a customizable basic non-blocking system alert
+     */
+    var systemAlertSetup = false;
+    function systemAlert(text) {
+        var alertBox = document.getElementById('systemAlert');
+        alertBox.style.display = 'block';
+        document.getElementById('alertContent').innerHTML = text;
+        if (!systemAlertSetup) {
+            systemAlertSetup = true;
+            alertBox.querySelector('button[data-hide]').addEventListener('click', function() {
+                alertBox.style.display = 'none';
+            });
+        }
+    } 
+    
+    /**
      * Displays a Bootstrap warning alert with information about how to access content in a ZIM with unsupported active UI
      */
     var activeContentWarningSetup = false;
@@ -444,6 +460,7 @@ define(rqDef, function() {
         replaceCSSLinkWithInlineCSS: replaceCSSLinkWithInlineCSS,
         deriveZimUrlFromRelativeUrl: deriveZimUrlFromRelativeUrl,
         removeUrlParameters: removeUrlParameters,
+        systemAlert: systemAlert,
         displayActiveContentWarning: displayActiveContentWarning,
         displayFileDownloadAlert: displayFileDownloadAlert,
         isElementInView: isElementInView,

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -349,13 +349,13 @@ define(rqDef, function() {
      * A rule may additionally be needed in app.css for full implementation of contentTheme
      * 
      * @param {String} theme The theme to apply (light|dark[_invert|_mwInvert])
+     * @param {Window} container The iframe, tab or window to which the theme should be applied
      */
-    function applyAppTheme(theme) {
+    function applyAppTheme(theme, container) {
         var htmlEl = document.querySelector('html');
         var footer = document.querySelector('footer');
         var oldTheme = htmlEl.dataset.theme || '';
-        var iframe = document.getElementById('articleContent');
-        var doc = iframe.contentDocument;
+        var doc = container.contentDocument || container.document;
         var kiwixJSSheet = doc ? doc.getElementById('kiwixJSTheme') || null : null;
         var appTheme = theme.replace(/_.*$/, '');
         var contentTheme = theme.replace(/^[^_]*/, '');
@@ -378,10 +378,10 @@ define(rqDef, function() {
         // Show any specific help for selected contentTheme
         var help = document.getElementById(theme + '-help');
         if (help) help.style.display = 'block';
-        
+        var frame = container.classList ? container : container.document.documentElement;
         // If there is no ContentTheme or we are applying a different ContentTheme, remove any previously applied ContentTheme
         if (oldContentTheme && oldContentTheme !== contentTheme) {
-            iframe.classList.remove(oldContentTheme);
+            frame.classList.remove(oldContentTheme);
             if (kiwixJSSheet) {
                 kiwixJSSheet.disabled = true;
                 kiwixJSSheet.parentNode.removeChild(kiwixJSSheet);
@@ -389,7 +389,7 @@ define(rqDef, function() {
         }
         // Apply the requested ContentTheme (if not already attached)
         if (contentTheme && (!kiwixJSSheet || !~kiwixJSSheet.href.search('kiwixJS' + contentTheme + '.css'))) {
-            iframe.classList.add(contentTheme);
+            frame.classList.add(contentTheme);
             // Use an absolute reference because Service Worker needs this (if an article loaded in SW mode is in a ZIM
             // subdirectory, then relative links injected into the article will not work as expected)
             // Note that location.pathname returns the path plus the filename, but is useful because it removes any query string

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -142,6 +142,21 @@ define(rqDef, function() {
     }
 
     /**
+     * Walk up the DOM tree to find the closest element where the tagname matches the supplied regular expression
+     * 
+     * @param {Element} el The starting DOM element
+     * @param {RegExp} rgx A regular expression to match the element's tagname
+     * @returns {Element|null} The matching element or null if no match was found
+     */
+    function getClosestMatchForTagname(el, rgx) {
+        do {
+            if (rgx.test(el.tagName)) return el;
+            el = el.parentElement || el.parentNode;
+        } while (el !== null && el.nodeType === 1);
+        return null;
+    }
+
+    /**
      * Displays a customizable basic non-blocking system alert
      */
     var systemAlertSetup = false;
@@ -459,6 +474,7 @@ define(rqDef, function() {
         feedNodeWithBlob: feedNodeWithBlob,
         replaceCSSLinkWithInlineCSS: replaceCSSLinkWithInlineCSS,
         deriveZimUrlFromRelativeUrl: deriveZimUrlFromRelativeUrl,
+        getClosestMatchForTagname: getClosestMatchForTagname,
         removeUrlParameters: removeUrlParameters,
         systemAlert: systemAlert,
         displayActiveContentWarning: displayActiveContentWarning,

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -352,10 +352,10 @@ define(rqDef, function() {
      * @param {Window} container The iframe, tab or window to which the theme should be applied
      */
     function applyAppTheme(theme, container) {
-        var htmlEl = document.querySelector('html');
+        var doc = container.contentDocument || container.document;
+        var htmlEl = container.kiwixType === 'window' ? doc.querySelector('html') : document.querySelector('html');
         var footer = document.querySelector('footer');
         var oldTheme = htmlEl.dataset.theme || '';
-        var doc = container.contentDocument || container.document;
         var kiwixJSSheet = doc ? doc.getElementById('kiwixJSTheme') || null : null;
         var appTheme = theme.replace(/_.*$/, '');
         var contentTheme = theme.replace(/^[^_]*/, '');

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -405,7 +405,7 @@ define(rqDef, function() {
         }
         // If we are in Config and a real document has been loaded already, expose return link so user can see the result of the change
         // DEV: The Placeholder string below matches the dummy article.html that is loaded before any articles are loaded
-        var dummyArticle = doc.querySelector('meta[name="description"]');
+        var dummyArticle = doc ? doc.querySelector('meta[name="description"]') : null;
         dummyArticle = dummyArticle ? dummyArticle.content === "Placeholder for injecting an article into the iframe or window" : false;
         if (document.getElementById('liConfigureNav').classList.contains('active') && !dummyArticle ) {
             showReturnLink();


### PR DESCRIPTION
This is currently a rough draft of a possible way to manage tabbed browsing in Kiwix JS in jQuery mode, addressing #678. This PR is not needed for Service Worker mode because the browser handles tabbed browsing natively.

With this PR, a user can launch a new tab or a new window (depending on OS/browser) in one of two ways:

1. Ctrl-click or command-click on a hyperlink (if user has a keyboard and mouse, or keyboard and tap);
2. Long press on a hyperlink for more than 600ms (only on browsers that support the [`touchstart` event](https://caniuse.com/?search=touchstart) - i.e. FFOS and Windows Mobile are not supported, but I don't think anyone really wants to open a new window on these mobile apps).

The second option is an alternative to patching the right-click context menu. This menu has useful things a user may wish to do, so we should not override it. As a result, this PR does *not* support opening a new tab from the context menu (it is natively supported in SW mode). There is no reliable way to patch the "open in new tab" entry in the context menu without completely replacing the menu. 

The tabs opened by this PR are independently browsable, i.e. the user can click on ZIM hyperlinks and they will open in the same window, and also ctrl-click on links to open yet another window/tab).

The new tabs do not have the Kiwix JS UI (no search bar, no random button or navigation buttons). I see this as an advantage for the user who would like to read a page fullscreen or print a page using the browser's native print function.

There is currently a small bug with setting the title of each tab on some browsers: it will intermittently show "Localhost" instead of the page title - this is probably a minor race condition with setting the title at the right moment.