### PR TITLE
Support new v1 directory listings

### DIFF
--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -280,7 +280,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
         }, true).then(function(firstIndex) {
             var dirEntries = [];
             var addDirEntries = function(index) {
-                if (search.status === 'cancelled' || index >= firstIndex + resultSize || index >= that._file.articleCount) {
+                if (search.status === 'cancelled' || index >= firstIndex + resultSize || index >= articleCount) {
                     return dirEntries;
                 }
                 return that._file.dirEntryByTitleIndex(index).then(function(dirEntry) {
@@ -374,7 +374,8 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      * @param {callbackDirEntry} callback
      */
     ZIMArchive.prototype.getRandomDirEntry = function(callback) {
-        var index = Math.floor(Math.random() * this._file.articleCount);
+        var articleCount = this._file.articleCount || this._file.entryCount;
+        var index = Math.floor(Math.random() * articleCount);
         this._file.dirEntryByUrlIndex(index).then(callback);
     };
     

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -249,8 +249,19 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
     };
 
     ZIMFile.prototype.setTitleListing = function() {
-        var titleListing = 
+        // If we are in a legacy ZIM archive, there is nothing further to look up
         if (this.minorVersion === 0) return;
+        var titleListingPaths = [];
+        // We only need to look up a v1 title listing if it is not already in the archive header
+        if (!this.titlePtrPos) titleListingPaths.push('X/listing/titleOrdered/v1');
+        // We always need to look up a v2 title listing
+        titleListingPaths.push('X/listing/titleOrdered/v2');
+        titleListingPaths.forEach(function(path) {
+            // Initiate a binary search for the titleListingPath
+            // Read the dirEntry for the cluster and blob numbers
+            // Look up the absolute offset
+            // Set appropriate archive header keys
+        });
     }    
 
     /**


### PR DESCRIPTION
This is a draft of support for the new directory listings, corresponding to issue #708.

In line with a suggestion from @mgautierfr , I've implemented it in an extensible way: a developer can add further (future) listings in the `ZIMArchive` function of `zimArchive.js` by adding more known listings to the array of Listing objects. Obviously the only two listed there are currently as in code block below. This is very much just-in-case, as there are no plans to extend the listings.

Just note that, for testing with the ZIMs we have a available, the code is currently rigged to fill out the `articlePtrPos` and `articleCount` metadata from `X/listing/titleOrdered/v0` because we don't have a ZIM (at least not the ones I've tested) with a non-empty `X/listing/titleOrdered/v1`. The rigged code will be changed (a one-letter change) once we have a valid ZIM for testing. It is clearly commented where I've rigged it in `zimArchive.js`.

I've only done preliminary testing on two `nons` ZIMs (Ray Charles and Basketball), and on one legacy ZIM (Ray Charles, plus it is passing push tests with a split Ray Charles).

```
[{
    path: 'X/listing/titleOrdered/v0',
    ptrName: 'titlePtrPos',
    countName: 'entryCount'
},
{
    path: 'X/listing/titleOrdered/v1',
    ptrName: 'articlePtrPos',
    countName: 'articleCount'
}]
```