### PR TITLE
Update source code to v3.3-WIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please note that this application has changed its name over time.
 It was first called Evopedia (and was using the file format of Evopedia).
 Then it was renamed Kiwix-html5 (and uses ZIM files), and then again was renamed to Kiwix-JS.
 
+## Kiwix-JS v3.3.0
+
+Released on *TODO*
+
 ## Kiwix-JS v3.2.0
 
 Released on *2021-08-22*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Then it was renamed Kiwix-html5 (and uses ZIM files), and then again was renamed
 
 Released on *TODO*
 
+Detailed changelog: TODO
+
 ## Kiwix-JS v3.2.0
 
 Released on *2021-08-22*

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Kiwix",
-    "version": "3.2-WIP",
+    "version": "3.3-WIP",
 
     "description": "Kiwix : offline Wikipedia reader",
     

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,5 +1,5 @@
 {
-  "version": "3.2-WIP",
+  "version": "3.3-WIP",
   "name": "Kiwix",
   "description": "Offline Wikipedia Viewer, and more",
   "launch_path": "/www/index.html",

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -12,8 +12,8 @@ while getopts tdv: option; do
     esac
 done
 
-MAJOR_NUMERIC_VERSION="3.2"
-VERSION_TO_REPLACE="3\.2-WIP"
+MAJOR_NUMERIC_VERSION="3.3"
+VERSION_TO_REPLACE="3\.3-WIP"
 
 # Set the secret environment variables if available
 # The file set_secret_environment_variables.sh should not be commited for security reasons

--- a/ubuntu_touch/manifest.json
+++ b/ubuntu_touch/manifest.json
@@ -4,7 +4,7 @@
   "architecture": "all",
   "maintainer": "Kiwix team <contact+ubuntutouch@kiwix.org>",
   "framework" : "ubuntu-sdk-16.04",
-  "version" : "3.2-WIP",
+  "version" : "3.3-WIP",
   "title": "kiwix",
   "hooks": {
     "ubports-little-webapp": {

--- a/www/index.html
+++ b/www/index.html
@@ -55,7 +55,7 @@
         <section id="search-article" role="region">
             <header id="top">
                 <nav class="navbar navbar-expand-md bg-light" role="navigation">
-                    <a class="navbar-brand">Kiwix 3.2-WIP</a>
+                    <a class="navbar-brand">Kiwix 3.3-WIP</a>
 
                     <!-- Toggler/collapsible Button -->
                     <button class="navbar-toggler" type="button" data-toggle="collapse"


### PR DESCRIPTION
@mossroy I think this is all the places where we update the version number. This is for merge into master.

As a separate point, I propose that the implementation on GitHub pages should be set to the release tag, rather than to master with the source code. updated to -WIP. If you're happy with that, I can do that.