### PR TITLE
Calculate true number of articles in a legacy ZIM

### DIFF
--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -273,6 +273,8 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
             return that._file.dirEntryByTitleIndex(i).then(function(dirEntry) {
                 if (search.status === 'cancelled') return 0;
                 var ns = dirEntry.namespace;
+                // DEV: This search is redundant if we managed to populate articlePtrLst and articleCount, but it only takes two instructions and
+                // provides maximum compatibility with rare ZIMs where attempts to find first and last article (in zimArchive.js) may have failed
                 if (ns < cns) return 1;
                 if (ns > cns) return -1;
                 // We should now be in namespace A (old format ZIM) or C (new format ZIM)

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -282,22 +282,11 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
                         var ns = dirEntry.namespace;
                         var url = ns + '/' + dirEntry.getTitleOrUrl();
                         var prefix = ordinal === 'first' ? 'A' : 'B';
-                        // DIAGNOSTIC TO BE REMOVED
-                            console.debug(ordinal + ': ' + url);
                         if (prefix < ns) return -1;
                         else if (prefix > ns) return 1;
                         return prefix < url ? -1 : 1;
                     });
                 }, true).then(function(index) {
-                    // DIAGNOSTIC CODE TO BE REMOVED //
-                        console.log('The **' + ordinal + '** dirEntry in range is index ' + index);
-                        console.log('Checking dirEntry title for index and index-1 (async)...');
-                        [index, index-1].forEach(function (idx) {
-                            that.dirEntryByTitleIndex(idx).then(function (dEntry) {
-                                console.log('--> ' + dEntry.namespace + '/' + dEntry.getTitleOrUrl());
-                            });
-                        });
-                    // END OF DIAGNOSTIC CODE
                     return index;
                 });
             };

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -305,6 +305,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
             if (!listing) {
                 // No more listings, so exit
                 console.debug('ZIM DirListing version: ' + highestListingVersion, that);
+                console.debug('Article count is: ' + that.articleCount);
                 return null;
             }
             // Check if we already have this listing's values, so we don't do redundant binary searches

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -55,7 +55,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
      * @property {String} name Abstract archive name for file set
      * @property {Integer} id Arbitrary numeric ZIM id used to track the currently loaded archive
      * @property {Integer} entryCount Total number of entries in the URL pointerlist
-     * @property {Integer} articleCount Total number of articles in the v1 article-only pointerlist (async calculated entry)
+     * @property {Integer} articleCount Total number of article titles in the v1 article-only pointerlist (async calculated entry)
      * @property {Integer} clusterCount Total number of clusters
      * @property {Integer} urlPtrPos Position of the directory pointerlist ordered by URL
      * @property {Integer} titlePtrPos Position of the legacy v0 pointerlist ordered by title
