### PR TITLE
Revert check for PWA existence prior to passthrough

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -856,7 +856,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         var response;
         if (settingsStore.getItem('allowInternetAccess') === 'true') {
             if (PWASuccessfullyLaunched) {
-                checkPWAIsOnline();
+                launchPWA();
             } else {
                 response = confirm('The last attempt to launch the PWA appears to have failed.\n\nDo you wish to try again?');
                 if (response) {


### PR DESCRIPTION
Fixes #795.

The reason the code did not work is that this check is made from the extension, while the Service Worker of the https://moz-extension.kiwix.org implementation is suspended, because that page is not active. Loading an image from a domain appears not to be sufficient to wake up the Service Worker controlling that domain (and for good reason!).

We could possibly wake up the Service Worker so that it can indicate that it is installed if we loaded the app into an iframe. But that seems like real overkill and it would introduce a noticeable delay between launching the app and passing through to SW mode. We would essentially have to load the PWA twice, once in an iframe to confirm that it is available, and again when we pass through. The only gain is in some rare edge cases where the following conditions are met:

* User has successfully launched the PWA;
* User has, in the meantime, emptied all caches / deleted Web data in browser;
* User has put their machine into offline mode;
* User attempts to launch the app while still offline.

If all those conditions are met, then the user will be passed through to a non-functioning app / blank page, and will be confused. However, a simple re-launch of the app will enable the app to run in jQuery mode (offline), and a dialogue box will inform the user what has happened.

If the user meets all the above conditions, but does have Internet access, then they won't notice anything, and the app will reload from the server and the Service Worker will re-install itself transparently.

Therefore, I think this qualifies as an edge case, and we can revert this.