### PR TITLE
Correct usage of classList method

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1324,7 +1324,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         // Extract any css classes from the html tag (they will be stripped when injected in iframe with .innerHTML)
         var htmlCSS = htmlArticle.match(/<html[^>]*class\s*=\s*["']\s*([^"']+)/i);
         // Normalize classList and convert to array
-        htmlCSS = htmlCSS ? htmlCSS[1].replace(/\s+/g, ' ').split(' ') : '';
+        htmlCSS = htmlCSS ? htmlCSS[1].replace(/\s+/g, ' ').split(' ') : [];
         
         // Tell jQuery we're removing the iframe document: clears jQuery cache and prevents memory leaks [kiwix-js #361]
         $('#articleContent').contents().remove();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1323,7 +1323,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
 
         // Extract any css classes from the html tag (they will be stripped when injected in iframe with .innerHTML)
         var htmlCSS = htmlArticle.match(/<html[^>]*class\s*=\s*["']\s*([^"']+)/i);
-        htmlCSS = htmlCSS ? htmlCSS[1] : '';
+        // Normalize classList and convert to array
+        htmlCSS = htmlCSS ? htmlCSS[1].replace(/\s+/g, ' ').split(' ') : '';
         
         // Tell jQuery we're removing the iframe document: clears jQuery cache and prevents memory leaks [kiwix-js #361]
         $('#articleContent').contents().remove();
@@ -1357,7 +1358,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             docBody = docBody ? docBody[0] : null;
             if (docBody) {
                 // Add any missing classes stripped from the <html> tag
-                if (htmlCSS) docBody.classList.add(htmlCSS);
+                if (htmlCSS) htmlCSS.forEach(function (cl) {
+                    docBody.classList.add(cl);
+                });
                 // Deflect drag-and-drop of ZIM file on the iframe to Config
                 docBody.addEventListener('dragover', handleIframeDragover);
                 docBody.addEventListener('drop', handleIframeDrop);


### PR DESCRIPTION
The no-namespace ZIM `beer_stackexchange_com_2021-07.zim` has exposed a coding error in Kiwix JS. The `classList.add()` method was being used incorrectly to add a list of classes with a simple string separated by a space (e.g. "myClass1 myClass2"). This turns out to cause an exception, and we have been lucky up till now that no ZIMs previously appear to have had multiple classes on the html element. The correct syntax is `classList.add("myClass1", "myClass2"). The [documentation at MDN](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/add) is a bit misleading, because it says the method accepts "A DOMString representing the token (**or tokens**) to add to the tokenList" (my bold). In fact the string must contain a single token.

This simple PR corrects this generically, and enables the landing page of the `beer_stackexchange_com_2021-07.zim` to be shown in jQuery mode (there are different issues at ZIM level affecting SW mode, see https://github.com/kiwix/kiwix-js/issues/708#issuecomment-881537057).
