### PR TITLE
Disable dragging of some elements

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -601,10 +601,10 @@
                     </div>
                 </div>
                 <div id="navigationButtons" class="btn-group btn-block">
-                    <a href="#" class="btn btn-lg" draggable="false" id="btnHomeBottom" title="Home"><i class="fas fa-home"></i></a>
-                    <a href="#" class="btn btn-lg" draggable="false" id="btnBack" title="Back"><i class="fas fa-arrow-left"></i></a>
-                    <a href="#" class="btn btn-lg" draggable="false" id="btnForward" title="Forward"><i class="fas fa-arrow-right"></i></a>
-                    <a href="#top" class="btn btn-lg" draggable="false" id="btnTop" title="Top"><i class="fas fa-arrow-up"></i></a>
+                    <a href="#" class="btn btn-lg" draggable="false" id="btnHomeBottom" title="Home"><i class="fas fa-home" draggable="false"></i></a>
+                    <a href="#" class="btn btn-lg" draggable="false" id="btnBack" title="Back"><i class="fas fa-arrow-left" draggable="false"></i></a>
+                    <a href="#" class="btn btn-lg" draggable="false" id="btnForward" title="Forward"><i class="fas fa-arrow-right" draggable="false"></i></a>
+                    <a href="#top" class="btn btn-lg" draggable="false" id="btnTop" title="Top"><i class="fas fa-arrow-up" draggable="false"></i></a>
                 </div>
             </footer>
         </section>

--- a/www/index.html
+++ b/www/index.html
@@ -601,10 +601,10 @@
                     </div>
                 </div>
                 <div id="navigationButtons" ondragstart="return false;" class="btn-group btn-block">
-                    <a href="#" class="btn btn-lg" draggable="false" id="btnHomeBottom" title="Home"><i class="fas fa-home" draggable="false"></i></a>
-                    <a href="#" class="btn btn-lg" draggable="false" id="btnBack" title="Back"><i class="fas fa-arrow-left" draggable="false"></i></a>
-                    <a href="#" class="btn btn-lg" draggable="false" id="btnForward" title="Forward"><i class="fas fa-arrow-right" draggable="false"></i></a>
-                    <a href="#top" class="btn btn-lg" draggable="false" id="btnTop" title="Top"><i class="fas fa-arrow-up" draggable="false"></i></a>
+                    <a href="#" class="btn btn-lg" id="btnHomeBottom" title="Home"><i class="fas fa-home"></i></a>
+                    <a href="#" class="btn btn-lg" id="btnBack" title="Back"><i class="fas fa-arrow-left"></i></a>
+                    <a href="#" class="btn btn-lg" id="btnForward" title="Forward"><i class="fas fa-arrow-right"></i></a>
+                    <a href="#top" class="btn btn-lg" id="btnTop" title="Top"><i class="fas fa-arrow-up"></i></a>
                 </div>
             </footer>
         </section>

--- a/www/index.html
+++ b/www/index.html
@@ -96,7 +96,7 @@
             <article class="view-content">
                 <div id="about" style="display: none;" class="container">
                     <h2 id="contents">
-                        <img src="img/icons/kiwix-60.png" alt="Kiwix icon"/>
+                        <img src="img/icons/kiwix-60.png" draggable="false" alt="Kiwix icon"/>
                         Kiwix : offline Wikipedia viewer
                     </h2>
                     <p>Official site : <a href="https://www.kiwix.org/" target="_blank">https://www.kiwix.org&nbsp;<img src="img/Icon_External_Link.png" /></a></p>
@@ -601,10 +601,10 @@
                     </div>
                 </div>
                 <div id="navigationButtons" class="btn-group btn-block">
-                    <a href="#" class="btn btn-lg" id="btnHomeBottom" title="Home"><i class="fas fa-home"></i></a>
-                    <a href="#" class="btn btn-lg" id="btnBack" title="Back"><i class="fas fa-arrow-left"></i></a>
-                    <a href="#" class="btn btn-lg" id="btnForward" title="Forward"><i class="fas fa-arrow-right"></i></a>
-                    <a href="#top" class="btn btn-lg" id="btnTop" title="Top"><i class="fas fa-arrow-up"></i></a>
+                    <a href="#" class="btn btn-lg" draggable="false" id="btnHomeBottom" title="Home"><i class="fas fa-home"></i></a>
+                    <a href="#" class="btn btn-lg" draggable="false" id="btnBack" title="Back"><i class="fas fa-arrow-left"></i></a>
+                    <a href="#" class="btn btn-lg" draggable="false" id="btnForward" title="Forward"><i class="fas fa-arrow-right"></i></a>
+                    <a href="#top" class="btn btn-lg" draggable="false" id="btnTop" title="Top"><i class="fas fa-arrow-up"></i></a>
                 </div>
             </footer>
         </section>

