### PR TITLE
Tweak regular expression that detects ZIM URIs

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1284,10 +1284,11 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     // Regex below finds images, scripts, stylesheets and tracks with ZIM-type metadata and image namespaces [kiwix-js #378].
     // It first searches for <img, <script, <link, etc., then scans forward to find, on a word boundary, either src=["'] or href=["']
     // (ignoring any extra whitespace), and it then tests the path of the URL with a non-capturing negative lookahead that excludes
-    // URLs that begin 'http' (i.e. non-relative URLs). It then captures the whole of the URL up until either the opening delimiter
-    // (" or ', which is capture group \3) or a querystring or hash character (? or #). When the regex is used below, it will be further
-    // processed to calculate the ZIM URL from the relative path. This regex can cope with legitimate single quote marks (') in the URL.
-    var regexpTagsWithZimUrl = /(<(?:img|script|link|track)\b[^>]*?\s)(?:src|href)(\s*=\s*(["']))(?!http)(.+?)(?=\3|\?|#)/ig;
+    // URLs that begin 'http' (i.e. non-relative URLs) or 'data:' images/css. It then captures the whole of the URL up until either
+    // the opening delimiter (" or ', which is capture group \3) or a querystring or hash character (? or #). When the regex is used
+    // below, it will be further processed to calculate the ZIM URL from the relative path. This regex can cope with legitimate single
+    // quote marks (') in the URL.
+    var regexpTagsWithZimUrl = /(<(?:img|script|link|track)\b[^>]*?\s)(?:src|href)(\s*=\s*(["']))(?!http|data:)(.+?)(?=\3|\?|#)/ig;
     // Regex below tests the html of an article for active content [kiwix-js #466]
     // It inspects every <script> block in the html and matches in the following cases: 1) the script loads a UI application called app.js;
     // 2) the script block has inline content that does not contain "importScript()", "toggleOpenSection" or an "articleId" assignment

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1281,14 +1281,14 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     // Compile some regular expressions needed to modify links
     // Pattern to find a ZIM URL (with its namespace) - see https://wiki.openzim.org/wiki/ZIM_file_format#Namespaces
     var regexpZIMUrlWithNamespace = /^[./]*([-ABCIJMUVWX]\/.+)$/;
-    // Regex below finds images, scripts, stylesheets and tracks with ZIM-type metadata and image namespaces [kiwix-js #378].
+    // The case-insensitive regex below finds images, scripts, stylesheets and tracks with ZIM-type metadata and image namespaces.
     // It first searches for <img, <script, <link, etc., then scans forward to find, on a word boundary, either src=["'] or href=["']
-    // (ignoring any extra whitespace), and it then tests the path of the URL with a non-capturing negative lookahead that excludes
-    // URLs that begin 'http' (i.e. non-relative URLs) or 'data:' images/css. It then captures the whole of the URL up until either
+    // (ignoring any extra whitespace), and it then tests the path of the URL with a non-capturing negative lookahead (?!...) that excludes
+    // absolute URIs with protocols that conform to RFC 3986 (e.g. 'http:', 'data:'). It then captures the whole of the URL up until either
     // the opening delimiter (" or ', which is capture group \3) or a querystring or hash character (? or #). When the regex is used
     // below, it will be further processed to calculate the ZIM URL from the relative path. This regex can cope with legitimate single
     // quote marks (') in the URL.
-    var regexpTagsWithZimUrl = /(<(?:img|script|link|track)\b[^>]*?\s)(?:src|href)(\s*=\s*(["']))(?!http|data:)(.+?)(?=\3|\?|#)/ig;
+    var regexpTagsWithZimUrl = /(<(?:img|script|link|track)\b[^>]*?\s)(?:src|href)(\s*=\s*(["']))(?![a-z][a-z0-9+.-]+:)(.+?)(?=\3|\?|#)/ig;
     // Regex below tests the html of an article for active content [kiwix-js #466]
     // It inspects every <script> block in the html and matches in the following cases: 1) the script loads a UI application called app.js;
     // 2) the script block has inline content that does not contain "importScript()", "toggleOpenSection" or an "articleId" assignment


### PR DESCRIPTION
This is a hypothetical but realistic bugfix. I realized that the ZIM URI detection in jQuery mode should theoretically exclude some other potential URI types that could be found in some ZIMs. We currently exclude only URIs beginning 'http' (to include 'https') from processing as ZIM URIs -- i.e. URIs that point to external resources. However, this could lead to errors or unnecessary processing with URIs with the protocol 'data:'. These are perfectly conceivable for either CSS or images, so should be excluded explicitly from processing.

I know that Firefox OS doesn't allow data URIs for CSS (I think), but does allow them for images (I think) -- or is it the other way round? But that is rather specific to that OS.

I did wonder also whether we should add 'javascript:' as another protocol that can (and is) found in ZIMs. But maybe it's better to disable JavaScript links in jQuery mode, as they could reference scripts that are not loaded in that mode, and I think they are not allowed to run by some CSPs in any case (they may still be allowed in the iframe).

To be clear, I don't classify this as an 'enhancement' to jQuery mode. It's a small tweak to prevent potential bugs especially with newer ZIM types. Unfortunately I haven't identified an actual case. There are some data URIs in CSS, but we currently don't process CSS at all.