### PR TITLE
Provide methods for resetting the app and bypassing appCache

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -239,15 +239,18 @@ self.addEventListener('message', function (event) {
             outgoingMessagePort = null;
             fetchCaptureEnabled = false;
         }
+        var oldValue;
         if (event.data.action.assetsCache) {
             // Turns caching on or off (a string value of 'enable' turns it on, any other string turns it off)
+            oldValue = useAssetsCache;
             useAssetsCache = event.data.action.assetsCache === 'enable';
-            console.debug('[SW] Use of assetsCache was switched to: ' + event.data.action.assetsCache);
+            if (useAssetsCache !== oldValue) console.debug('[SW] Use of assetsCache was switched to: ' + event.data.action.assetsCache);
         }
         if (event.data.action.appCache) {
             // Enables or disables use of appCache
+            oldValue = useAppCache;
             useAppCache = event.data.action.appCache === 'enable';
-            console.debug('[SW] Use of appCache was switched to: ' + event.data.action.appCache);
+            if (useAppCache !== oldValue) console.debug('[SW] Use of appCache was switched to: ' + event.data.action.appCache);
         }
         if (event.data.action === 'getCacheNames') {
             event.ports[0].postMessage({ 'app': APP_CACHE, 'assets': ASSETS_CACHE });

--- a/service-worker.js
+++ b/service-worker.js
@@ -55,6 +55,14 @@ const APP_CACHE = 'kiwixjs-appCache-' + appVersion;
  */
 var useCache = true;
 
+/**
+ * A global Boolean that governs whether the APP_CACHE will be used
+ * This is an expert setting in Configuration
+ * @type {Boolean}
+ */
+ var appCache = true;
+
+
 /**  
  * A regular expression that matches the Content-Types of assets that may be stored in ASSETS_CACHE
  * Add any further Content-Types you wish to cache to the regexp, separated by '|'
@@ -236,6 +244,11 @@ self.addEventListener('message', function (event) {
             useCache = event.data.action.useCache === 'on';
             console.debug('[SW] Caching was turned ' + event.data.action.useCache);
         }
+        if (event.data.action.appCache) {
+            // Enables or disables use of appCache
+            appCache = event.data.action.appCache === 'enable';
+            console.debug('[SW] Use of appCache was switched to: ' + event.data.action.appCache);
+        }
         if (event.data.action === 'getCacheNames') {
             event.ports[0].postMessage({ 'app': APP_CACHE, 'assets': ASSETS_CACHE });
         }
@@ -328,7 +341,7 @@ function removeUrlParameters(url) {
  */
 function fromCache(cache, requestUrl) {
     // Prevents use of Cache API if user has disabled it
-    if (!useCache && cache === ASSETS_CACHE) return Promise.reject('disabled');
+    if (!appCache && cache === APP_CACHE || ! useCache && cache === ASSETS_CACHE) return Promise.reject('disabled');
     return caches.open(cache).then(function (cacheObj) {
         return cacheObj.match(requestUrl).then(function (matching) {
             if (!matching || matching.status === 404) {
@@ -349,7 +362,7 @@ function fromCache(cache, requestUrl) {
  */
 function updateCache(cache, request, response) {
     // Prevents use of Cache API if user has disabled it
-    if (!useCache && cache === ASSETS_CACHE) return Promise.resolve();
+    if (!appCache && cache === APP_CACHE || ! useCache && cache === ASSETS_CACHE) return Promise.resolve();
     return caches.open(cache).then(function (cacheObj) {
         console.debug('[SW] Adding ' + request.url + ' to ' + cache + '...');
         return cacheObj.put(request, response);

--- a/service-worker.js
+++ b/service-worker.js
@@ -239,10 +239,10 @@ self.addEventListener('message', function (event) {
             outgoingMessagePort = null;
             fetchCaptureEnabled = false;
         }
-        if (event.data.action.useCache) {
-            // Turns caching on or off (a string value of 'on' turns it on, any other string turns it off)
-            useAssetsCache = event.data.action.useCache === 'on';
-            console.debug('[SW] Caching was turned ' + event.data.action.useCache);
+        if (event.data.action.assetsCache) {
+            // Turns caching on or off (a string value of 'enable' turns it on, any other string turns it off)
+            useAssetsCache = event.data.action.assetsCache === 'enable';
+            console.debug('[SW] Use of assetsCache was switched to: ' + event.data.action.assetsCache);
         }
         if (event.data.action.appCache) {
             // Enables or disables use of appCache

--- a/service-worker.js
+++ b/service-worker.js
@@ -250,13 +250,13 @@ let fetchCaptureEnabled = false;
             // Turns caching on or off (a string value of 'enable' turns it on, any other string turns it off)
             oldValue = useAssetsCache;
             useAssetsCache = event.data.action.assetsCache === 'enable';
-            if (useAssetsCache !== oldValue) console.debug('[SW] Use of assetsCache was switched to: ' + event.data.action.assetsCache);
+            if (useAssetsCache !== oldValue) console.debug('[SW] Use of assetsCache was switched to: ' + useAssetsCache);
         }
         if (event.data.action.appCache) {
             // Enables or disables use of appCache
             oldValue = useAppCache;
             useAppCache = event.data.action.appCache === 'enable';
-            if (useAppCache !== oldValue) console.debug('[SW] Use of appCache was switched to: ' + event.data.action.appCache);
+            if (useAppCache !== oldValue) console.debug('[SW] Use of appCache was switched to: ' + useAppCache);
         }
         if (event.data.action === 'getCacheNames') {
             event.ports[0].postMessage({ 'app': APP_CACHE, 'assets': ASSETS_CACHE });

--- a/service-worker.js
+++ b/service-worker.js
@@ -53,14 +53,14 @@ const APP_CACHE = 'kiwixjs-appCache-' + appVersion;
  * Caching is on by default but can be turned off by the user in Configuration
  * @type {Boolean}
  */
-var useCache = true;
+var useAssetsCache = true;
 
 /**
  * A global Boolean that governs whether the APP_CACHE will be used
  * This is an expert setting in Configuration
  * @type {Boolean}
  */
- var appCache = true;
+ var useAppCache = true;
 
 
 /**  
@@ -241,12 +241,12 @@ self.addEventListener('message', function (event) {
         }
         if (event.data.action.useCache) {
             // Turns caching on or off (a string value of 'on' turns it on, any other string turns it off)
-            useCache = event.data.action.useCache === 'on';
+            useAssetsCache = event.data.action.useCache === 'on';
             console.debug('[SW] Caching was turned ' + event.data.action.useCache);
         }
         if (event.data.action.appCache) {
             // Enables or disables use of appCache
-            appCache = event.data.action.appCache === 'enable';
+            useAppCache = event.data.action.appCache === 'enable';
             console.debug('[SW] Use of appCache was switched to: ' + event.data.action.appCache);
         }
         if (event.data.action === 'getCacheNames') {
@@ -341,7 +341,7 @@ function removeUrlParameters(url) {
  */
 function fromCache(cache, requestUrl) {
     // Prevents use of Cache API if user has disabled it
-    if (!appCache && cache === APP_CACHE || ! useCache && cache === ASSETS_CACHE) return Promise.reject('disabled');
+    if (!useAppCache && cache === APP_CACHE || !useAssetsCache && cache === ASSETS_CACHE) return Promise.reject('disabled');
     return caches.open(cache).then(function (cacheObj) {
         return cacheObj.match(requestUrl).then(function (matching) {
             if (!matching || matching.status === 404) {
@@ -362,7 +362,7 @@ function fromCache(cache, requestUrl) {
  */
 function updateCache(cache, request, response) {
     // Prevents use of Cache API if user has disabled it
-    if (!appCache && cache === APP_CACHE || ! useCache && cache === ASSETS_CACHE) return Promise.resolve();
+    if (!useAppCache && cache === APP_CACHE || !useAssetsCache && cache === ASSETS_CACHE) return Promise.resolve();
     return caches.open(cache).then(function (cacheObj) {
         console.debug('[SW] Adding ' + request.url + ' to ' + cache + '...');
         return cacheObj.put(request, response);
@@ -377,7 +377,7 @@ function updateCache(cache, request, response) {
  */
 function testCacheAndCountAssets(url) {
     if (regexpExcludedURLSchema.test(url)) return Promise.resolve(['custom', 'custom', 'Custom', '-']);
-    if (!useCache) return Promise.resolve(['none', 'none', 'None', 0]);
+    if (!useAssetsCache) return Promise.resolve(['none', 'none', 'None', 0]);
     return caches.open(ASSETS_CACHE).then(function (cache) {
         return cache.keys().then(function (keys) {
             return ['cacheAPI', ASSETS_CACHE, 'Cache API', keys.length];

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,7 +3,7 @@
  * in order to capture the HTTP requests made by an article, and respond with the
  * corresponding content, coming from the archive
  * 
- * Copyright 2015 Mossroy and contributors
+ * Copyright 2022 Mossroy, Jaifroid and contributors
  * License GPL v3:
  * 
  * This file is part of Kiwix.
@@ -184,7 +184,10 @@ self.addEventListener('activate', function (event) {
 let outgoingMessagePort = null;
 let fetchCaptureEnabled = false;
 
-self.addEventListener('fetch', function (event) {
+/**
+ * Intercept selected Fetch requests from the browser window
+ */
+ self.addEventListener('fetch', function (event) {
     // Only cache GET requests
     if (event.request.method !== "GET") return;
     // Remove any querystring before requesting from the cache
@@ -215,20 +218,23 @@ self.addEventListener('fetch', function (event) {
             } else {
                 // It's not an asset, or it doesn't match a ZIM URL pattern, so we should fetch it with Fetch API
                 return fetch(event.request).then(function (response) {
-                  // If request was successful, add or update it in the cache, but be careful not to cache the ZIM archive itself!
-                  if (!regexpExcludedURLSchema.test(rqUrl) && !/\.zim\w{0,2}$/i.test(rqUrl)) {
-                    event.waitUntil(updateCache(APP_CACHE, event.request, response.clone()));
-                  }
-                  return response;
+                    // If request was successful, add or update it in the cache, but be careful not to cache the ZIM archive itself!
+                    if (!regexpExcludedURLSchema.test(rqUrl) && !/\.zim\w{0,2}$/i.test(rqUrl)) {
+                        event.waitUntil(updateCache(APP_CACHE, event.request, response.clone()));
+                    }
+                    return response;
                 }).catch(function (error) {
-                  console.debug("[SW] Network request failed and no cache.", error);
+                    console.debug("[SW] Network request failed and no cache.", error);
                 });
             }
         })
     );
 });
 
-self.addEventListener('message', function (event) {
+/**
+ * Handle custom commands sent from app.js
+ */
+ self.addEventListener('message', function (event) {
     if (event.data.action) {
         if (event.data.action === 'init') {
             // On 'init' message, we initialize the outgoingMessagePort and enable the fetchEventListener

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -105,6 +105,10 @@
     background: #171717;
 }
 
+.dark .card-warning .card-header {
+    background-color: #FFFF00;
+}
+
 /* End of app theme: dark */
 
 /* Content themes: _invert, _mwInvert */

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -222,6 +222,11 @@ button {
     margin: 2px;
 }
 
+.btn-danger {
+    background-color: lightyellow;
+    color: darkred;
+}
+
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }

--- a/www/index.html
+++ b/www/index.html
@@ -251,8 +251,8 @@
                     <h4 id="format">ZIM archive format</h4>
                     <p>
                         Offline archives use the <a href="https://www.openzim.org//wiki/OpenZIM" target="_blank">OpenZIM format&nbsp;<img src="img/Icon_External_Link.png" /></a>,
-                        but note that this app has only been tested extensively on Wikipedia, WikiMedia and Stackexchage archives. Video content is in principle supported
-                        if your device, browser or OS understands the format. Some other ZIMs use a proprietary dynamic UI which is only supported in ServiceWorker Mode
+                        but note that this app has only been tested extensively on Wikipedia, WikiMedia, Gutenberg, Stackexchage and TED Talks archives. Video content is
+                        supported if your device, browser or OS understands the format. Some ZIMs use a proprietary dynamic UI which is only supported in ServiceWorker Mode
                         (<a href="#modes">see below</a>).
                     </p>
 
@@ -441,14 +441,6 @@
                             <div class="card-header">Display options:</div>
                             <div class="card-body">
                                 <div class="checkbox">
-                                    <label title="A warning is shown if you load a ZIM that has active or dynamic content while you are in JQuery mode. It is not recommended to disable this warning." >
-                                        <input type="checkbox" name="hideActiveContentWarning"
-                                            id="hideActiveContentWarningCheck">
-                                        <strong>Permanently hide active content warning</strong> (for
-                                        experienced users)
-                                    </label>
-                                </div>
-                                <div class="checkbox">
                                     <label title="The animation is on by default and can be disabled by unchecking this option." >
                                         <input type="checkbox" name="showUIAnimations" id="showUIAnimationsCheck"
                                             checked>
@@ -554,7 +546,7 @@
                                     <label title="This mode requires that the browser or framework be capable of installing a Service Worker. It works by intercepting the browser or framework's Fetch calls and supplying the requested content from the ZIM.">
                                         <input type="radio" name="contentInjectionMode" value="serviceworker"
                                             id="serviceworkerModeRadio">
-                                        <strong>ServiceWorker</strong> (supports archives with dynamic content, requires secure context)
+                                        <strong>ServiceWorker</strong> (supports archives with dynamic content)
                                     </label>
                                 </div>
                             </div>
@@ -566,10 +558,12 @@
                         <div class="card card-danger" id="expertSettingsDiv">
                             <div class="card-header">Troubleshooting and development</div>
                             <div class="card-body">
-                                <p>Reset the app to default settings and erase all caches:</p>
-                                <div class="button">
-                                    <label title="This will return the app to its original settings on launch, and will empty all caches and settings and deregister Service Workers. The app will then reload.">
-                                        <button type="button" class="btn btn-danger" id="btnReset">Reset</button> Full app reset
+                                <div class="checkbox">
+                                    <label title="A warning is shown if you load a ZIM that has active or dynamic content while you are in JQuery mode. It is not recommended to disable this warning." >
+                                        <input type="checkbox" name="hideActiveContentWarning"
+                                            id="hideActiveContentWarningCheck">
+                                        <strong>Permanently hide active content warning</strong> (for
+                                        experienced users)
                                     </label>
                                 </div>
                                 <div class="checkbox" id="bypassAppCacheDiv">
@@ -577,6 +571,12 @@
                                         title="WARNING: Leaving this checked will prevent offline usage of the PWA. Setting will clear all existing Cache API caches, but assetsCache will be used unless also disabled above. For testing new code with the PWA.">
                                         <input type="checkbox" name="bypassAppCache" id="bypassAppCacheCheck">
                                         <b>Bypass AppCache</b> (<i>disables offline use of PWA!</i>)
+                                    </label>
+                                </div>
+                                <p class="pt-2">Reset the app to default settings and erase all caches:</p>
+                                <div class="button">
+                                    <label title="This will return the app to its original settings on launch, and will empty all caches and settings and deregister Service Workers. The app will then reload.">
+                                        <button type="button" class="btn btn-danger" id="btnReset">Reset App</button>
                                     </label>
                                 </div>
                             </div>
@@ -614,7 +614,7 @@
                         <strong>Unable to display active content:</strong> This ZIM is not fully supported in jQuery mode.<br />
                         Content may be available by searching above (type a space or a letter of the alphabet), or else 
                         <a id="swModeLink" href="#contentInjectionModeDiv" class="alert-link">switch to Service Worker mode</a>
-                        if your platform supports it. &nbsp;[<a id="stop" href="#displaySettingsDiv" class="alert-link">Permanently hide</a>]
+                        if your platform supports it. &nbsp;[<a id="stop" href="#expertSettingsDiv" class="alert-link">Permanently hide</a>]
                     </div>
                 </div>
                 <iframe id="articleContent" class="articleIFrame" src="article.html"></iframe>

--- a/www/index.html
+++ b/www/index.html
@@ -563,12 +563,12 @@
                             <div class="row">
                                 <div class="col-sm-5">
                                     <label title="This will return the app to its original settings on launch, and will empty all caches and settings and deregister Service Workers. The app will then reload.">
-                                        <button type="button" class="btn btn-danger" id="btnReset">Reset</button> Full app reset!
+                                        <button type="button" class="btn btn-danger" id="btnReset">Reset</button> Full app reset
                                     </label>
                                 </div>
                                 <div class="col-sm-7">
                                     <label
-                                        title="WARNING: Leaving this checked will prevent offline usage of the PWA. This setting is intended principally for developers to test new code with the PWA. Setting will clear existing caches, but assetsCache will be enabled unless also disabled above.">
+                                        title="WARNING: Leaving this checked will prevent offline usage of the PWA. Setting will clear all existing Cache API caches, but assetsCache will be used unless also disabled above. For testing new code with the PWA.">
                                         <input type="checkbox" name="bypassAppCache" id="bypassAppCacheCheck">
                                         <b>Bypass AppCache</b> (<i>disables offline use of PWA!</i>)
                                     </label>

--- a/www/index.html
+++ b/www/index.html
@@ -561,19 +561,16 @@
                         </div>
                         <div class="card card-danger card-footer">
                             <div class="row">
-                                <div class="col-sm-4">
-                                    <label title="This will return the app to its original settings on launch, and will empty all caches and settings. The app will reload.">
-                                        <button class="btn btn-danger" id="btnReset">
-                                            Reset
-                                        </button>
-                                        Performs a complete app reset
+                                <div class="col-sm-5">
+                                    <label title="This will return the app to its original settings on launch, and will empty all caches and settings and deregister Service Workers. The app will then reload.">
+                                        <button type="button" class="btn btn-danger" id="btnReset">Reset</button> Full app reset!
                                     </label>
                                 </div>
-                                <div class="col-sm-8">
+                                <div class="col-sm-7">
                                     <label
-                                        title="This allows developers to test new code. WARNING: Leaving this checked will prevent offline functionality!">
+                                        title="WARNING: Leaving this checked will prevent offline usage of the PWA. This setting is intended principally for developers to test new code with the PWA. Setting will clear existing caches, but assetsCache will be enabled unless also disabled above.">
                                         <input type="checkbox" name="bypassAppCache" id="bypassAppCacheCheck">
-                                        <b>Prevent use of appCache</b> (<i>for developers</i>)
+                                        <b>Bypass AppCache</b> (<i>disables offline use of PWA!</i>)
                                     </label>
                                 </div>
                             </div>

--- a/www/index.html
+++ b/www/index.html
@@ -559,12 +559,24 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="card card-danger">
-                            <button class="btn btn-danger" id="btnReset" 
-                                title="This will return the app to its original settings on launch, and will empty all caches and settings. The app will reload.">
-                                Reset
-                            </button>
-                            Performs a complete app reset (will remove all caches and settings)
+                        <div class="card card-danger card-footer">
+                            <div class="row">
+                                <div class="col-sm-4">
+                                    <label title="This will return the app to its original settings on launch, and will empty all caches and settings. The app will reload.">
+                                        <button class="btn btn-danger" id="btnReset">
+                                            Reset
+                                        </button>
+                                        Performs a complete app reset
+                                    </label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <label
+                                        title="This allows developers to test new code. WARNING: Leaving this checked will prevent offline functionality!">
+                                        <input type="checkbox" name="bypassAppCache" id="bypassAppCacheCheck">
+                                        <b>Prevent use of appCache</b> (<i>for developers</i>)
+                                    </label>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <br />

--- a/www/index.html
+++ b/www/index.html
@@ -559,6 +559,13 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="card card-danger">
+                            <button class="btn btn-danger" id="btnReset" 
+                                title="This will return the app to its original settings on launch, and will empty all caches and settings. The app will reload.">
+                                Reset
+                            </button>
+                            Performs a complete app reset (will remove all caches and settings)
+                        </div>
                     </div>
                     <br />
                     <div class="container">

--- a/www/index.html
+++ b/www/index.html
@@ -106,7 +106,7 @@
                         <li><a href="#searchSyntax">Title Search Usage</a></li>
                         <li><a href="#imageDownload">Image Download</a></li>
                         <li><a href="#privacy">Privacy Policy</a></li>
-                        <li><a href="#expert">Expert Settings and Technical Information</a>
+                        <li><a href="#technical">Technical Information</a>
                             <ul>
                                 <li><a href="#format">ZIM Archive Format</a></li>
                                 <li><a href="#FAT">Downloading and Storing Large Archives</a></li>
@@ -246,7 +246,7 @@
                     </p>
                     <p style="text-align: right"><a href="#contents">↑ Back to Contents</a></p>
                     
-                    <h3 id="expert">Expert settings and technical information</h3>
+                    <h3 id="technical">Technical information</h3>
 
                     <h4 id="format">ZIM archive format</h4>
                     <p>
@@ -280,7 +280,7 @@
                     <h4 id="modes">JQuery and ServiceWorker Modes</h4>
                     <p>
                         Depending on your browser or framework, this app may be capable of running in two different modes, which we call
-                        "JQuery Mode" and "ServiceWorker Mode" for short. There is a toggle under Expert Settings in Configuration.
+                        "JQuery Mode" and "ServiceWorker Mode" for short. There is a toggle under Compatibility Settings in Configuration.
                         Here is a technical explanation of what these modes do:
                         <ul>
                             <li>
@@ -292,7 +292,8 @@
                                 but it is compensated for because we do not extract or run JavaScript assets (which would be technically
                                 extremely complicated). As a result, for WikiMedia archives this mode is usually quite fast. On the downside,
                                 ZIMs that have a proprietary dynamic UI (such as Gutenberg or TED talks) are only partially supported in this
-                                mode: the UI does not work, but articles can be searched for and loaded from the search bar.
+                                mode: the UI does not work, but articles can be searched for and loaded from the search bar. This mode is
+                                compatible with older browsers and frameworks.
                             </li>
                             <li>
                                 <b>ServiceWorker Mode</b>: This mode, as its name implies, requires that the browser or framework be capable of
@@ -300,8 +301,8 @@
                                 and supplying the requested content from the ZIM. This mode requires no DOM traversal, and the content is
                                 read and supplied as-is from the archive. Dynamic content (e.g. JavaScript) and proprietary UIs are fully
                                 supported in this mode. It can feel initially a little slower while commonly used assets are being cached,
-                                but it soon equals JQuery mode in speed, at least in modern browsers. However, older browsers such as IE11 do
-                                not support this mode, and the app must be running in a secure context (<code>https:</code>, <code>localhost</code>,
+                                but it soon equals JQuery mode in speed, at least in modern browsers. However, older browsers such as IE11 are
+                                incompatible with this mode, and the app must be running in a secure context (<code>https:</code>, <code>localhost</code>,
                                 or certain browser extensions). While this mode is not natively supported in Mozilla (Firefox) browser
                                 extensions, we provide a functional workaround by re-launching the extension as a Progressive Web App (PWA).
                                 Note that this mode cannot run with the <code>file:</code> protocol (but only IE11 and old Edge allow the app to run
@@ -537,36 +538,41 @@
                     </div>
                     <br />
                     <div class="container">
-                        <h3>Expert settings</h3>
-                        <div class="card card-danger" id="contentInjectionModeDiv">
+                        <h3>Compatibility settings</h3>
+                        <div class="card card-warning" id="contentInjectionModeDiv">
                             <div class="card-header">Content injection mode</div>
                             <div class="card-body">
-                                <p>See <a href="#modes" id="modesLink">About (Expert Settings)</a> for an explanation of the difference between these modes:</p>
+                                <p>See <a href="#modes" id="modesLink">About (Technical Information)</a> for an explanation of the difference between these modes:</p>
                                 <div class="radio">
                                     <label title="This mode is fine for everyday use with Wikipedia / WikiMedia archives, and is stable and safe.">
                                         <input type="radio" name="contentInjectionMode" value="jquery"
                                             id="jQueryModeRadio" checked>
-                                        <strong>JQuery</strong> (stable and safe)
+                                        <strong>JQuery</strong> (compatible with older browsers and frameworks)
                                     </label>
                                 </div>
                                 <div class="radio">
                                     <label title="This mode requires that the browser or framework be capable of installing a Service Worker. It works by intercepting the browser or framework's Fetch calls and supplying the requested content from the ZIM.">
                                         <input type="radio" name="contentInjectionMode" value="serviceworker"
                                             id="serviceworkerModeRadio">
-                                        <strong>ServiceWorker</strong> (not available on all platforms, but supports
-                                        more ZIM files)
+                                        <strong>ServiceWorker</strong> (supports archives with dynamic content, requires secure context)
                                     </label>
                                 </div>
                             </div>
                         </div>
-                        <div class="card card-danger card-footer">
-                            <div class="row">
-                                <div class="col-sm-5">
+                    </div>
+                    <br />
+                    <div class="container">
+                        <h3>Expert settings</h3>
+                        <div class="card card-danger" id="expertSettingsDiv">
+                            <div class="card-header">Troubleshooting and development</div>
+                            <div class="card-body">
+                                <p>Reset the app to default settings and erase all caches:</p>
+                                <div class="button">
                                     <label title="This will return the app to its original settings on launch, and will empty all caches and settings and deregister Service Workers. The app will then reload.">
                                         <button type="button" class="btn btn-danger" id="btnReset">Reset</button> Full app reset
                                     </label>
                                 </div>
-                                <div class="col-sm-7">
+                                <div class="checkbox" id="bypassAppCacheDiv">
                                     <label
                                         title="WARNING: Leaving this checked will prevent offline usage of the PWA. Setting will clear all existing Cache API caches, but assetsCache will be used unless also disabled above. For testing new code with the PWA.">
                                         <input type="checkbox" name="bypassAppCache" id="bypassAppCacheCheck">

--- a/www/index.html
+++ b/www/index.html
@@ -266,7 +266,7 @@
                     </p>
                     <p>
                         If you need to store a large ZIM archive on an older filesystem formatted as FAT16 or FAT32, you need to be aware of the file size limits of those systems
-                        (FAT16 < 2GiB; FAT32 < 4GiB). Most modern microSD cards, thumb drives or hard drives are formatted as exFAT or another modern FS such as NTFS, which do not
+                        (FAT16 &lt; 2GiB; FAT32 &lt; 4GiB). Most modern microSD cards, thumb drives or hard drives are formatted as exFAT or another modern FS such as NTFS, which do not
                         have this issue. If your ZIM archive is larger than the FS limit, it is possible to split the archive into several 2GiB-1 or 4GiB-1 files (or smaller).
                         You will need to give a file extension to each chunk in the right order following this pattern: <code>*.zimaa</code>, <code>*.zimab</code>, <code>*.zimac</code>,
                         <code>...</code>, etc.). When you pick this archive in the app, be sure to pick <b>all</b> the chunks, or drag-and-drop them all into the app.

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -464,12 +464,14 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             refreshCacheStatus();
         }
     });
+    var titleSearchRangeVal = document.getElementById('titleSearchRangeVal');
     document.getElementById('titleSearchRange').addEventListener('change', function(e) {
         settingsStore.setItem('maxSearchResultsSize', e.target.value, Infinity);
         params.maxSearchResultsSize = e.target.value;
+        titleSearchRangeVal.innerHTML = e.target.value;
     });
     document.getElementById('titleSearchRange').addEventListener('input', function(e) {
-        document.getElementById('titleSearchRangeVal').innerHTML = e.target.value;
+        titleSearchRangeVal.innerHTML = e.target.value;
     });
     document.getElementById('modesLink').addEventListener('click', function () {
         document.getElementById('btnAbout').click();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -411,6 +411,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         // Do the necessary to enable or disable the Service Worker
         setContentInjectionMode(this.value);
     });
+    document.getElementById('btnReset').addEventListener('click', function () {
+        settingsStore.reset();
+    });
     $('input:checkbox[name=hideActiveContentWarning]').on('change', function () {
         params.hideActiveContentWarning = this.checked ? true : false;
         settingsStore.setItem('hideActiveContentWarning', params.hideActiveContentWarning, Infinity);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -711,7 +711,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 var channel = new MessageChannel();
                 if (isServiceWorkerAvailable() && navigator.serviceWorker.controller) {
                     navigator.serviceWorker.controller.postMessage({
-                        'action': { 'assetsCache': 'off' }
+                        'action': { 'assetsCache': 'disable' }
                     }, [channel.port2]);
                 }
                 caches.delete(ASSETS_CACHE);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -570,9 +570,12 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         }
         apiName = params.decompressorAPI.errorStatus || apiName || 'Not initialized';
         decompAPIStatusDiv.innerHTML = 'Decompressor API: ' + apiName;
-
         // Add a warning colour to the API Status Panel if any of the above tests failed
         apiStatusPanel.classList.add(apiPanelClass);
+
+        // Set visibility of UI elements according to mode
+        document.getElementById('bypassAppCacheDiv').style.display = params.contentInjectionMode === 'serviceworker' ? 'block' : 'none';
+
     }
 
     /**

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -154,7 +154,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     document.getElementById('hideActiveContentWarningCheck').checked = params.hideActiveContentWarning;
     document.getElementById('showUIAnimationsCheck').checked = params.showUIAnimations;
     document.getElementById('titleSearchRange').value = params.maxSearchResultsSize;
-    document.getElementById('titleSearchRangeVal').textContent = encodeURIComponent(params.maxSearchResultsSize);
+    document.getElementById('titleSearchRangeVal').textContent = params.maxSearchResultsSize;
     document.getElementById('appThemeSelect').value = params.appTheme;
     uiUtil.applyAppTheme(params.appTheme);
     document.getElementById('useHomeKeyToFocusSearchBarCheck').checked = params.useHomeKeyToFocusSearchBar;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -82,9 +82,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     params['showUIAnimations'] = settingsStore.getItem('showUIAnimations') ? settingsStore.getItem('showUIAnimations') === 'true' : true;
     // Maximum number of article titles to return (range is 5 - 50, default 25)
     params['maxSearchResultsSize'] = settingsStore.getItem('maxSearchResultsSize') || 25;
-    // A global parameter that turns caching on or off and deletes the cache (it defaults to true unless explicitly turned off in UI)
+    // Turns caching of assets on or off and deletes the cache (it defaults to true unless explicitly turned off in UI)
     params['assetsCache'] = settingsStore.getItem('assetsCache') !== 'false';
-    // A global parameter that disables use of the appCache (it defaults to true unless explicitly turned off in UI)
+    // Turns caching of the PWA's code on or off and deletes the cache (it defaults to true unless the bypass option is set in Expert Settings)
     params['appCache'] = settingsStore.getItem('appCache') !== 'false';
     // A parameter to set the app theme and, if necessary, the CSS theme for article content (defaults to 'light')
     params['appTheme'] = settingsStore.getItem('appTheme') || 'light'; // Currently implemented: light|dark|dark_invert|dark_mwInvert

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -575,7 +575,6 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
 
         // Set visibility of UI elements according to mode
         document.getElementById('bypassAppCacheDiv').style.display = params.contentInjectionMode === 'serviceworker' ? 'block' : 'none';
-
     }
 
     /**
@@ -684,6 +683,11 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     function setContentInjectionMode(value) {
         params.contentInjectionMode = value;
         if (value === 'jquery') {
+            if (!params.appCache) {
+                alert('You must deselect the "Bypass AppCache" option before switching to JQuery mode!');
+                setContentInjectionMode('serviceworker');
+                return;
+            }
             if (params.referrerExtensionURL) {
                 // We are in an extension, and the user may wish to revert to local code
                 var message = 'This will switch to using locally packaged code only. Some configuration settings may be lost.\n\n' +

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -154,7 +154,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     document.getElementById('hideActiveContentWarningCheck').checked = params.hideActiveContentWarning;
     document.getElementById('showUIAnimationsCheck').checked = params.showUIAnimations;
     document.getElementById('titleSearchRange').value = params.maxSearchResultsSize;
-    document.getElementById('titleSearchRangeVal').innerHTML = encodeURIComponent(params.maxSearchResultsSize);
+    document.getElementById('titleSearchRangeVal').textContent = encodeURIComponent(params.maxSearchResultsSize);
     document.getElementById('appThemeSelect').value = params.appTheme;
     uiUtil.applyAppTheme(params.appTheme);
     document.getElementById('useHomeKeyToFocusSearchBarCheck').checked = params.useHomeKeyToFocusSearchBar;
@@ -468,10 +468,10 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     document.getElementById('titleSearchRange').addEventListener('change', function(e) {
         settingsStore.setItem('maxSearchResultsSize', e.target.value, Infinity);
         params.maxSearchResultsSize = e.target.value;
-        titleSearchRangeVal.innerHTML = e.target.value;
+        titleSearchRangeVal.textContent = e.target.value;
     });
     document.getElementById('titleSearchRange').addEventListener('input', function(e) {
-        titleSearchRangeVal.innerHTML = e.target.value;
+        titleSearchRangeVal.textContent = e.target.value;
     });
     document.getElementById('modesLink').addEventListener('click', function () {
         document.getElementById('btnAbout').click();

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -108,12 +108,10 @@ define([], function () {
       var foundCrumb = false;
       var cookieCrumb = regexpCookieKeys.exec(currentCookie);
       while (cookieCrumb !== null) {
-        // If the cookie crumb starts with the keyPrefix
-        if (~decodeURIComponent(cookieCrumb[0]).indexOf(params.keyPrefix)) {
-          foundCrumb = true;
-          // This expiry date will cause the browser to delete the cookie crumb on next page refresh
-          document.cookie = cookieCrumb[1] + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
-        }
+        // DEV: Note that we don't use the keyPrefix in legacy cookie support
+        foundCrumb = true;
+        // This expiry date will cause the browser to delete the cookie crumb on next page refresh
+        document.cookie = cookieCrumb[1] + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
         cookieCrumb = regexpCookieKeys.exec(currentCookie);
       }
       if (foundCrumb) console.debug('All cookie keys were expired...');

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -94,7 +94,7 @@ define([], function () {
 
   /**
    * Performs a full app reset, deleting all caches and settings
-   * Or, if a paramter is supplied, deletes or disables the object
+   * Or, if a parameter is supplied, deletes or disables the object
    * @param {String} object Optional name of the object to disable or delete ('cookie', 'localStorage', 'cacheAPI')
    */
   function reset(object) {
@@ -103,21 +103,20 @@ define([], function () {
     
     // 1. Clear any cookie entries
     if (!object || object === 'cookie') {
-      var cookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;
+      var regexpCookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;
       var currentCookie = document.cookie;
-      var cookieCrumb = cookieKeys.exec(currentCookie);
-      var cook = false;
+      var foundCrumb = false;
+      var cookieCrumb = regexpCookieKeys.exec(currentCookie);
       while (cookieCrumb !== null) {
-        // If the cookie key starts with the keyPrefix
-        if (~params.keyPrefix.indexOf(decodeURIComponent(cookieCrumb[0]))) {
-          cook = true;
-          key = cookieCrumb[1];
-          // This expiry date will cause the browser to delete the cookie on next page refresh
-          document.cookie = key + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
+        // If the cookie crumb starts with the keyPrefix
+        if (~decodeURIComponent(cookieCrumb[0]).indexOf(params.keyPrefix)) {
+          foundCrumb = true;
+          // This expiry date will cause the browser to delete the cookie crumb on next page refresh
+          document.cookie = cookieCrumb[1] + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
         }
-        cookieCrumb = cookieKeys.exec(currentCookie);
+        cookieCrumb = regexpCookieKeys.exec(currentCookie);
       }
-      if (cook) console.debug('All cookie keys were expiered...');
+      if (foundCrumb) console.debug('All cookie keys were expired...');
     }
 
     // 2. Clear any localStorage settings

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -42,7 +42,8 @@ define([], function () {
    * @type {Array}
    */
   var deprecatedKeys = [
-    'lastContentInjectionMode'
+    'lastContentInjectionMode',
+    'useCache'
   ];
 
   /**
@@ -140,14 +141,14 @@ define([], function () {
               if (!cnt) {
                 // All caches deleted
                 console.debug('All Cache API caches were deleted...');
-                if (!object || !params.disableAppCache) _reloadApp();
+                if (!object || params.appCache) _reloadApp();
               }
             });
           };
         } else {
           console.debug('No Cache API caches were in use (or we do not have access to the names).');
           // All operations complete
-          if (!object || !params.disableAppCache) _reloadApp();
+          if (!object || params.appCache) _reloadApp();
         }
       });
     }

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -172,7 +172,7 @@ define([], function () {
     var reboot = function () {
       console.debug('Performing app reload...');
       setTimeout(function () {
-        window.location.search = uriParams;
+        window.location.href = location.origin + location.pathname + uriParams 
       }, 300);
     };
     // Compile a sensible querystring, so that parameters are not set on reload

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -175,9 +175,11 @@ define([], function () {
         window.location.href = location.origin + location.pathname + uriParams 
       }, 300);
     };
-    // Compile a sensible querystring, so that parameters are not set on reload
+    // Blank the querystring, so that parameters are not set on reload
     var uriParams = '';
     if (~window.location.href.indexOf(params.PWAServer) && params.referrerExtensionURL) {
+      // However, if we're in a PWA that was called from local code, then by definition we must remain in SW mode and we need to
+      // ensure the user still has access to the referrerExtensionURL (so they can get back to local code from the UI)
       uriParams = '?allowInternetAccess=truee&contentInjectionMode=serviceworker';
       uriParams += '&referrerExtensionURL=' + encodeURIComponent(params.referrerExtensionURL);
     }

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -144,7 +144,7 @@ define([], function () {
                 if (!object || params.appCache) _reloadApp();
               }
             });
-          };
+          }
         } else {
           console.debug('No Cache API caches were in use (or we do not have access to the names).');
           // All operations complete

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -186,7 +186,7 @@ define([], function () {
           return;
         }
         cnt++;
-        for (let registration of registrations) {
+        registrations.forEach(function (registration) {
           registration.unregister().then(function () {
             cnt--;
             if (!cnt) {
@@ -194,7 +194,7 @@ define([], function () {
               reboot();
             }
           });
-        }
+        });
       }).catch(function (err) {
         console.error(err);
         reboot();

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -104,8 +104,8 @@ define([], function () {
     // 1. Clear any cookie entries
     if (!object || object === 'cookie') {
       var cookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;
-      var currentCookies = document.cookie;
-      var cookieCrumb = cookieKeys.exec(currentCookies);
+      var currentCookie = document.cookie;
+      var cookieCrumb = cookieKeys.exec(currentCookie);
       var cook = false;
       while (cookieCrumb !== null) {
         // If the cookie key starts with the keyPrefix
@@ -115,9 +115,9 @@ define([], function () {
           // This expiry date will cause the browser to delete the cookie on next page refresh
           document.cookie = key + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
         }
-        cookieCrumb = cookieKeys.exec(currentCookies);
+        cookieCrumb = cookieKeys.exec(currentCookie);
       }
-      if (cook) console.debug('All cookies were expiered...');
+      if (cook) console.debug('All cookie keys were expiered...');
     }
 
     // 2. Clear any localStorage settings
@@ -140,13 +140,14 @@ define([], function () {
               if (!cnt) {
                 // All caches deleted
                 console.debug('All Cache API caches were deleted...');
+                // Reload if user performed full reset or if appCache is needed
                 if (!object || params.appCache) _reloadApp();
               }
             });
           }
         } else {
           console.debug('No Cache API caches were in use (or we do not have access to the names).');
-          // All operations complete
+          // All operations complete, reload if user performed full reset or if appCache is needed
           if (!object || params.appCache) _reloadApp();
         }
       });

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -170,7 +170,7 @@ define([], function () {
     }
   }
 
-  // Deregisters and Service Workers and reboots the app
+  // Deregisters all Service Workers and reboots the app
   function _reloadApp() {
     var reboot = function () {
       console.debug('Performing app reload...');

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -172,9 +172,15 @@ define([], function () {
     var reboot = function () {
       console.debug('Performing app reload...');
       setTimeout(function () {
-        window.location.reload();
+        window.location.search = uriParams;
       }, 300);
     };
+    // Compile a sensible querystring, so that parameters are not set on reload
+    var uriParams = '';
+    if (~window.location.href.indexOf(params.PWAServer) && params.referrerExtensionURL) {
+      uriParams = '?allowInternetAccess=truee&contentInjectionMode=serviceworker';
+      uriParams += '&referrerExtensionURL=' + encodeURIComponent(params.referrerExtensionURL);
+    }
     if (navigator && navigator.serviceWorker) {
       console.debug('Deregistering Service Workers...');
       var cnt = 0;

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -238,6 +238,8 @@ define(rqDef, function() {
                 var cacheNames = event.data;
                 if (cacheNames.error) return;
                 else {
+                    // Store the cacheNames for use elsewhere
+                    params.cacheNames = cacheNames;
                     caches.keys().then(function (keyList) {
                         updateAlert.style.display = 'none';
                         var cachePrefix = cacheNames.app.replace(/^([^\d]+).+/, '$1');

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -24,14 +24,14 @@
 // DEV: Put your RequireJS definition in the rqDef array below, and any function exports in the function parenthesis of the define statement
 // We need to do it this way in order to load WebP polyfills conditionally. The WebP polyfills are only needed by a few old browsers, so loading them
 // only if needed saves approximately 1MB of memory.
-var rqDef = [];
+var rqDef = ['settingsStore'];
 
 // Add WebP polyfill only if webpHero was loaded in init.js
 if (webpMachine) {
     rqDef.push('webpHeroBundle');
 }
 
-define(rqDef, function() {
+define(rqDef, function(settingsStore) {
   
     /**
      * Creates either a blob: or data: URI from the given content
@@ -231,14 +231,9 @@ define(rqDef, function() {
     var updateAlert = document.getElementById('updateAlert');
     function checkUpdateStatus(appstate) {
         if ('serviceWorker' in navigator && !appstate.pwaUpdateNeeded) {
-            // Create a Message Channel
-            var channel = new MessageChannel();
-            // Handler for receiving message reply from service worker
-            channel.port1.onmessage = function (event) {
-                var cacheNames = event.data;
-                if (cacheNames.error) return;
-                else {
-                    // Store the cacheNames for use elsewhere
+            settingsStore.getCacheNames(function (cacheNames) {
+                if (cacheNames && !cacheNames.error) {
+                    // Store the cacheNames globally for use elsewhere
                     params.cacheNames = cacheNames;
                     caches.keys().then(function (keyList) {
                         updateAlert.style.display = 'none';
@@ -255,10 +250,7 @@ define(rqDef, function() {
                         });
                     });
                 }
-            };
-            if (navigator.serviceWorker.controller) navigator.serviceWorker.controller.postMessage({
-                action: 'getCacheNames'
-            }, [channel.port2]);
+            });
         }
     }
     if (updateAlert) updateAlert.querySelector('button[data-hide]').addEventListener('click', function () {


### PR DESCRIPTION
This is intended to address #794, because we have a number of new developers who will find the new functionality confusing.

This provides a UI for resetting the app (see screenshot) under Expert Settings.

The button "**Reset**" performs a full app reset consisting of:

* Warning the user and seeking confirmation
* Clearing any cookie entries
* Clearing any Local Storage entries
* Deleting the Cache API caches
* Deregistering any registered Service Workers
* Rebooting the app

Of course all settings are lost and reverted to defaults.

The **checkbox** is intended for Service Worker mode only (it will complain if set in JQuery mode). It bypasses the appCache by:

* Clearing the Cache API caches
* Preventing Service Worker from using the appCache, forcing it to fetch all app files

When re-enabling the appCache (by unticking the checkbox), it will:

* Deregister the current Service Worker
* Reboot the app in order to reinstall the Service Worker and repopulate the offline appCache.

![image](https://user-images.githubusercontent.com/4304337/149041710-5489ef51-2cda-48a0-b56d-bff955ef5765.png)