@@ -264,17 +264,45 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
     /**
      * Read the metadata (archive offset pointer, and number of entiries) of one or more ZIM directory Listings.
      * This supports reading a subset of user content that might be ordered differently from the main URL pointerlist.
-     * In particular, it supports v1 title pointerlists, which contain articles sorted by title, superseding the article
+     * In particular, it supports the v1 article pointerlist, which contains articles sorted by title, superseding the article
      * namespace ('A') in legazy ZIM archives.  
      * @param {Array<DirListing>} listings An array of DirListing objects (see zimArchive.js for examples)  
+     * @returns {Promise} A promise that populates calculated entries in the ZIM file header
      */
     ZIMFile.prototype.setListings = function(listings) {
-        // If we are in a legacy ZIM archive, there is nothing further to look up
+        var that = this;
+        // If we are in a legacy ZIM archive, we need to calculate the true article count (of entries in the A namespace)
+        // This effectively emulates the v1 article pointerlist
         if (this.minorVersion === 0) {
             console.debug('ZIM DirListing version: 0 (legacy)', this);
-            return;
+            // Initiate a binary search for the first or last article
+            var getArticleIndexByOrdinal = function (ordinal) {
+                var foundDirEntry = {};
+                return util.binarySearch(0, that.entryCount, function(i) {
+                    return that.dirEntryByUrlIndex(i).then(function(dirEntry) {
+                        foundDirEntry = dirEntry;
+                        var ns = dirEntry.namespace;
+                        var url = ns + '/' + dirEntry.url;
+                        var prefix = ordinal === 'first' ? 'A' : 'B';
+                        console.debug(ordinal + ':' + url);
+                        if (prefix < ns) return -1;
+                        else if (prefix > ns) return 1;
+                        return prefix <= url ? -1 : 1;
+                    });
+                }, true).then(function(index) {
+                    console.debug('Found dirEntry: ' + foundDirEntry.namespace + '/' + foundDirEntry.url);
+                    return index;
+                });
+            };
+            return getArticleIndexByOrdinal('first').then(function(idxFirstArticle) {
+                return getArticleIndexByOrdinal('last').then(function(idxLastArticle) {
+                    // Technically idxFirstArticle points to the entry before the first article, acting as a zero-based pointer
+                    that.articlePtrPos = that.titlePtrPos + idxFirstArticle * 4;
+                    that.articleCount = idxLastArticle - idxFirstArticle;
+                    console.debug('Calculated article count is: ' + that.articleCount);
+                });
+            });
         }
-        var that = this;
         var highestListingVersion = 0;
         var listingAccessor = function (listing) {
             if (!listing) {
@@ -400,7 +428,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
                     zf.clusterCount = readInt(header, 28, 4);
                     zf.urlPtrPos = urlPtrPos;
                     zf.titlePtrPos = readInt(header, 40, 8);
-                    zf.articlePtrPos = null; // Calculated async by setListings() called from zimArchive.js 
+                    zf.articlePtrPos = null; // Calculated async by setListings() 
                     zf.clusterPtrPos = readInt(header, 48, 8);
                     zf.mimeListPos = mimeListPos;
                     zf.mainPage = readInt(header, 64, 4);

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -269,7 +269,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
      * @param {Array<DirListing>} listings An array of DirListing objects (see zimArchive.js for examples)  
      * @returns {Promise} A promise that populates calculated entries in the ZIM file header
      */
-    ZIMFile.prototype.setListings = function(listings) {
+    ZIMFile.prototype.setListings = function (listings) {
         var that = this;
         // If we are in a legacy ZIM archive, we need to calculate the true article count (of entries in the A namespace)
         // This effectively emulates the v1 article pointerlist
@@ -283,7 +283,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
                         var url = ns + '/' + dirEntry.getTitleOrUrl();
                         var prefix = ordinal === 'first' ? 'A' : 'B';
                         // DIAGNOSTIC TO BE REMOVED
-                        console.debug(ordinal + ': ' + url);
+                            console.debug(ordinal + ': ' + url);
                         if (prefix < ns) return -1;
                         else if (prefix > ns) return 1;
                         return prefix < url ? -1 : 1;
@@ -291,11 +291,11 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'q', 'zimDirEntry', 
                 }, true).then(function(index) {
                     // DIAGNOSTIC CODE TO BE REMOVED //
                         console.log('The **' + ordinal + '** dirEntry in range is index ' + index);
-                    console.log('Checking dirEntry title for index and index-1 (async)...');
-                    [index, index-1].forEach(function (idx) {
-                        that.dirEntryByTitleIndex(idx).then(function (dEntry) {
+                        console.log('Checking dirEntry title for index and index-1 (async)...');
+                        [index, index-1].forEach(function (idx) {
+                            that.dirEntryByTitleIndex(idx).then(function (dEntry) {
                                 console.log('--> ' + dEntry.namespace + '/' + dEntry.getTitleOrUrl());
-                        });
+                            });
                         });
                     // END OF DIAGNOSTIC CODE
                     return index;


### PR DESCRIPTION
This fixes #720.

It turned out to be an interesting logical problem. For a legacy (i.e. current) ZIM format, the random function takes the full range of titles in the title pointerlist and hops through it until it finds an article. The title pointerlist is merely the entire list of dirEntries ordered by title, as opposed to url. The number of entries in the title pointerlist is thus the same as the number of entries in the url pointerlist, which is equal to the number of directory entries. Random is therefore quite inefficient, because it is trying to find a random article in a sea of other directory entries (e.g. the number of images can easily outnumber the number of articles).

However, in a v1 no-namespace ZIM, we will have an article pointerlist which is the subset of dirEntries that represent articles, and the random function will search through this list, thus being more efficient and more truly random.

However, it struck me that the v1 article pointerlist is actually equivalent to the subset of the v0 (legacy) title pointerlist that is in the `A` namespace, i.e. all articles and only articles. If we pre-calculate the start of that subset in a v0 ZIM, and find out the number of entries in that subset, then we have the equivalent of the v1 article pointerlist, i.e., we have emulated it for a legacy ZIM.

Doing this doesn't only make the random function more efficient. It also speeds up title binary search, because we are only hopping through a reduced subset of the full title list that would otherwise include images, metadata, etc. We end up saving quite a number of hops (you can see them in the debug console log during the initial pre-calculation in this PR). Effectively we do this calculation once in advance instead of doing it for every title (binary) search.

While it may seem pointless enhancing search (and random) in legacy ZIMs, when the format is about to be deprecated, I think in fact we'll be dealing with these legacy ZIMs for quite a long time, so this PR is worth it.

There is one thing to note that will always prevent the random function from being truly random (in the practical rather than the theoretical sense). This is the fact that the article list contains (at least for Wikipedia ZIMs) lots of redundant entries. For example, we may have `(USA)`, `US`, `united states`, `United States`, `United states of America`, `United States of America`, etc., etc., all pointing to the same underlying article. Thus, the random function will end up biased towards those articles with lots and lots of aliases, whereas less popular articles will often have no aliases. There is no way to overcome this, as we don't have a list of unique articles.

I need to test this PR more extensively before it is ready for review. Note that I'll clean out most of the console debug log before merging.