### PR TITLE
tests: Use Chrome for 'npm test' in GitHub CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,9 +35,8 @@ jobs:
       - name: Unit tests (Linux)
         run: npm test
 
-  # This job only runs when SauceLabs credentials are available
-  # (e.g. direct pushes and local non-fork PRs) and is used to
-  # run tests on additional operating systems and browsers.
+  # This job only runs when SauceLabs credentials are available (e.g. direct pushes and same-repo PRs)
+  # and is used to run tests on additional operating systems and browsers.
   tests-secure:
     # Ideally this would be `if: secrets.SAUCE_USERNAME` or `if: fork`, which Travis CI
     # supported, but GitHub Actions does not. When a commit or PR is from a source (non-fork)
@@ -58,9 +57,11 @@ jobs:
     # decides whether the job runs, not the secrets loads, so it doesn't need to be
     # match perfectly. At worst it might in some edge case skip or run when it shouldn't
     # and simply fail due to absence of secrets.
+    # To trigger a job for same-repo PRs as well, use
+    # `if: … || github.event.pull_request.head.repo.full_name == github.repository`
     # https://github.community/t/have-github-action-only-run-on-master-repo-and-not-on-forks/140840
     # https://github.community/t/distinguish-between-forked-pr-and-own-pr/16678/2
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/tests/karma.conf.local.js
+++ b/tests/karma.conf.local.js
@@ -10,7 +10,12 @@ module.exports = function (config) {
       // whereas Windows and macOS users tend to have auto-updating Google Chrome.
       //
       // See package.json for commands to run tests in a single browser only.
-      process.platform === 'linux' ? 'ChromiumHeadless' : 'ChromeHeadless'
+      //
+      // The CHROME_BIN check is to temporarily accomodate GitHub Actions
+      // which oddly uses Ubuntu but replaces the standard Chromium distribution
+      // with a custom install of Google Chrome. Being fixed in the next release:
+      // https://github.com/actions/virtual-environments/issues/2388
+      process.platform === 'linux' && !process.env.CHROME_BIN ? 'ChromiumHeadless' : 'ChromeHeadless'
     ],
     frameworks: ['qunit'],
     client: {


### PR DESCRIPTION
Follows-up 55186c8. I had this check originally, but then removed it after GitHub merged the upstream improvement.
It looks like some CI runners might not yet have it applied, so keep it a little longer for now.