### PR TITLE
Fix race condition while loading decompressors

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -504,6 +504,16 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     //switch on/off the feature to use Home Key to focus search bar
     function switchHomeKeyToFocusSearchBar() {
         var iframeContentWindow = document.getElementById('articleContent').contentWindow;
+        // Test whether iframe is accessible (because if not, we do not want to throw an error at this point, before we can tell the user what is wrong)
+        var isIframeAccessible = true;
+        try {
+            iframeContentWindow.removeEventListener('keydown', focusPrefixOnHomeKey);
+        }
+        catch (err) {
+            console.error('The iframe is probably not accessible', err);
+            isIframeAccessible = false;
+        }
+        if (!isIframeAccessible) return;
         // when the feature is in active state
         if (params.useHomeKeyToFocusSearchBar) {
             //Handle Home key press inside window(outside iframe) to focus #prefix

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -474,8 +474,9 @@ define(rqDef, function(settingsStore) {
 
     // Reports an error in loading one of the ASM or WASM machines to the UI API Status Panel
     // This can't be done in app.js because the error occurs after the API panel is first displayed
-    function reportAssemblerErrorToAPIStatusPanel(decoderType, error) {
+    function reportAssemblerErrorToAPIStatusPanel(decoderType, error, assemblerMachineType) {
         console.error('Could not instantiate any ' + decoderType + ' decoder!', error);
+        params.decompressorAPI.assemblerMachineType = assemblerMachineType;
         params.decompressorAPI.errorStatus = 'Error loading ' + decoderType + ' decompressor!';
         var decompAPI = document.getElementById('decompressorAPIStatus');
         decompAPI.innerHTML = 'Decompressor API: ' + params.decompressorAPI.errorStatus;


### PR DESCRIPTION
This may fix #820. It also contains a fix for #812 because that blocks the app completely when loading from file protocol if the iframe is inaccessible, and prevents us accessing the API panel or posting an explanatory message to the user.

I've only tested this in Edge accessing from the file system. This is as close a simulation as I can get to the errors shown in the Ubuntu touch log. The race condition was undoubtedly affecting the loading sequence on Ubuntu touch, because it failed to fall back to ASM only with one of the decompressors (ZSTD), which happened to be the one needed.

Of course something else may be blocking the Ubuntu touch app, but fixing these two issues should allow us to diagnose better, if there are other issues in the way of a solution.