### PR TITLE
Add missing controls property to media containers

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1603,6 +1603,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                     return;
                 }
                 var mediaElement = /audio|video/i.test(mediaSource.tagName) ? mediaSource : mediaSource.parentElement;
+                // If the "controls" property is missing, we need to add it to ensure jQuery-only users can operate the video. See kiwix-js #760.
+                if (/audio|video/i.test(mediaElement.tagName) && !mediaElement.controls) mediaElement.controls = "true"; 
                 selectedArchive.getDirEntryByPath(source).then(function(dirEntry) {
                     return selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, mediaArray) {
                         var mimeType = mediaSource.type ? mediaSource.type : dirEntry.getMimetype();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1604,7 +1604,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 }
                 var mediaElement = /audio|video/i.test(mediaSource.tagName) ? mediaSource : mediaSource.parentElement;
                 // If the "controls" property is missing, we need to add it to ensure jQuery-only users can operate the video. See kiwix-js #760.
-                if (/audio|video/i.test(mediaElement.tagName) && !mediaElement.controls) mediaElement.controls = "true"; 
+                if (/audio|video/i.test(mediaElement.tagName) && !mediaElement.hasAttribute('controls')) mediaElement.setAttribute('controls', ''); 
                 selectedArchive.getDirEntryByPath(source).then(function(dirEntry) {
                     return selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, mediaArray) {
                         var mimeType = mediaSource.type ? mediaSource.type : dirEntry.getMimetype();


### PR DESCRIPTION
Fixes #760. Although that should be fixed in the YouTube scraper, it will take a long time for that fix (if it is accepted) to come through to new ZIMs. This patch is a one-liner in the specific jQuery code that inserts media blobs, so I think it is worth doing, as it will redstore the ability to play videos to existing ZIM archives as well.

I tested this on `khan-academy-videos_en_special-relativity-physics-khan-academy_2021-03.zim`.