### PR TITLE
Support ZIM archives with no namespace

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -53,11 +53,11 @@ var regexpCachedContentTypes = /text\/css|text\/javascript|application\/javascri
 var regexpExcludedURLSchema = /^(?:chrome-extension|example-extension):/i;
 
 /** 
- * Pattern for ZIM file namespace: see https://wiki.openzim.org/wiki/ZIM_file_format#Namespaces
- * In our case, there is also the ZIM file name used as a prefix in the URL
+ * Pattern for a ZIM link: these can be distinguished because they contain a ZIM file name
+ * used as a prefix in the URL
  * @type {RegExp}
  */
-var regexpZIMUrlWithNamespace = /(?:^|\/)([^\/]+\/)([-ABIJMUVWX])\/(.+)/;
+var regexpZIMUrl = /^(.*?\.[zZ][iI][mM]\/)(?:([-ABCIJMUVWX])\/)?(.+)/;
 
 self.addEventListener('install', function (event) {
     event.waitUntil(self.skipWaiting());
@@ -75,7 +75,7 @@ var fetchCaptureEnabled = false;
 
 self.addEventListener('fetch', function (event) {
     if (fetchCaptureEnabled &&
-        regexpZIMUrlWithNamespace.test(event.request.url) &&
+        regexpZIMUrl.test(event.request.url) &&
         event.request.method === "GET") {
 
         // The ServiceWorker will handle this request either from CACHE_NAME or from app.js
@@ -146,9 +146,10 @@ function fetchRequestFromZIM(fetchEvent) {
         var nameSpace;
         var title;
         var titleWithNameSpace;
-        var regexpResult = regexpZIMUrlWithNamespace.exec(fetchEvent.request.url);
+        var regexpResult = regexpZIMUrl.exec(fetchEvent.request.url);
         var prefix = regexpResult[1];
-        nameSpace = regexpResult[2];
+        // If there is no namespace, we are in a new-style ZIM where all content is in 'C'
+        nameSpace = regexpResult[2] || 'C';
         title = regexpResult[3];
 
         // We need to remove the potential parameters in the URL

--- a/service-worker.js
+++ b/service-worker.js
@@ -57,7 +57,7 @@ var regexpExcludedURLSchema = /^(?:chrome-extension|example-extension):/i;
  * In our case, there is also the ZIM file name used as a prefix in the URL
  * @type {RegExp}
  */
-var regexpZIMUrlWithNamespace = /(?:^|\/)([^\/]+\/)([-ABCIJMUVWX])\/(.+)/;
+var regexpZIMUrlWithNamespace = /(?:^|\/)([^/]+\/)([-ABCIJMUVWX])\/(.+)/;
 
 self.addEventListener('install', function (event) {
     event.waitUntil(self.skipWaiting());

--- a/service-worker.js
+++ b/service-worker.js
@@ -57,7 +57,7 @@ var regexpExcludedURLSchema = /^(?:chrome-extension|example-extension):/i;
  * In our case, there is also the ZIM file name used as a prefix in the URL
  * @type {RegExp}
  */
-var regexpZIMUrlWithNamespace = /(?:^|\/)([^\/]+\/)([-ABIJMUVWX])\/(.+)/;
+var regexpZIMUrlWithNamespace = /(?:^|\/)([^\/]+\/)([-ABCIJMUVWX])\/(.+)/;
 
 self.addEventListener('install', function (event) {
     event.waitUntil(self.skipWaiting());

--- a/service-worker.js
+++ b/service-worker.js
@@ -53,11 +53,11 @@ var regexpCachedContentTypes = /text\/css|text\/javascript|application\/javascri
 var regexpExcludedURLSchema = /^(?:chrome-extension|example-extension):/i;
 
 /** 
- * Pattern for a ZIM link: these can be distinguished because they contain a ZIM file name
- * used as a prefix in the URL
+ * Pattern for ZIM file namespace: see https://wiki.openzim.org/wiki/ZIM_file_format#Namespaces
+ * In our case, there is also the ZIM file name used as a prefix in the URL
  * @type {RegExp}
  */
-var regexpZIMUrl = /^(.*?\.[zZ][iI][mM]\/)(?:([-ABCIJMUVWX])\/)?(.+)/;
+var regexpZIMUrlWithNamespace = /(?:^|\/)([^\/]+\/)([-ABIJMUVWX])\/(.+)/;
 
 self.addEventListener('install', function (event) {
     event.waitUntil(self.skipWaiting());
@@ -75,7 +75,7 @@ var fetchCaptureEnabled = false;
 
 self.addEventListener('fetch', function (event) {
     if (fetchCaptureEnabled &&
-        regexpZIMUrl.test(event.request.url) &&
+        regexpZIMUrlWithNamespace.test(event.request.url) &&
         event.request.method === "GET") {
 
         // The ServiceWorker will handle this request either from CACHE_NAME or from app.js
@@ -146,10 +146,9 @@ function fetchRequestFromZIM(fetchEvent) {
         var nameSpace;
         var title;
         var titleWithNameSpace;
-        var regexpResult = regexpZIMUrl.exec(fetchEvent.request.url);
+        var regexpResult = regexpZIMUrlWithNamespace.exec(fetchEvent.request.url);
         var prefix = regexpResult[1];
-        // If there is no namespace, we are in a new-style ZIM where all content is in 'C'
-        nameSpace = regexpResult[2] || 'C';
+        nameSpace = regexpResult[2];
         title = regexpResult[3];
 
         // We need to remove the potential parameters in the URL

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1624,6 +1624,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $("#searchingArticles").hide();
                 alert("Error finding random article.");
             } else {
+                // We fall back to the old A namespace to support old ZIM files without a text/html MIME type for articles
+                // DEV: This will need to be changed if we search titlePtrList version 1
+                // in a future PR, as that list contains only articles
                 if (dirEntry.getMimetype() === 'text/html' || dirEntry.namespace === 'A') {
                     params.isLandingPage = false;
                     $('#activeContent').hide();
@@ -1646,7 +1649,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $("#searchingArticles").hide();
                 $("#welcomeText").show();
             } else {
-                if (dirEntry.redirect || dirEntry.getMimetype() === 'text/html') {
+                // DEV: see comment above under goToRandomArticle()
+                if (dirEntry.redirect || dirEntry.getMimetype() === 'text/html' || 
+                dirEntry.namespace === 'A') {
                     params.isLandingPage = true;
                     readArticle(dirEntry);
                 } else {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1614,7 +1614,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $("#searchingArticles").hide();
                 alert("Error finding random article.");
             } else {
-                if (dirEntry.namespace === 'A') {
+                if (dirEntry.getMimetype() === 'text/html') {
                     params.isLandingPage = false;
                     $('#activeContent').hide();
                     $('#searchingArticles').show();
@@ -1636,7 +1636,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $("#searchingArticles").hide();
                 $("#welcomeText").show();
             } else {
-                if (/[ACW-]/.test(dirEntry.namespace)) {
+                if (dirEntry.redirect || dirEntry.getMimetype() === 'text/html') {
                     params.isLandingPage = true;
                     readArticle(dirEntry);
                 } else {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1224,7 +1224,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     // URLs that begin 'http' (i.e. non-relative URLs). It then captures the whole of the URL up until either the opening delimiter
     // (" or ', which is capture group \3) or a querystring or hash character (? or #). When the regex is used below, it will be further
     // processed to calculate the ZIM URL from the relative path. This regex can cope with legitimate single quote marks (') in the URL.
-    var regexpTagsWithZimUrl = /(<(?:img|script|link|track)\b[^>]*?\s)(?:src|href)(\s*=\s*(["']))(?!http)((?:.(?!\3|\?|#))+.)/ig;
+    var regexpTagsWithZimUrl = /(<(?:img|script|link|track)\b[^>]*?\s)(?:src|href)(\s*=\s*(["']))(?!http)(.+?)(?=\3|\?|#)/ig;
     // Regex below tests the html of an article for active content [kiwix-js #466]
     // It inspects every <script> block in the html and matches in the following cases: 1) the script loads a UI application called app.js;
     // 2) the script block has inline content that does not contain "importScript()", "toggleOpenSection" or an "articleId" assignment

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1266,7 +1266,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 console.log('ZIM URL: ' + dirEntry.namespace + '/' + dirEntry.url);
                 console.log('Full URL: ' + relAssetUrl);
                 console.log('Base URL: ' + baseUrl);
-                console.log('Calculated asset URL: ' + decAssetZIMUrl);
+                console.log('Calculated asset URL: ' + assetZIMUrl);
             **/
             // DEV: Note that deriveZimUrlFromRelativeUrl produces a *decoded* URL (and incidentally would remove any URI component
             // if we had captured it). We therefore re-encode the URI with encodeURI (which does not encode forward slashes) instead

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1261,16 +1261,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         // with the correct namespace (this works for old-style -,I,J namespaces and for new-style C namespace)
         htmlArticle = htmlArticle.replace(regexpTagsWithZimUrl, function(match, blockStart, equals, quote, relAssetUrl) {
             var assetZIMUrl = uiUtil.deriveZimUrlFromRelativeUrl(relAssetUrl, baseUrl);
-            // Uncomment logging below to test the calculation of relative URLs if you are having issues 
-            /**
-                console.log('ZIM URL: ' + dirEntry.namespace + '/' + dirEntry.url);
-                console.log('Full URL: ' + relAssetUrl);
-                console.log('Base URL: ' + baseUrl);
-                console.log('Calculated asset URL: ' + assetZIMUrl);
-            **/
             // DEV: Note that deriveZimUrlFromRelativeUrl produces a *decoded* URL (and incidentally would remove any URI component
             // if we had captured it). We therefore re-encode the URI with encodeURI (which does not encode forward slashes) instead
-            // of encodeURIComponent. 
+            // of encodeURIComponent.
             return blockStart + 'data-kiwixurl' + equals + encodeURI(assetZIMUrl);
         });
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1624,7 +1624,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $("#searchingArticles").hide();
                 alert("Error finding random article.");
             } else {
-                if (dirEntry.getMimetype() === 'text/html') {
+                if (dirEntry.getMimetype() === 'text/html' || dirEntry.namespace === 'A') {
                     params.isLandingPage = false;
                     $('#activeContent').hide();
                     $('#searchingArticles').show();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1268,8 +1268,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 console.log('Base URL: ' + baseUrl);
                 console.log('Calculated asset URL: ' + decAssetZIMUrl);
             **/
-            // DEV: Note that deriveZimUrlFromRelativeUrl produces a *decoded* URL (and removes any URI component)
-            // so we re-encode it with encodeURI (this does not encode forward slashes) 
+            // DEV: Note that deriveZimUrlFromRelativeUrl produces a *decoded* URL (and incidentally would remove any URI component
+            // if we had captured it). We therefore re-encode the URI with encodeURI (which does not encode forward slashes) instead
+            // of encodeURIComponent. 
             return m1 + 'data-kiwixurl' + m2 + encodeURI(assetZIMUrl);
         });
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1650,8 +1650,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $("#welcomeText").show();
             } else {
                 // DEV: see comment above under goToRandomArticle()
-                if (dirEntry.redirect || dirEntry.getMimetype() === 'text/html' || 
-                dirEntry.namespace === 'A') {
+                if (dirEntry.redirect || dirEntry.getMimetype() === 'text/html' || dirEntry.namespace === 'A') {
                     params.isLandingPage = true;
                     readArticle(dirEntry);
                 } else {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1261,12 +1261,15 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         htmlArticle = htmlArticle.replace(regexpTagsWithZimUrl, function(m0, m1, m2, relAssetUrl) {
             var assetZIMUrl = uiUtil.deriveZimUrlFromRelativeUrl(relAssetUrl, baseUrl);
             // Uncomment logging below to test the calculation of relative URLs if you are having issues 
-            /** console.log('ZIM URL: ' + dirEntry.namespace + '/' + dirEntry.url);
-            console.log('Full URL: ' + relAssetUrl);
-            console.log('Base URL: ' + baseUrl);
-            console.log('Calculated asset URL: ' + decAssetZIMUrl); **/
-            // DEV: Note that deriveZimUrlFromRelativeUrl produces a *decoded* URL, so we re-encode it 
-            return m1 + 'data-kiwixurl' + m2 + encodeURIComponent(assetZIMUrl);
+            /**
+                console.log('ZIM URL: ' + dirEntry.namespace + '/' + dirEntry.url);
+                console.log('Full URL: ' + relAssetUrl);
+                console.log('Base URL: ' + baseUrl);
+                console.log('Calculated asset URL: ' + decAssetZIMUrl);
+            **/
+            // DEV: Note that deriveZimUrlFromRelativeUrl produces a *decoded* URL (and removes any URI component)
+            // so we re-encode it with encodeURI (this does not encode forward slashes) 
+            return m1 + 'data-kiwixurl' + m2 + encodeURI(assetZIMUrl);
         });
 
         // Extract any css classes from the html tag (they will be stripped when injected in iframe with .innerHTML)

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1220,7 +1220,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     var regexpZIMUrlWithNamespace = /^[./]*([-ABIJMUVWX]\/.+)$/;
     // Regex below finds images, scripts, stylesheets and tracks with ZIM-type metadata and image namespaces [kiwix-js #378]
     // It first searches for <img, <script, <link, etc., then scans forward to find, on a word boundary, either src=["']
-    // or href=["'] (ignoring any extra whitespace), and it then tests the path of the URL with a non-capturing megative lookahead
+    // or href=["'] (ignoring any extra whitespace), and it then tests the path of the URL with a non-capturing negative lookahead
     // that excludes URLs that begin 'http' (i.e. non-relative URLs). When the regex is used below, it will be further processed to
     // account for any relative path.
     var regexpTagsWithZimUrl = /(<(?:img|script|link|track)\b[^>]*?\s)(?:src|href)(\s*=\s*["'])(?!http)([^"']+)/ig;
@@ -1258,14 +1258,14 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         // Replaces ZIM-style URLs of img, script, link and media tags with a data-kiwixurl to prevent 404 errors [kiwix-js #272 #376]
         // This replacement also processes the URL relative to the page's ZIM URL so that we can find the ZIM URL of the asset
         // with the correct namespace (this works for old-style -,I,J namespaces and for new-style C namespace)
-        htmlArticle = htmlArticle.replace(regexpTagsWithZimUrl, function(m0, m1, m2, fullUrl) {
-            var url = uiUtil.deriveZimUrlFromRelativeUrl(fullUrl, baseUrl);
+        htmlArticle = htmlArticle.replace(regexpTagsWithZimUrl, function(m0, m1, m2, relAssetUrl) {
+            var decAssetZIMUrl = uiUtil.deriveZimUrlFromRelativeUrl(relAssetUrl, baseUrl);
             // Uncomment logging below to test the calculation of relative URLs if you are having issues 
             /** console.log('ZIM URL: ' + dirEntry.namespace + '/' + dirEntry.url);
-            console.log('Full URL: ' + fullUrl);
+            console.log('Full URL: ' + relAssetUrl);
             console.log('Base URL: ' + baseUrl);
-            console.log('Calculated URL: ' + url); **/
-            return m1 + 'data-kiwixurl' + m2 + url;
+            console.log('Calculated asset URL: ' + decAssetZIMUrl); **/
+            return m1 + 'data-kiwixurl' + m2 + encodeURIComponent(decAssetZIMUrl);
         });
 
         // Extract any css classes from the html tag (they will be stripped when injected in iframe with .innerHTML)

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1259,7 +1259,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         // Replaces ZIM-style URLs of img, script, link and media tags with a data-kiwixurl to prevent 404 errors [kiwix-js #272 #376]
         // This replacement also processes the URL relative to the page's ZIM URL so that we can find the ZIM URL of the asset
         // with the correct namespace (this works for old-style -,I,J namespaces and for new-style C namespace)
-        htmlArticle = htmlArticle.replace(regexpTagsWithZimUrl, function(m0, m1, m2, m3, relAssetUrl) {
+        htmlArticle = htmlArticle.replace(regexpTagsWithZimUrl, function(match, blockStart, equals, quote, relAssetUrl) {
             var assetZIMUrl = uiUtil.deriveZimUrlFromRelativeUrl(relAssetUrl, baseUrl);
             // Uncomment logging below to test the calculation of relative URLs if you are having issues 
             /**
@@ -1271,7 +1271,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             // DEV: Note that deriveZimUrlFromRelativeUrl produces a *decoded* URL (and incidentally would remove any URI component
             // if we had captured it). We therefore re-encode the URI with encodeURI (which does not encode forward slashes) instead
             // of encodeURIComponent. 
-            return m1 + 'data-kiwixurl' + m2 + encodeURI(assetZIMUrl);
+            return blockStart + 'data-kiwixurl' + equals + encodeURI(assetZIMUrl);
         });
 
         // Extract any css classes from the html tag (they will be stripped when injected in iframe with .innerHTML)

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1220,10 +1220,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     var regexpZIMUrlWithNamespace = /^[./]*([-ABIJMUVWX]\/.+)$/;
     // Regex below finds images, scripts, stylesheets and tracks with ZIM-type metadata and image namespaces [kiwix-js #378]
     // It first searches for <img, <script, <link, etc., then scans forward to find, on a word boundary, either src=["']
-    // or href=["'] (ignoring any extra whitespace), and it then tests the path of the URL with a non-capturing lookahead that
-    // matches ZIM URLs with namespaces [-IJ] ('-' = metadata or 'I'/'J' = image). When the regex is used below, it will also
-    // remove any relative or absolute path from ZIM-style URLs.
-    // DEV: If you want to support more namespaces, add them to the END of the character set [-IJ] (not to the beginning) 
+    // or href=["'] (ignoring any extra whitespace), and it then tests the path of the URL with a non-capturing megative lookahead
+    // that excludes URLs that begin 'http' (i.e. non-relative URLs). When the regex is used below, it will be further processed to
+    // account for any relative path.
     var regexpTagsWithZimUrl = /(<(?:img|script|link|track)\b[^>]*?\s)(?:src|href)(\s*=\s*["'])(?!http)(?:\.\.\/|\/)*([^"']+)/ig;
     // Regex below tests the html of an article for active content [kiwix-js #466]
     // It inspects every <script> block in the html and matches in the following cases: 1) the script loads a UI application called app.js;
@@ -1255,6 +1254,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
 
         // Replaces ZIM-style URLs of img, script, link and media tags with a data-kiwixurl to prevent 404 errors [kiwix-js #272 #376]
         // This replacement also processes the URL to remove the path so that the URL is ready for subsequent jQuery functions
+        // If we are in a new-style ZIM archive with a single namespace for user content, then that namespace is added to the URL
         htmlArticle = htmlArticle.replace(regexpTagsWithZimUrl, function(m0, m1, m2, url) {
             // If it's a new ZIM URL without namespace, add the C namespace (=Content)
             url = /^[-IJ]/.test(url) ? url : 'C/' + url;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1636,7 +1636,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $("#searchingArticles").hide();
                 $("#welcomeText").show();
             } else {
-                if (/[AC-]/.test(dirEntry.namespace)) {
+                if (/[ACW-]/.test(dirEntry.namespace)) {
                     params.isLandingPage = true;
                     readArticle(dirEntry);
                 } else {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -118,9 +118,9 @@ define(rqDef, function() {
      * Derives the URL.pathname from a relative or semi-relative URL using the given base ZIM URL
      * 
      * @param {String} url The (URI-encoded) URL to convert (e.g. "Einstein", "../Einstein",
-     *      "../../I/im%C3%A1gen.png", "-/s/style.css", "/A/Einstein.html")
-     * @param {String} base The base ZIM URL of the currently loaded article (e.g. "A/" or "A/subdir1/subdir2/")
-     * @returns {String} The derived ZIM URL in decoded form (e.g. "A/Einstein", "I/imágen.png")
+     *      "../../I/im%C3%A1gen.png", "-/s/style.css", "/A/Einstein.html". "../static/bootstrap/css/bootstrap.min.css")
+     * @param {String} base The base ZIM URL of the currently loaded article (e.g. "A/", "A/subdir1/subdir2/", "C/Singapore/")
+     * @returns {String} The derived ZIM URL in decoded form (e.g. "A/Einstein", "I/imágen.png", "C/")
      */
     function deriveZimUrlFromRelativeUrl(url, base) {
         // We use a dummy domain because URL API requires a valid URI

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -118,7 +118,7 @@ define(rqDef, function() {
      * Derives the URL.pathname from a relative or semi-relative URL using the given base ZIM URL
      * 
      * @param {String} url The (URI-encoded) URL to convert (e.g. "Einstein", "../Einstein",
-     *      "../../I/im%C3%A1gen.png", "-/s/style.css", "/A/Einstein.html". "../static/bootstrap/css/bootstrap.min.css")
+     *      "../../I/im%C3%A1gen.png", "-/s/style.css", "/A/Einstein.html", "../static/bootstrap/css/bootstrap.min.css")
      * @param {String} base The base ZIM URL of the currently loaded article (e.g. "A/", "A/subdir1/subdir2/", "C/Singapore/")
      * @returns {String} The derived ZIM URL in decoded form (e.g. "A/Einstein", "I/imágen.png", "C/")
      */

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -223,9 +223,10 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
         util.binarySearch(0, this._file.articleCount, function(i) {
             return that._file.dirEntryByTitleIndex(i).then(function(dirEntry) {
                 if (search.status === 'cancelled') return 0;
-                if (dirEntry.namespace < 'A') return 1;
-                if (dirEntry.namespace > 'C') return -1;
-                // We should now be in namespace A or C (or possibly B, but that is unlikely)
+                var ns = dirEntry.namespace;
+                if (ns < 'A') return 1;
+                if (ns === 'B' || ns > 'C') return -1;
+                // We should now be in namespace A (old format ZIM) or C (new format ZIM)
                 return prefix <= dirEntry.getTitleOrUrl() ? -1 : 1;
             });
         }, true).then(function(firstIndex) {

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -224,8 +224,8 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
             return that._file.dirEntryByTitleIndex(i).then(function(dirEntry) {
                 if (search.status === 'cancelled') return 0;
                 if (dirEntry.namespace < 'A') return 1;
-                if (dirEntry.namespace > 'A') return -1;
-                // We should now be in namespace A
+                if (dirEntry.namespace > 'C') return -1;
+                // We should now be in namespace A or C (or possibly B, but that is unlikely)
                 return prefix <= dirEntry.getTitleOrUrl() ? -1 : 1;
             });
         }, true).then(function(firstIndex) {
@@ -237,7 +237,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
                 return that._file.dirEntryByTitleIndex(index).then(function(dirEntry) {
                     var title = dirEntry.getTitleOrUrl();
                     // Only return dirEntries with titles that actually begin with prefix
-                    if (dirEntry.namespace === 'A' && title.indexOf(prefix) === 0) {
+                    if (/[AC]/.test(dirEntry.namespace) && title.indexOf(prefix) === 0) {
                         dirEntries.push(dirEntry);
                         // Report interim result
                         callback([dirEntry], true);

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -209,6 +209,20 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
         }
         searchNextVariant();
     };
+
+    /**
+     * A method to return the namespace in the ZIM file that contains the primary user content. In old-format ZIM files (minor
+     * version 0) there are a number of content namespaces, but the primary one in which to search for titles is 'A'. In new-format
+     * ZIMs (minor version 1) there is a single content namespace 'C'. See https://openzim.org/wiki/ZIM_file_format.
+     * @returns {String|null} The content namespace for the ZIM archive or null if the namespace cannot be determined 
+     */
+    ZIMArchive.prototype.getContentNamespace = function() {
+        if (this.isReady()) {
+            var ver = this._file.minorVersion;
+            return ver === 0 ? 'A' : ver === 1 ? 'C' : null;
+        }
+        return null;
+    };
     
     /**
      * Look for dirEntries with title starting with the given prefix (case-sensitive)
@@ -220,12 +234,15 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      */
     ZIMArchive.prototype.findDirEntriesWithPrefixCaseSensitive = function(prefix, resultSize, search, callback) {
         var that = this;
+        // DEV: if we cannot determine the namespace, we will assume the most common type, but this should not happen
+        // In the future, if the 'C' type becomes the dominant strain, change this fallback value
+        var cns = this.getContentNamespace() || 'A';
         util.binarySearch(0, this._file.articleCount, function(i) {
             return that._file.dirEntryByTitleIndex(i).then(function(dirEntry) {
                 if (search.status === 'cancelled') return 0;
                 var ns = dirEntry.namespace;
-                if (ns < 'A') return 1;
-                if (ns === 'B' || ns > 'C') return -1;
+                if (ns < cns) return 1;
+                if (ns > cns) return -1;
                 // We should now be in namespace A (old format ZIM) or C (new format ZIM)
                 return prefix <= dirEntry.getTitleOrUrl() ? -1 : 1;
             });

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -213,10 +213,11 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
     /**
      * A method to return the namespace in the ZIM file that contains the primary user content. In old-format ZIM files (minor
      * version 0) there are a number of content namespaces, but the primary one in which to search for titles is 'A'. In new-format
-     * ZIMs (minor version 1) there is a single content namespace 'C'. See https://openzim.org/wiki/ZIM_file_format.
-     * @returns {String|null} The content namespace for the ZIM archive or null if the namespace cannot be determined 
+     * ZIMs (minor version 1) there is a single content namespace 'C'. See https://openzim.org/wiki/ZIM_file_format. This method
+     * throws an error if it cannot determine the namespace or if the ZIM is not ready.
+     * @returns {String} The content namespace for the ZIM archive 
      */
-    ZIMArchive.prototype.getContentNamespace = function() {
+    ZIMArchive.prototype.getContentNamespace = function () {
         var errorText;
         if (this.isReady()) {
             var ver = this._file.minorVersion;

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -301,8 +301,9 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
                         zf.id = tempFileId++;
                         fileIDs.set(zf.name, zf.id);
                     }
-                    zf.majorVersion = readInt(header, 4, 2);
-                    zf.minorVersion = readInt(header, 6, 2);
+                    // For a description of these values, see https://wiki.openzim.org/wiki/ZIM_file_format
+                    zf.majorVersion = readInt(header, 4, 2); // Not currently used by this implementation
+                    zf.minorVersion = readInt(header, 6, 2); // Used to determine the User Content namespace
                     zf.articleCount = readInt(header, 24, 4);
                     zf.clusterCount = readInt(header, 28, 4);
                     zf.urlPtrPos = urlPtrPos;

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -301,6 +301,8 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
                         zf.id = tempFileId++;
                         fileIDs.set(zf.name, zf.id);
                     }
+                    zf.majorVersion = readInt(header, 4, 2);
+                    zf.minorVersion = readInt(header, 6, 2);
                     zf.articleCount = readInt(header, 24, 4);
                     zf.clusterCount = readInt(header, 28, 4);
                     zf.urlPtrPos = urlPtrPos;


### PR DESCRIPTION
This is preliminary work on #597.

I've done some hacks to the code in jQuery mode (for now) as a proof-of-concept.

This supports reading and showing articles in the sample ZIM file `wikipedia_en_ray_charles_2018-09_nons.zim`. It is also backwardly compatible with older ZIM files. It supports searching for a title, with the proviso that results are not yet filtered for an article MIME type.

One confusing thing is that the landing article of this ZIM is in namespace '-' instead of 'W' or 'C'. This could simply be an earlier version of the spec.

Service Worker mode is not currently working.