--- a/www/index.html
+++ b/www/index.html
@@ -600,7 +600,7 @@
                         <span id="alertMessage"></span>
                     </div>
                 </div>
-                <div id="navigationButtons" ondragstart="return false;" class="btn-group btn-block">
+                <div id="navigationButtons" class="btn-group btn-block">
                     <a href="#" class="btn btn-lg" id="btnHomeBottom" title="Home"><i class="fas fa-home"></i></a>
                     <a href="#" class="btn btn-lg" id="btnBack" title="Back"><i class="fas fa-arrow-left"></i></a>
                     <a href="#" class="btn btn-lg" id="btnForward" title="Forward"><i class="fas fa-arrow-right"></i></a>

--- a/www/index.html
+++ b/www/index.html
@@ -600,7 +600,7 @@
                         <span id="alertMessage"></span>
                     </div>
                 </div>
-                <div id="navigationButtons" class="btn-group btn-block">
+                <div id="navigationButtons" ondragstart="return false;" class="btn-group btn-block">
                     <a href="#" class="btn btn-lg" draggable="false" id="btnHomeBottom" title="Home"><i class="fas fa-home" draggable="false"></i></a>
                     <a href="#" class="btn btn-lg" draggable="false" id="btnBack" title="Back"><i class="fas fa-arrow-left" draggable="false"></i></a>
                     <a href="#" class="btn btn-lg" draggable="false" id="btnForward" title="Forward"><i class="fas fa-arrow-right" draggable="false"></i></a>

--- a/www/index.html
+++ b/www/index.html
@@ -96,7 +96,7 @@
             <article class="view-content">
                 <div id="about" style="display: none;" class="container">
                     <h2 id="contents">
-                        <img src="img/icons/kiwix-60.png" id='kiwixLogo' alt="Kiwix icon"/>
+                        <img src="img/icons/kiwix-60.png" id="kiwixLogo" alt="Kiwix icon"/>
                         Kiwix : offline Wikipedia viewer
                     </h2>
                     <p>Official site : <a href="https://www.kiwix.org/" target="_blank">https://www.kiwix.org&nbsp;<img src="img/Icon_External_Link.png" /></a></p>

--- a/www/index.html
+++ b/www/index.html
@@ -96,7 +96,7 @@
             <article class="view-content">
                 <div id="about" style="display: none;" class="container">
                     <h2 id="contents">
-                        <img src="img/icons/kiwix-60.png" draggable="false" alt="Kiwix icon"/>
+                        <img src="img/icons/kiwix-60.png" id='kiwixLogo' alt="Kiwix icon"/>
                         Kiwix : offline Wikipedia viewer
                     </h2>
                     <p>Official site : <a href="https://www.kiwix.org/" target="_blank">https://www.kiwix.org&nbsp;<img src="img/Icon_External_Link.png" /></a></p>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -393,7 +393,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             document.getElementById('modes').scrollIntoView();
         }, 600);
     });
-    document.getElementById('navigationButtons').ondragstart=function (e) {return false;}
+    document.getElementById('navigationButtons').ondragstart=function () {return false;}
 
     //focus search bar (#prefix) if Home key is pressed
     function focusPrefixOnHomeKey(event) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -393,6 +393,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             document.getElementById('modes').scrollIntoView();
         }, 600);
     });
+    document.getElementById('navigationButtons').ondragstart=function (e) {return false;}
 
     //focus search bar (#prefix) if Home key is pressed
     function focusPrefixOnHomeKey(event) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -395,7 +395,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     });
 
     //Adds an event listener to kiwix logo and bottom navigation bar which gets triggered when these elements are dragged.
-    //Returning false prevents their dragging(which can cause some unexpected behavior)
+    //Returning false prevents their dragging (which can cause some unexpected behavior)
+    //Doing that in javascript is the only way to make it cross-browser compatible
     document.getElementById('kiwixLogo').ondragstart=function () {return false;}
     document.getElementById('navigationButtons').ondragstart=function () {return false;}
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -393,6 +393,10 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             document.getElementById('modes').scrollIntoView();
         }, 600);
     });
+
+    //Adds an event listener to kiwix logo and bottom navigation bar which gets triggered when these elements are dragged.
+    //Returning false prevents their dragging(which can cause some unexpected behavior)
+    document.getElementById('kiwixLogo').ondragstart=function () {return false;}
     document.getElementById('navigationButtons').ondragstart=function () {return false;}
 
     //focus search bar (#prefix) if Home key is pressed


### PR DESCRIPTION
Fixes #782
Added the attribute `draggable=false` to the bottom navigation bar to prevent it from causing unexpected behavior.
