### PR TITLE
Update CHANGELOG for v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Released on *2021-08-22*
 * NEW: Use fast binary WASM decoders with fallback to ASM if necessary
 * UPDATE: Clearer and more extensive documentation for end users in About
 * UPDATE: Unit testing updated to latest QUnit, and use Karma instead of Nightwatch
-* UPDATE: Replace Travis by GitHub Actions for the continuous integration
+* UPDATE: Replace Travis by GitHub Actions for continuous integration
 * UPDATE: Added helper scripts and instructions for recompiling decompressors with Docker
 * BUGFIX: Issue with calculation for selection of random articles
 * BUGFIX: Incorrect syntax in usage of classList method that caused an exception in older browsers with rare ZIM types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,23 @@ Please note that this application has changed its name over time.
 It was first called Evopedia (and was using the file format of Evopedia).
 Then it was renamed Kiwix-html5 (and uses ZIM files), and then again was renamed to Kiwix-JS.
 
-+## Kiwix-JS v3.2.0
+## Kiwix-JS v3.2.0
 
-Released on *TODO*
+Released on *2021-08-22*
 
-Detailed changelog: TODO
+* NEW: Support latest format of ZIM archives (with no namespace)
+* NEW: Optimization of title search by eliminating redundancies
+* NEW: Support new format of title listings (v1) in no-namespace ZIM archives
+* NEW: 'Home' key can now be used to focus the search field
+* NEW: Use native Promises (or modern polyfill where required) instead of Q
+* NEW: Use fast binary WASM decoders with fallback to ASM if necessary
+* UPDATE: Clearer and more extensive documentation for end users in About
+* UPDATE: Code testing updated to latest QUnit and moved to GitHub + SauceLabs
+* UPDATE: Added helper scripts and instructions for recompiling decompressors with Docker
+* BUGFIX: Issue with calculation for selection of random articles
+* BUGFIX: Bug with incorrect syntax in usage of classList method
+
+Detailed changelog: https://github.com/kiwix/kiwix-js/milestone/25?closed=1
 
 ## Kiwix-JS v3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Released on *2021-08-22*
 * NEW: Use native Promises (or modern polyfill where required) instead of Q
 * NEW: Use fast binary WASM decoders with fallback to ASM if necessary
 * UPDATE: Clearer and more extensive documentation for end users in About
-* UPDATE: Code testing updated to latest QUnit and moved to GitHub + SauceLabs
+* UPDATE: Unit testing updated to latest QUnit, and use Karma instead of Nightwatch
+* UPDATE: Replace Travis by GitHub Actions for the continuous integration
 * UPDATE: Added helper scripts and instructions for recompiling decompressors with Docker
 * BUGFIX: Issue with calculation for selection of random articles
 * BUGFIX: Bug with incorrect syntax in usage of classList method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,14 @@ Released on *2021-08-22*
 * NEW: Optimization of title search by eliminating redundancies
 * NEW: Support new format of title listings (v1) in no-namespace ZIM archives
 * NEW: 'Home' key can now be used to focus the search field
-* NEW: Use native Promises (or modern polyfill where required) instead of Q
+* NEW: Use native Promises (or modern polyfill where required) instead of Q, improving performance in modern browsers and IE11
 * NEW: Use fast binary WASM decoders with fallback to ASM if necessary
 * UPDATE: Clearer and more extensive documentation for end users in About
 * UPDATE: Unit testing updated to latest QUnit, and use Karma instead of Nightwatch
 * UPDATE: Replace Travis by GitHub Actions for the continuous integration
 * UPDATE: Added helper scripts and instructions for recompiling decompressors with Docker
 * BUGFIX: Issue with calculation for selection of random articles
-* BUGFIX: Bug with incorrect syntax in usage of classList method
+* BUGFIX: Incorrect syntax in usage of classList method that caused an exception in older browsers with rare ZIM types
 
 Detailed changelog: https://github.com/kiwix/kiwix-js/milestone/25?closed=1
 


### PR DESCRIPTION
I think it's best to add the TODO for the next version as part of the step for preparing source code for v3.3.0, and not show it in the tagged version of v3.2.0. However, if you don't agree, I'll happily replace it now.