### PR TITLE
Displaying message if shuffled without loading a ZIM file

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -109,6 +109,14 @@
     background-color: #FFFF00;
 }
 
+.dark .modal-content{
+    background: #333 !important;
+}
+
+.dark .modal-title, .dark .modal-body{
+    color: #FFFFFF !important;
+}
+
 /* End of app theme: dark */
 
 /* Content themes: _invert, _mwInvert */

--- a/www/index.html
+++ b/www/index.html
@@ -59,8 +59,9 @@
                         <p id="modalText">Modal text goes here.</p>
                     </div>
                     <div class="modal-footer" id="modalFooter">
-                        <button type="button" class="btn btn-primary" id="approveModal" data-dismiss="modal">Confirm</button>
-                        <button type="button" class="btn btn-secondary" id="declineModal" data-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-primary" id="approveConfirm" data-dismiss="modal">Confirm</button>
+                        <button type="button" class="btn btn-secondary" id="declineConfirm" data-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-primary" id="closeMessage" data-dismiss="modal">Okay</button>
                     </div>
                 </div>
             </div>

--- a/www/index.html
+++ b/www/index.html
@@ -658,7 +658,7 @@
         </section>
 
         <!-- Using require.js, a module system for javascript, include the
-             js files. This loads "main.js", which in turn can load other
+             js files. This loads "init.js", which in turn can load other
              files, all handled by require.js:
              https://requirejs.org/docs/api.html#jsfiles -->
         <script type="text/javascript"

--- a/www/index.html
+++ b/www/index.html
@@ -45,6 +45,27 @@
         <link rel="icon" type="image/png" href="img/icons/kiwix-256.png" sizes="256x256"/>
     </head>
     <body role="application">
+        <!--Bootstrap modal for alert and confirmation pop up-->
+        <div class="modal fade" id="alertModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="modalLabel">Modal title goes here</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <p id="modalText">Modal text goes here.</p>
+                    </div>
+                    <div class="modal-footer" id="modalFooter">
+                        <button type="button" class="btn btn-primary" id="confirmModal" style="visibility: hidden;">Confirm</button>
+                        <button type="button" class="btn btn-secondary" id="closeModal">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Status indicators -->
         <div id="searchingArticles" style="display: none;" class="status">
             <div class="loader"></div>
@@ -54,6 +75,8 @@
         </div>
         <section id="search-article" role="region">
             <header id="top">
+                
+
                 <nav class="navbar navbar-expand-md bg-light" role="navigation">
                     <a id="appVersion" class="navbar-brand">Kiwix</a>
 

--- a/www/index.html
+++ b/www/index.html
@@ -59,7 +59,7 @@
                         <p id="modalText">Modal text goes here.</p>
                     </div>
                     <div class="modal-footer" id="modalFooter">
-                        <button type="button" class="btn btn-primary" id="approveModal" style="visibility: hidden;" data-dismiss="modal">Confirm</button>
+                        <button type="button" class="btn btn-primary" id="approveModal" data-dismiss="modal">Confirm</button>
                         <button type="button" class="btn btn-secondary" id="declineModal" data-dismiss="modal">Close</button>
                     </div>
                 </div>

--- a/www/index.html
+++ b/www/index.html
@@ -59,8 +59,8 @@
                         <p id="modalText">Modal text goes here.</p>
                     </div>
                     <div class="modal-footer" id="modalFooter">
-                        <button type="button" class="btn btn-primary" id="confirmModal" style="visibility: hidden;">Confirm</button>
-                        <button type="button" class="btn btn-secondary" id="closeModal">Close</button>
+                        <button type="button" class="btn btn-primary" id="confirmModal" style="visibility: hidden;" data-dismiss="modal">Confirm</button>
+                        <button type="button" class="btn btn-secondary" id="closeModal" data-dismiss="modal">Close</button>
                     </div>
                 </div>
             </div>

--- a/www/index.html
+++ b/www/index.html
@@ -60,7 +60,7 @@
                     </div>
                     <div class="modal-footer" id="modalFooter">
                         <button type="button" class="btn btn-primary" id="approveModal" data-dismiss="modal">Confirm</button>
-                        <button type="button" class="btn btn-secondary" id="declineModal" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-secondary" id="declineModal" data-dismiss="modal">Cancel</button>
                     </div>
                 </div>
             </div>

--- a/www/index.html
+++ b/www/index.html
@@ -59,8 +59,8 @@
                         <p id="modalText">Modal text goes here.</p>
                     </div>
                     <div class="modal-footer" id="modalFooter">
-                        <button type="button" class="btn btn-primary" id="confirmModal" style="visibility: hidden;" data-dismiss="modal">Confirm</button>
-                        <button type="button" class="btn btn-secondary" id="closeModal" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-primary" id="approveModal" style="visibility: hidden;" data-dismiss="modal">Confirm</button>
+                        <button type="button" class="btn btn-secondary" id="declineModal" data-dismiss="modal">Close</button>
                     </div>
                 </div>
             </div>

--- a/www/index.html
+++ b/www/index.html
@@ -75,8 +75,6 @@
         </div>
         <section id="search-article" role="region">
             <header id="top">
-                
-
                 <nav class="navbar navbar-expand-md bg-light" role="navigation">
                     <a id="appVersion" class="navbar-brand">Kiwix</a>
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -797,7 +797,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                             if (protocol === 'file:') {
                                 message += "\n\nYou seem to be opening kiwix-js with the file:// protocol. You should open it through a web server : either through a local one (http://localhost/...) or through a remote one (but you need SSL : https://webserver/...)";
                             }
-                            uiUtil.systemAlert("Alert", message, false).then(function () {
+                            uiUtil.systemAlert("Incompatible protocol", message, false).then(function () {
                                 setContentInjectionMode('jquery');
                             });                  
                         }
@@ -898,7 +898,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             if (PWASuccessfullyLaunched) {
                 launchPWA();
             } else {
-                uiUtil.systemAlert('Confirmation', 'The last attempt to launch the PWA appears to have failed.\n\nDo you wish to try again?', true).then(function (response) {
+                uiUtil.systemAlert('Confirmation to try again PWA', 'The last attempt to launch the PWA appears to have failed.\n\nDo you wish to try again?', true).then(function (response) {
                     if (response) {
                         checkPWAIsOnline();
                     } else {
@@ -908,7 +908,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 })
             }
         } else {
-            uiUtil.systemAlert('Confirmation', message, true).then(function (response) {
+            uiUtil.systemAlert('Allow Internet access', message, true).then(function (response) {
                 if (response) checkPWAIsOnline();
                 else {
                     setContentInjectionMode('jquery');
@@ -1003,7 +1003,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         for (var i = 0; i < archiveDirectories.length; i++) {
             var archiveDirectory = archiveDirectories[i];
             if (archiveDirectory === "/") {
-                uiUtil.systemAlert("Alert", "It looks like you have put some archive files at the root of your sdcard (or internal storage). Please move them in a subdirectory", false);
+                uiUtil.systemAlert("Error: invalid archive files location", "It looks like you have put some archive files at the root of your sdcard (or internal storage). Please move them in a subdirectory", false);
             } else {
                 comboArchiveList.options[i] = new Option(archiveDirectory, archiveDirectory);
             }
@@ -1023,12 +1023,12 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             // Set the localArchive as the last selected (or the first one if it has never been selected)
             setLocalArchiveFromArchiveList();
         } else {
-            uiUtil.systemAlert("Alert", "Welcome to Kiwix! This application needs at least a ZIM file in your SD-card (or internal storage). Please download one and put it on the device (see About section). Also check that your device is not connected to a computer through USB device storage (which often locks the SD-card content)", false)
+            uiUtil.systemAlert("Welcome", "Welcome to Kiwix! This application needs at least a ZIM file in your SD-card (or internal storage). Please download one and put it on the device (see About section). Also check that your device is not connected to a computer through USB device storage (which often locks the SD-card content)", false)
             .then(function () {
                 $("#btnAbout").click();
                 var isAndroid = (navigator.userAgent.indexOf("Android") !== -1);
                 if (isAndroid) {
-                    uiUtil.systemAlert("Alert", "You seem to be using an Android device. Be aware that there is a bug on Firefox, that prevents finding Wikipedia archives in a SD-card (at least on some devices. See about section). Please put the archive in the internal storage if the application can't find it.", false);
+                    uiUtil.systemAlert("Warning", "You seem to be using an Android device with DeviceStorage API. That must be a quite old Firefox version because this API has been removed in 2016. Be aware that there was a bug on Firefox, that prevents finding Wikipedia archives in a SD-card (at least on some devices). Please put the archive in the internal storage if the application can't find it.", false);
                 }
             });
         }
@@ -1055,7 +1055,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                     }
                 }
                 if (selectedStorage === null) {
-                    uiUtil.systemAlert("Alert", "Unable to find which device storage corresponds to directory " + archiveDirectory, false);
+                    uiUtil.systemAlert("Error: no matching storage", "Unable to find which device storage corresponds to directory " + archiveDirectory, false);
                 }
             } else {
                 // This happens when the archiveDirectory is not prefixed by the name of the storage
@@ -1064,7 +1064,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 if (storages.length === 1) {
                     selectedStorage = storages[0];
                 } else {
-                    uiUtil.systemAlert("Alert", "Something weird happened with the DeviceStorage API : found a directory without prefix : "
+                    uiUtil.systemAlert("Error: unprefixed directory", "Something weird happened with the DeviceStorage API : found a directory without prefix : "
                     + archiveDirectory + ", but there were " + storages.length
                     + " storages found with getDeviceStorages instead of 1", false);
                 }
@@ -1255,7 +1255,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             // We have to remove the focus from the search field,
             // so that the keyboard does not stay above the message
             $("#searchArticles").focus();
-            uiUtil.systemAlert("Alert", "Archive not set : please select an archive", false).then(function () {
+            uiUtil.systemAlert("No archive selected", "Archive not set : please select an archive", false).then(function () {
                 $("#btnConfigure").click();
             });
         }
@@ -1341,7 +1341,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 readArticle(dirEntry);
             }
         } else {
-            uiUtil.systemAlert("Alert", "Data files not set", false);
+            uiUtil.systemAlert("Archive not ready", "Data files not set", false);
         }
     }
 
@@ -1899,7 +1899,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         selectedArchive.getDirEntryByPath(path).then(function(dirEntry) {
             if (dirEntry === null || dirEntry === undefined) {
                 $("#searchingArticles").hide();
-                uiUtil.systemAlert("Alert", "Article with url " + path + " not found in the archive", false);
+                uiUtil.systemAlert("Error: article not found", "Article with url " + path + " not found in the archive", false);
             } else if (download) {
                 selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
                     var mimetype = contentType || fileDirEntry.getMimetype();
@@ -1910,7 +1910,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $('#activeContent').hide();
                 readArticle(dirEntry);
             }
-        }).catch(function(e) { uiUtil.systemAlert("Alert", "Error reading article with url " + path + " : " + e, false); });
+        }).catch(function(e) { uiUtil.systemAlert("Error while reading article", "Error reading article with url " + path + " : " + e, false); });
     }
     
     function goToRandomArticle() {
@@ -1918,7 +1918,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         selectedArchive.getRandomDirEntry(function(dirEntry) {
             if (dirEntry === null || dirEntry === undefined) {
                 $("#searchingArticles").hide();
-                uiUtil.systemAlert("Alert", "Error finding random article", false);
+                uiUtil.systemAlert("Error finding article", "Error finding random article", false);
             } else {
                 // We fall back to the old A namespace to support old ZIM files without a text/html MIME type for articles
                 // DEV: If articlePtrPos is defined in zimFile, then we are using a v1 article-only title listing. By definition,

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1028,12 +1028,14 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             setLocalArchiveFromArchiveList();
         }
         else {
-            alert("Welcome to Kiwix! This application needs at least a ZIM file in your SD-card (or internal storage). Please download one and put it on the device (see About section). Also check that your device is not connected to a computer through USB device storage (which often locks the SD-card content)");
-            $("#btnAbout").click();
-            var isAndroid = (navigator.userAgent.indexOf("Android") !== -1);
-            if (isAndroid) {
-                alert("You seem to be using an Android device. Be aware that there is a bug on Firefox, that prevents finding Wikipedia archives in a SD-card (at least on some devices. See about section). Please put the archive in the internal storage if the application can't find it.");
-            }
+            uiUtil.systemAlert("Alert", "Welcome to Kiwix! This application needs at least a ZIM file in your SD-card (or internal storage). Please download one and put it on the device (see About section). Also check that your device is not connected to a computer through USB device storage (which often locks the SD-card content)", false)
+            .then(function() {
+                $("#btnAbout").click();
+                var isAndroid = (navigator.userAgent.indexOf("Android") !== -1);
+                if (isAndroid) {
+                    uiUtil.systemAlert("Alert", "You seem to be using an Android device. Be aware that there is a bug on Firefox, that prevents finding Wikipedia archives in a SD-card (at least on some devices. See about section). Please put the archive in the internal storage if the application can't find it.", false);
+                }
+            });
         }
     }
 
@@ -1060,18 +1062,16 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 if (selectedStorage === null) {
                     uiUtil.systemAlert("Alert", "Unable to find which device storage corresponds to directory " + archiveDirectory, false);
                 }
-            }
-            else {
+            } else {
                 // This happens when the archiveDirectory is not prefixed by the name of the storage
                 // (in the Simulator, or with FxOs 1.0, or probably on devices that only have one device storage)
                 // In this case, we use the first storage of the list (there should be only one)
                 if (storages.length === 1) {
                     selectedStorage = storages[0];
-                }
-                else {
-                    alert("Something weird happened with the DeviceStorage API : found a directory without prefix : "
-                        + archiveDirectory + ", but there were " + storages.length
-                        + " storages found with getDeviceStorages instead of 1");
+                } else {
+                    uiUtil.systemAlert("Alert", "Something weird happened with the DeviceStorage API : found a directory without prefix : "
+                    + archiveDirectory + ", but there were " + storages.length
+                    + " storages found with getDeviceStorages instead of 1", false);
                 }
             }
             resetCssCache();
@@ -1346,7 +1346,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 readArticle(dirEntry);
             }
         } else {
-            alert("Data files not set");
+            uiUtil.systemAlert("Alert", "Data files not set", false);
         }
     }
 
@@ -1906,7 +1906,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         selectedArchive.getDirEntryByPath(path).then(function(dirEntry) {
             if (dirEntry === null || dirEntry === undefined) {
                 $("#searchingArticles").hide();
-                alert("Article with url " + path + " not found in the archive");
+                uiUtil.systemAlert("Alert", "Article with url " + path + " not found in the archive", false);
             } else if (download) {
                 selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
                     var mimetype = contentType || fileDirEntry.getMimetype();
@@ -1917,7 +1917,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $('#activeContent').hide();
                 readArticle(dirEntry);
             }
-        }).catch(function(e) { alert("Error reading article with url " + path + " : " + e); });
+        }).catch(function(e) { uiUtil.systemAlert("Alert", "Error reading article with url " + path + " : " + e, false); });
     }
     
     function goToRandomArticle() {
@@ -1925,7 +1925,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         selectedArchive.getRandomDirEntry(function(dirEntry) {
             if (dirEntry === null || dirEntry === undefined) {
                 $("#searchingArticles").hide();
-                alert("Error finding random article.");
+                uiUtil.systemAlert("Alert", "Error finding random article", false);
             } else {
                 // We fall back to the old A namespace to support old ZIM files without a text/html MIME type for articles
                 // DEV: If articlePtrPos is defined in zimFile, then we are using a v1 article-only title listing. By definition,

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1260,8 +1260,12 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             // We have to remove the focus from the search field,
             // so that the keyboard does not stay above the message
             $("#searchArticles").focus();
-            alert("Archive not set : please select an archive");
-            $("#btnConfigure").click();
+            uiUtil.systemAlert("Alert", "Archive not set : please select an archive", false)
+                .then(function () {
+                    $("#btnConfigure").click();
+                });
+            // alert("Archive not set : please select an archive");
+            // $("#btnConfigure").click();
         }
     }
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1024,7 +1024,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             setLocalArchiveFromArchiveList();
         } else {
             uiUtil.systemAlert("Alert", "Welcome to Kiwix! This application needs at least a ZIM file in your SD-card (or internal storage). Please download one and put it on the device (see About section). Also check that your device is not connected to a computer through USB device storage (which often locks the SD-card content)", false)
-            .then(function() {
+            .then(function () {
                 $("#btnAbout").click();
                 var isAndroid = (navigator.userAgent.indexOf("Android") !== -1);
                 if (isAndroid) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -899,21 +899,23 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             if (PWASuccessfullyLaunched) {
                 launchPWA();
             } else {
-                response = confirm('The last attempt to launch the PWA appears to have failed.\n\nDo you wish to try again?');
-                if (response) {
-                    checkPWAIsOnline();
-                } else {
-                    settingsStore.setItem('allowInternetAccess', false, Infinity);
-                    setContentInjectionMode('jquery');
-                }
+                uiUtil.systemAlert('Confirmation', 'The last attempt to launch the PWA appears to have failed.\n\nDo you wish to try again?', true).then(function (response) {
+                    if (response) {
+                        checkPWAIsOnline();
+                    } else {
+                        settingsStore.setItem('allowInternetAccess', false, Infinity);
+                        setContentInjectionMode('jquery');
+                    }
+                })
             }
         } else {
-            response = confirm(message);
-            if (response) checkPWAIsOnline();
-            else {
-                setContentInjectionMode('jquery');
-                settingsStore.setItem('allowInternetAccess', false, Infinity);
-            }    
+            uiUtil.systemAlert('Confirmation', message, true).then(function (response) {
+                if (response) checkPWAIsOnline();
+                else {
+                    setContentInjectionMode('jquery');
+                    settingsStore.setItem('allowInternetAccess', false, Infinity);
+                }
+            });
         }
     }
     

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -797,10 +797,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                             if (protocol === 'file:') {
                                 message += "\n\nYou seem to be opening kiwix-js with the file:// protocol. You should open it through a web server : either through a local one (http://localhost/...) or through a remote one (but you need SSL : https://webserver/...)";
                             }
-                            uiUtil.systemAlert("Alert", message, false)
-                                .then(function () {
-                                    setContentInjectionMode('jquery');
-                                });                  
+                            uiUtil.systemAlert("Alert", message, false).then(function () {
+                                setContentInjectionMode('jquery');
+                            });                  
                         }
                     });
                 }
@@ -1009,8 +1008,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             var archiveDirectory = archiveDirectories[i];
             if (archiveDirectory === "/") {
                 uiUtil.systemAlert("Alert", "It looks like you have put some archive files at the root of your sdcard (or internal storage). Please move them in a subdirectory", false);
-            }
-            else {
+            } else {
                 comboArchiveList.options[i] = new Option(archiveDirectory, archiveDirectory);
             }
         }
@@ -1262,10 +1260,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             // We have to remove the focus from the search field,
             // so that the keyboard does not stay above the message
             $("#searchArticles").focus();
-            uiUtil.systemAlert("Alert", "Archive not set : please select an archive", false)
-                .then(function () {
-                    $("#btnConfigure").click();
-                });
+            uiUtil.systemAlert("Alert", "Archive not set : please select an archive", false).then(function () {
+                $("#btnConfigure").click();
+            });
         }
     }
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -421,7 +421,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     });
     document.getElementById('bypassAppCacheCheck').addEventListener('change', function () {
         if (params.contentInjectionMode !== 'serviceworker') {
-            alert('This setting can only be used in Service Worker mode!');
+            uiUtil.systemAlert('This setting can only be used in Service Worker mode!');
             this.checked = false;
         } else {
             params.appCache = !this.checked;
@@ -696,8 +696,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         params.contentInjectionMode = value;
         if (value === 'jquery') {
             if (!params.appCache) {
-                alert('You must deselect the "Bypass AppCache" option before switching to JQuery mode!');
-                setContentInjectionMode('serviceworker');
+                uiUtil.systemAlert('You must deselect the "Bypass AppCache" option before switching to JQuery mode!', 'Deselect "Bypass AppCache"').then(function () {
+                    setContentInjectionMode('serviceworker');
+                })
                 return;
             }
             if (params.referrerExtensionURL) {
@@ -712,12 +713,13 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                     window.location.href = params.referrerExtensionURL + '/www/index.html' + uriParams;
                     'Beam me down, Scotty!';
                 };
-                var response = confirm(message);
-                if (response) {
-                    launchLocal();
-                } else {
-                    setContentInjectionMode('serviceworker');
-                }
+                uiUtil.systemAlert(message, 'Warning!', true).then(function (response) {
+                    if (response) {
+                        launchLocal();
+                    } else {
+                        setContentInjectionMode('serviceworker');
+                    }
+                });
                 return;
             }
             // Because the Service Worker must still run in a PWA app so that it can work offline, we don't actually disable the SW in this context,
@@ -739,13 +741,15 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             }
         } else if (value === 'serviceworker') {
             if (!isServiceWorkerAvailable()) {
-                alert("The ServiceWorker API is not available on your device. Falling back to JQuery mode");
-                setContentInjectionMode('jquery');
+                uiUtil.systemAlert('The ServiceWorker API is not available on your device. Falling back to JQuery mode', 'ServiceWorker API not available').then(function () {
+                    setContentInjectionMode('jquery');
+                });
                 return;
             }
             if (!isMessageChannelAvailable()) {
-                alert("The MessageChannel API is not available on your device. Falling back to JQuery mode");
-                setContentInjectionMode('jquery');
+                uiUtil.systemAlert('The MessageChannel API is not available on your device. Falling back to JQuery mode', 'MessageChannel API not available').then(function () {
+                    setContentInjectionMode('jquery');
+                });
                 return;
             }
             var protocol = window.location.protocol;
@@ -887,11 +891,12 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             uiUtil.spinnerDisplay(true, 'Checking server access...');
             uiUtil.checkServerIsAccessible(params.PWAServer + 'www/img/icons/kiwix-32.png', launchPWA, function () {
                 uiUtil.spinnerDisplay(false);
-                alert('The server is not currently accessible! ' +
+                uiUtil.systemAlert('The server is not currently accessible! ' +
                     '\n\n(Kiwix needs one-time access to the server to cache the PWA).' +
-                    '\nPlease try again when you have a stable Internet connection.', 'Error!');
-                settingsStore.setItem('allowInternetAccess', false, Infinity);
-                setContentInjectionMode('jquery');
+                    '\nPlease try again when you have a stable Internet connection.', 'Error!').then(function () {
+                        settingsStore.setItem('allowInternetAccess', false, Infinity);
+                        setContentInjectionMode('jquery');
+                    });
             });
         };
         if (settingsStore.getItem('allowInternetAccess') === 'true') {
@@ -1154,7 +1159,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         for (var i = files.length; i--;) {
             // DEV: you can support other file types by adding (e.g.) '|dat|idx' after 'zim\w{0,2}'
             if (!/\.(?:zim\w{0,2})$/i.test(files[i].name)) {
-                alert("One or more files does not appear to be a ZIM file!");
+                uiUtil.systemAlert('One or more files does not appear to be a ZIM file!', 'Invalid File Format');
                 return;
             }
         }
@@ -1567,10 +1572,10 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             
             var iframeContentDocument = iframeArticleContent.contentDocument;
             if (!iframeContentDocument && window.location.protocol === 'file:') {
-                alert("You seem to be opening kiwix-js with the file:// protocol, which is blocked by your browser for security reasons."
-                        + "\nThe easiest way to run it is to download and run it as a browser extension (from the vendor store)."
-                        + "\nElse you can open it through a web server : either through a local one (http://localhost/...) or through a remote one (but you need SSL : https://webserver/...)"
-                        + "\nAnother option is to force your browser to accept that (but you'll open a security breach) : on Chrome, you can start it with --allow-file-access-from-files command-line argument; on Firefox, you can set privacy.file_unique_origin to false in about:config");
+                uiUtil.systemAlert("You seem to be opening kiwix-js with the file:// protocol, which is blocked by your browser for security reasons."
+                                    + "\nThe easiest way to run it is to download and run it as a browser extension (from the vendor store)."
+                                    + "\nElse you can open it through a web server : either through a local one (http://localhost/...) or through a remote one (but you need SSL : https://webserver/...)"
+                                    + "\nAnother option is to force your browser to accept that (but you'll open a security breach) : on Chrome, you can start it with --allow-file-access-from-files command-line argument; on Firefox, you can set privacy.file_unique_origin to false in about:config");
                 return;
             }
             

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -801,7 +801,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                             if (protocol === 'file:') {
                                 message += "\n\nYou seem to be opening kiwix-js with the file:// protocol. You should open it through a web server : either through a local one (http://localhost/...) or through a remote one (but you need SSL : https://webserver/...)";
                             }
-                            uiUtil.systemAlert(message, "Incompatible protocol").then(function () {
+                            uiUtil.systemAlert(message, "Failed to register ServiceWorker").then(function () {
                                 setContentInjectionMode('jquery');
                             });                  
                         }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -797,8 +797,10 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                             if (protocol === 'file:') {
                                 message += "\n\nYou seem to be opening kiwix-js with the file:// protocol. You should open it through a web server : either through a local one (http://localhost/...) or through a remote one (but you need SSL : https://webserver/...)";
                             }
-                            alert(message);                        
-                            setContentInjectionMode("jquery");
+                            uiUtil.systemAlert("Alert", message, false)
+                                .then(function () {
+                                    setContentInjectionMode('jquery');
+                                });                  
                         }
                     });
                 }
@@ -1006,7 +1008,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         for (var i = 0; i < archiveDirectories.length; i++) {
             var archiveDirectory = archiveDirectories[i];
             if (archiveDirectory === "/") {
-                alert("It looks like you have put some archive files at the root of your sdcard (or internal storage). Please move them in a subdirectory");
+                uiUtil.systemAlert("Alert", "It looks like you have put some archive files at the root of your sdcard (or internal storage). Please move them in a subdirectory", false);
             }
             else {
                 comboArchiveList.options[i] = new Option(archiveDirectory, archiveDirectory);
@@ -1058,7 +1060,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                     }
                 }
                 if (selectedStorage === null) {
-                    alert("Unable to find which device storage corresponds to directory " + archiveDirectory);
+                    uiUtil.systemAlert("Alert", "Unable to find which device storage corresponds to directory " + archiveDirectory, false);
                 }
             }
             else {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -909,8 +909,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             }
         } else {
             uiUtil.systemAlert(message, 'Allow Internet access', true).then(function (response) {
-                if (response) checkPWAIsOnline();
-                else {
+                if (response) {
+                    checkPWAIsOnline();
+                } else {
                     setContentInjectionMode('jquery');
                     settingsStore.setItem('allowInternetAccess', false, Infinity);
                 }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -894,7 +894,6 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 setContentInjectionMode('jquery');
             });
         };
-        var response;
         if (settingsStore.getItem('allowInternetAccess') === 'true') {
             if (PWASuccessfullyLaunched) {
                 launchPWA();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1264,8 +1264,6 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 .then(function () {
                     $("#btnConfigure").click();
                 });
-            // alert("Archive not set : please select an archive");
-            // $("#btnConfigure").click();
         }
     }
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -797,7 +797,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                             if (protocol === 'file:') {
                                 message += "\n\nYou seem to be opening kiwix-js with the file:// protocol. You should open it through a web server : either through a local one (http://localhost/...) or through a remote one (but you need SSL : https://webserver/...)";
                             }
-                            uiUtil.systemAlert("Incompatible protocol", message, false).then(function () {
+                            uiUtil.systemAlert(message, "Incompatible protocol").then(function () {
                                 setContentInjectionMode('jquery');
                             });                  
                         }
@@ -898,7 +898,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             if (PWASuccessfullyLaunched) {
                 launchPWA();
             } else {
-                uiUtil.systemAlert('Confirmation to try again PWA', 'The last attempt to launch the PWA appears to have failed.\n\nDo you wish to try again?', true).then(function (response) {
+                uiUtil.systemAlert('The last attempt to launch the PWA appears to have failed.\n\nDo you wish to try again?', 'Confirmation to try again PWA', true).then(function (response) {
                     if (response) {
                         checkPWAIsOnline();
                     } else {
@@ -908,7 +908,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 })
             }
         } else {
-            uiUtil.systemAlert('Allow Internet access', message, true).then(function (response) {
+            uiUtil.systemAlert(message, 'Allow Internet access', true).then(function (response) {
                 if (response) checkPWAIsOnline();
                 else {
                     setContentInjectionMode('jquery');
@@ -1003,7 +1003,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         for (var i = 0; i < archiveDirectories.length; i++) {
             var archiveDirectory = archiveDirectories[i];
             if (archiveDirectory === "/") {
-                uiUtil.systemAlert("Error: invalid archive files location", "It looks like you have put some archive files at the root of your sdcard (or internal storage). Please move them in a subdirectory", false);
+                uiUtil.systemAlert("It looks like you have put some archive files at the root of your sdcard (or internal storage). Please move them in a subdirectory", "Error: invalid archive files location");
             } else {
                 comboArchiveList.options[i] = new Option(archiveDirectory, archiveDirectory);
             }
@@ -1023,12 +1023,12 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             // Set the localArchive as the last selected (or the first one if it has never been selected)
             setLocalArchiveFromArchiveList();
         } else {
-            uiUtil.systemAlert("Welcome", "Welcome to Kiwix! This application needs at least a ZIM file in your SD-card (or internal storage). Please download one and put it on the device (see About section). Also check that your device is not connected to a computer through USB device storage (which often locks the SD-card content)", false)
+            uiUtil.systemAlert("Welcome to Kiwix! This application needs at least a ZIM file in your SD-card (or internal storage). Please download one and put it on the device (see About section). Also check that your device is not connected to a computer through USB device storage (which often locks the SD-card content)", "Welcome")
             .then(function () {
                 $("#btnAbout").click();
                 var isAndroid = (navigator.userAgent.indexOf("Android") !== -1);
                 if (isAndroid) {
-                    uiUtil.systemAlert("Warning", "You seem to be using an Android device with DeviceStorage API. That must be a quite old Firefox version because this API has been removed in 2016. Be aware that there was a bug on Firefox, that prevents finding Wikipedia archives in a SD-card (at least on some devices). Please put the archive in the internal storage if the application can't find it.", false);
+                    uiUtil.systemAlert("You seem to be using an Android device with DeviceStorage API. That must be a quite old Firefox version because this API has been removed in 2016. Be aware that there was a bug on Firefox, that prevents finding Wikipedia archives in a SD-card (at least on some devices). Please put the archive in the internal storage if the application can't find it.", "Warning");
                 }
             });
         }
@@ -1055,7 +1055,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                     }
                 }
                 if (selectedStorage === null) {
-                    uiUtil.systemAlert("Error: no matching storage", "Unable to find which device storage corresponds to directory " + archiveDirectory, false);
+                    uiUtil.systemAlert("Unable to find which device storage corresponds to directory " + archiveDirectory, "Error: no matching storage");
                 }
             } else {
                 // This happens when the archiveDirectory is not prefixed by the name of the storage
@@ -1255,7 +1255,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             // We have to remove the focus from the search field,
             // so that the keyboard does not stay above the message
             $("#searchArticles").focus();
-            uiUtil.systemAlert("No archive selected", "Archive not set : please select an archive", false).then(function () {
+            uiUtil.systemAlert("Archive not set : please select an archive", "No archive selected").then(function () {
                 $("#btnConfigure").click();
             });
         }
@@ -1341,7 +1341,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 readArticle(dirEntry);
             }
         } else {
-            uiUtil.systemAlert("Archive not ready", "Data files not set", false);
+            uiUtil.systemAlert("Data files not set", "Archive not ready");
         }
     }
 
@@ -1899,7 +1899,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         selectedArchive.getDirEntryByPath(path).then(function(dirEntry) {
             if (dirEntry === null || dirEntry === undefined) {
                 $("#searchingArticles").hide();
-                uiUtil.systemAlert("Error: article not found", "Article with url " + path + " not found in the archive", false);
+                uiUtil.systemAlert("Article with url " + path + " not found in the archive", "Error: article not found");
             } else if (download) {
                 selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
                     var mimetype = contentType || fileDirEntry.getMimetype();
@@ -1910,7 +1910,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $('#activeContent').hide();
                 readArticle(dirEntry);
             }
-        }).catch(function(e) { uiUtil.systemAlert("Error while reading article", "Error reading article with url " + path + " : " + e, false); });
+        }).catch(function(e) { uiUtil.systemAlert("Error reading article with url " + path + " : " + e, "Error while reading article"); });
     }
     
     function goToRandomArticle() {
@@ -1918,7 +1918,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         selectedArchive.getRandomDirEntry(function(dirEntry) {
             if (dirEntry === null || dirEntry === undefined) {
                 $("#searchingArticles").hide();
-                uiUtil.systemAlert("Error finding article", "Error finding random article", false);
+                uiUtil.systemAlert("Error finding random article", "Error finding article");
             } else {
                 // We fall back to the old A namespace to support old ZIM files without a text/html MIME type for articles
                 // DEV: If articlePtrPos is defined in zimFile, then we are using a v1 article-only title listing. By definition,

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1064,9 +1064,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 if (storages.length === 1) {
                     selectedStorage = storages[0];
                 } else {
-                    uiUtil.systemAlert("Error: unprefixed directory", "Something weird happened with the DeviceStorage API : found a directory without prefix : "
+                    uiUtil.systemAlert("Something weird happened with the DeviceStorage API : found a directory without prefix : "
                     + archiveDirectory + ", but there were " + storages.length
-                    + " storages found with getDeviceStorages instead of 1", false);
+                    + " storages found with getDeviceStorages instead of 1", "Error: unprefixed directory");
                 }
             }
             resetCssCache();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1920,27 +1920,34 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     }
     
     function goToRandomArticle() {
-        $("#searchingArticles").show();
-        selectedArchive.getRandomDirEntry(function(dirEntry) {
-            if (dirEntry === null || dirEntry === undefined) {
-                $("#searchingArticles").hide();
-                uiUtil.systemAlert("Error finding random article", "Error finding article");
-            } else {
-                // We fall back to the old A namespace to support old ZIM files without a text/html MIME type for articles
-                // DEV: If articlePtrPos is defined in zimFile, then we are using a v1 article-only title listing. By definition,
-                // all dirEntries in an article-only listing must be articles.  
-                if (selectedArchive._file.articlePtrPos || dirEntry.getMimetype() === 'text/html' || dirEntry.namespace === 'A') {
-                    params.isLandingPage = false;
-                    $('#activeContent').hide();
-                    $('#searchingArticles').show();
-                    readArticle(dirEntry);
+        if (selectedArchive !== null && selectedArchive.isReady()) {
+            $("#searchingArticles").show();
+            selectedArchive.getRandomDirEntry(function(dirEntry) {
+                if (dirEntry === null || dirEntry === undefined) {
+                    $("#searchingArticles").hide();
+                    uiUtil.systemAlert("Error finding random article", "Error finding article");
                 } else {
-                    // If the random title search did not end up on an article,
-                    // we try again, until we find one
-                    goToRandomArticle();
+                    // We fall back to the old A namespace to support old ZIM files without a text/html MIME type for articles
+                    // DEV: If articlePtrPos is defined in zimFile, then we are using a v1 article-only title listing. By definition,
+                    // all dirEntries in an article-only listing must be articles.  
+                    if (selectedArchive._file.articlePtrPos || dirEntry.getMimetype() === 'text/html' || dirEntry.namespace === 'A') {
+                        params.isLandingPage = false;
+                        $('#activeContent').hide();
+                        $('#searchingArticles').show();
+                        readArticle(dirEntry);
+                    } else {
+                        // If the random title search did not end up on an article,
+                        // we try again, until we find one
+                        goToRandomArticle();
+                    }
                 }
-            }
-        });
+            });
+        } else {
+            // Showing the relavant error message and redirecting to config page for adding the ZIM file
+            uiUtil.systemAlert("Archive not set : please select an archive", "No archive selected").then(function () {
+                $("#btnConfigure").click();
+            });
+        }
     }
     
     function goToMainArticle() {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -929,8 +929,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         if (listOfArchivesFromSettingsStore !== null && listOfArchivesFromSettingsStore !== undefined && listOfArchivesFromSettingsStore !== "") {
             var directories = listOfArchivesFromSettingsStore.split('|');
             populateDropDownListOfArchives(directories);
-        }
-        else {
+        } else {
             searchForArchivesInStorage();
         }
     }
@@ -954,19 +953,16 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         // After that, we can start looking for archives
         storages[0].get("fake-file-to-read").then(searchForArchivesInPreferencesOrStorage,
                                                   searchForArchivesInPreferencesOrStorage);
-    }
-    else {
+    } else {
         // If DeviceStorage is not available, we display the file select components
         displayFileSelect();
         if (document.getElementById('archiveFiles').files && document.getElementById('archiveFiles').files.length>0) {
             // Archive files are already selected, 
             setLocalArchiveFromFileSelect();
-        }
-        else {
+        } else {
             $("#btnConfigure").click();
         }
     }
-
 
     // Display the article when the user goes back in the browser history
     window.onpopstate = function(event) {
@@ -984,8 +980,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             
             if (title && !(""===title)) {
                 goToArticle(title);
-            }
-            else if (titleSearch && titleSearch !== '') {
+            } else if (titleSearch && titleSearch !== '') {
                 $('#prefix').val(titleSearch);
                 if (titleSearch !== appstate.search.prefix) {
                     searchDirEntriesFromPrefix(titleSearch);
@@ -1027,8 +1022,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             }
             // Set the localArchive as the last selected (or the first one if it has never been selected)
             setLocalArchiveFromArchiveList();
-        }
-        else {
+        } else {
             uiUtil.systemAlert("Alert", "Welcome to Kiwix! This application needs at least a ZIM file in your SD-card (or internal storage). Please download one and put it on the device (see About section). Also check that your device is not connected to a computer through USB device storage (which often locks the SD-card content)", false)
             .then(function() {
                 $("#btnAbout").click();
@@ -1881,13 +1875,11 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
             stateObj.title = title;
             urlParameters = "?title=" + title;
             stateLabel = "Wikipedia Article : " + title;
-        }
-        else if (titleSearch && !(""===titleSearch)) {
+        } else if (titleSearch && !(""===titleSearch)) {
             stateObj.titleSearch = titleSearch;
             urlParameters = "?titleSearch=" + titleSearch;
             stateLabel = "Wikipedia search : " + titleSearch;
-        }
-        else {
+        } else {
             return;
         }
         window.history.pushState(stateObj, stateLabel, urlParameters);

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -32,6 +32,9 @@ define([], function () {
    * will not need to be migrated
    * @type {RegExp}
    */
+  
+  // https://www.bitnative.com/2015/02/03/circular-dependencies-in-requirejs/
+  var uiUtil = require('uiUtil'); //using this style to work around circular reference
   var regexpCookieKeysToMigrate = new RegExp([
     'hideActiveContentWarning', 'showUIAnimations', 'appTheme', 'useCache',
     'contentInjectionMode', 'listOfArchives', 'lastSelectedArchive'
@@ -148,7 +151,6 @@ define([], function () {
         });
       }
     }
-    var uiUtil = require('uiUtil');
     if (object) {
       performReset();
     } else {

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -98,7 +98,7 @@ define([], function () {
    * @param {String} object Optional name of the object to disable or delete ('cookie', 'localStorage', 'cacheAPI')
    */
   function reset(object) {
-    const performReset = function () {
+    var performReset = function () {
       // 1. Clear any cookie entries
       if (!object || object === 'cookie') {
         var regexpCookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -98,58 +98,61 @@ define(['jquery', 'uiUtil'], function ($, uiUtil) {
    * @param {String} object Optional name of the object to disable or delete ('cookie', 'localStorage', 'cacheAPI')
    */
   function reset(object) {
-    console.log(uiUtil) //outputs undefined
+    var uiUtil = require('uiUtil');
     // If no specific object was specified, we are doing a general reset, so ask user for confirmation
-    if (!object && !confirm('WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!')) return;
+    uiUtil.systemAlert('Confirmation', 'WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!', true)
+      .then(function (result) {
+        if(!object && !result) return;
 
-    // 1. Clear any cookie entries
-    if (!object || object === 'cookie') {
-      var regexpCookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;
-      var currentCookie = document.cookie;
-      var foundCrumb = false;
-      var cookieCrumb = regexpCookieKeys.exec(currentCookie);
-      while (cookieCrumb !== null) {
-        // DEV: Note that we don't use the keyPrefix in legacy cookie support
-        foundCrumb = true;
-        // This expiry date will cause the browser to delete the cookie crumb on next page refresh
-        document.cookie = cookieCrumb[1] + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
-        cookieCrumb = regexpCookieKeys.exec(currentCookie);
-      }
-      if (foundCrumb) console.debug('All cookie keys were expired...');
-    }
-
-    // 2. Clear any localStorage settings
-    if (!object || object === 'localStorage') {
-      if (params.storeType === 'local_storage') {
-        localStorage.clear();
-        console.debug('All Local Storage settings were deleted...');
-      }
-    }
-
-    // 3. Clear any Cache API caches
-    if (!object || object === 'cacheAPI') {
-      getCacheNames(function (cacheNames) {
-        if (cacheNames && !cacheNames.error) {
-          var cnt = 0;
-          for (var cacheName in cacheNames) {
-            cnt++;
-            caches.delete(cacheNames[cacheName]).then(function () {
-              cnt--;
-              if (!cnt) {
-                // All caches deleted
-                console.debug('All Cache API caches were deleted...');
-                // Reload if user performed full reset or if appCache is needed
-                if (!object || params.appCache) _reloadApp();
-              }
-            });
+        // 1. Clear any cookie entries
+        if (!object || object === 'cookie') {
+          var regexpCookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;
+          var currentCookie = document.cookie;
+          var foundCrumb = false;
+          var cookieCrumb = regexpCookieKeys.exec(currentCookie);
+          while (cookieCrumb !== null) {
+            // DEV: Note that we don't use the keyPrefix in legacy cookie support
+            foundCrumb = true;
+            // This expiry date will cause the browser to delete the cookie crumb on next page refresh
+            document.cookie = cookieCrumb[1] + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
+            cookieCrumb = regexpCookieKeys.exec(currentCookie);
           }
-        } else {
-          console.debug('No Cache API caches were in use (or we do not have access to the names).');
-          // All operations complete, reload if user performed full reset or if appCache is needed
-          if (!object || params.appCache) _reloadApp();
+          if (foundCrumb) console.debug('All cookie keys were expired...');
+        }
+
+        // 2. Clear any localStorage settings
+        if (!object || object === 'localStorage') {
+          if (params.storeType === 'local_storage') {
+            localStorage.clear();
+            console.debug('All Local Storage settings were deleted...');
+          }
+        }
+
+        // 3. Clear any Cache API caches
+        if (!object || object === 'cacheAPI') {
+          getCacheNames(function (cacheNames) {
+            if (cacheNames && !cacheNames.error) {
+              var cnt = 0;
+              for (var cacheName in cacheNames) {
+                cnt++;
+                caches.delete(cacheNames[cacheName]).then(function () {
+                  cnt--;
+                  if (!cnt) {
+                    // All caches deleted
+                    console.debug('All Cache API caches were deleted...');
+                    // Reload if user performed full reset or if appCache is needed
+                    if (!object || params.appCache) _reloadApp();
+                  }
+                });
+              }
+            } else {
+              console.debug('No Cache API caches were in use (or we do not have access to the names).');
+              // All operations complete, reload if user performed full reset or if appCache is needed
+              if (!object || params.appCache) _reloadApp();
+            }
+          });
         }
       });
-    }
   }
 
   // Gets cache names from Service Worker, as we cannot rely on having them in params.cacheNames

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -1,5 +1,5 @@
 'use strict';
-define([], function () {
+define(['jquery', 'uiUtil'], function ($, uiUtil) {
   /**
    * settingsStore.js
    * 
@@ -98,9 +98,10 @@ define([], function () {
    * @param {String} object Optional name of the object to disable or delete ('cookie', 'localStorage', 'cacheAPI')
    */
   function reset(object) {
+    console.log(uiUtil) //outputs undefined
     // If no specific object was specified, we are doing a general reset, so ask user for confirmation
     if (!object && !confirm('WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!')) return;
-    
+
     // 1. Clear any cookie entries
     if (!object || object === 'cookie') {
       var regexpCookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -98,56 +98,66 @@ define([], function () {
    * @param {String} object Optional name of the object to disable or delete ('cookie', 'localStorage', 'cacheAPI')
    */
   function reset(object) {
-    // If no specific object was specified, we are doing a general reset, so ask user for confirmation
-    if (!object && !confirm('WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!')) return;
-    
-    // 1. Clear any cookie entries
-    if (!object || object === 'cookie') {
-      var regexpCookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;
-      var currentCookie = document.cookie;
-      var foundCrumb = false;
-      var cookieCrumb = regexpCookieKeys.exec(currentCookie);
-      while (cookieCrumb !== null) {
-        // DEV: Note that we don't use the keyPrefix in legacy cookie support
-        foundCrumb = true;
-        // This expiry date will cause the browser to delete the cookie crumb on next page refresh
-        document.cookie = cookieCrumb[1] + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
-        cookieCrumb = regexpCookieKeys.exec(currentCookie);
-      }
-      if (foundCrumb) console.debug('All cookie keys were expired...');
-    }
-
-    // 2. Clear any localStorage settings
-    if (!object || object === 'localStorage') {
-      if (params.storeType === 'local_storage') {
-        localStorage.clear();
-        console.debug('All Local Storage settings were deleted...');
-      }
-    }
-
-    // 3. Clear any Cache API caches
-    if (!object || object === 'cacheAPI') {
-      getCacheNames(function (cacheNames) {
-        if (cacheNames && !cacheNames.error) {
-          var cnt = 0;
-          for (var cacheName in cacheNames) {
-            cnt++;
-            caches.delete(cacheNames[cacheName]).then(function () {
-              cnt--;
-              if (!cnt) {
-                // All caches deleted
-                console.debug('All Cache API caches were deleted...');
-                // Reload if user performed full reset or if appCache is needed
-                if (!object || params.appCache) _reloadApp();
-              }
-            });
-          }
-        } else {
-          console.debug('No Cache API caches were in use (or we do not have access to the names).');
-          // All operations complete, reload if user performed full reset or if appCache is needed
-          if (!object || params.appCache) _reloadApp();
+    const performReset = function () {
+      // 1. Clear any cookie entries
+      if (!object || object === 'cookie') {
+        var regexpCookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;
+        var currentCookie = document.cookie;
+        var foundCrumb = false;
+        var cookieCrumb = regexpCookieKeys.exec(currentCookie);
+        while (cookieCrumb !== null) {
+          // DEV: Note that we don't use the keyPrefix in legacy cookie support
+          foundCrumb = true;
+          // This expiry date will cause the browser to delete the cookie crumb on next page refresh
+          document.cookie = cookieCrumb[1] + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
+          cookieCrumb = regexpCookieKeys.exec(currentCookie);
         }
-      });
+        if (foundCrumb) console.debug('All cookie keys were expired...');
+      }
+
+      // 2. Clear any localStorage settings
+      if (!object || object === 'localStorage') {
+        if (params.storeType === 'local_storage') {
+          localStorage.clear();
+          console.debug('All Local Storage settings were deleted...');
+        }
+      }
+
+      // 3. Clear any Cache API caches
+      if (!object || object === 'cacheAPI') {
+        getCacheNames(function (cacheNames) {
+          if (cacheNames && !cacheNames.error) {
+            var cnt = 0;
+            for (var cacheName in cacheNames) {
+              cnt++;
+              caches.delete(cacheNames[cacheName]).then(function () {
+                cnt--;
+                if (!cnt) {
+                  // All caches deleted
+                  console.debug('All Cache API caches were deleted...');
+                  // Reload if user performed full reset or if appCache is needed
+                  if (!object || params.appCache) _reloadApp();
+                }
+              });
+            }
+          } else {
+            console.debug('No Cache API caches were in use (or we do not have access to the names).');
+            // All operations complete, reload if user performed full reset or if appCache is needed
+            if (!object || params.appCache) _reloadApp();
+          }
+        });
+      }
+    }
+    var uiUtil = require('uiUtil');
+    if (object) {
+      performReset();
+    } else {
+      // If no specific object was specified, we are doing a general reset, so ask user for confirmation
+      uiUtil.systemAlert('WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!', 'Warning!', true).then(function (response) {
+        if (response) {
+          performReset();
+        }
+      })
     }
   }
 

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -100,7 +100,7 @@ define([], function () {
   function reset(object) {
     var uiUtil = require('uiUtil');
     // If no specific object was specified, we are doing a general reset, so ask user for confirmation
-    uiUtil.systemAlert('Confirmation', 'WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!', true, "Decline", "Approve")
+    uiUtil.systemAlert('Confirmation', 'WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!', true)
       .then(function (confirmation) {
         if(!object && !confirmation) return;
 

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -100,7 +100,7 @@ define([], function () {
   function reset(object) {
     var uiUtil = require('uiUtil');
     // If no specific object was specified, we are doing a general reset, so ask user for confirmation
-    uiUtil.systemAlert('Confirmation', 'WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!', true)
+    uiUtil.systemAlert('Confirmation', 'WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!', true, "Decline", "Approve")
       .then(function (confirmation) {
         if(!object && !confirmation) return;
 

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -148,7 +148,7 @@ define([], function () {
           if (!object || params.appCache) _reloadApp();
         }
       });
-    }  
+    }
   }
 
   // Gets cache names from Service Worker, as we cannot rely on having them in params.cacheNames

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -32,9 +32,7 @@ define([], function () {
    * will not need to be migrated
    * @type {RegExp}
    */
-  
-  // https://www.bitnative.com/2015/02/03/circular-dependencies-in-requirejs/
-  var uiUtil = require('uiUtil'); //using this style to work around circular reference
+
   var regexpCookieKeysToMigrate = new RegExp([
     'hideActiveContentWarning', 'showUIAnimations', 'appTheme', 'useCache',
     'contentInjectionMode', 'listOfArchives', 'lastSelectedArchive'
@@ -101,6 +99,9 @@ define([], function () {
    * @param {String} object Optional name of the object to disable or delete ('cookie', 'localStorage', 'cacheAPI')
    */
   function reset(object) {
+    // https://www.bitnative.com/2015/02/03/circular-dependencies-in-requirejs/
+    var uiUtil = require('uiUtil'); //using this style to work around circular reference
+    
     var performReset = function () {
       // 1. Clear any cookie entries
       if (!object || object === 'cookie') {

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -101,8 +101,8 @@ define([], function () {
     var uiUtil = require('uiUtil');
     // If no specific object was specified, we are doing a general reset, so ask user for confirmation
     uiUtil.systemAlert('Confirmation', 'WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!', true)
-      .then(function (result) {
-        if(!object && !result) return;
+      .then(function (confirmation) {
+        if(!object && !confirmation) return;
 
         // 1. Clear any cookie entries
         if (!object || object === 'cookie') {

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -1,5 +1,5 @@
 'use strict';
-define(['jquery', 'uiUtil'], function ($, uiUtil) {
+define([], function () {
   /**
    * settingsStore.js
    * 

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -98,16 +98,9 @@ define([], function () {
    * @param {String} object Optional name of the object to disable or delete ('cookie', 'localStorage', 'cacheAPI')
    */
   function reset(object) {
-    //Requiring uiUtil to handle circular dependency b/w settingsStore and uiUtil
-    var uiUtil = require('uiUtil');
     // If no specific object was specified, we are doing a general reset, so ask user for confirmation
-    if (!object) {
-      uiUtil.systemAlert('Confirmation', 'WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!', true)
-        .then(function (confirmation) {
-          if (!confirmation) return;
-        });
-    }
-
+    if (!object && !confirm('WARNING: This will reset the app to a freshly installed state, deleting all app caches and settings!')) return;
+    
     // 1. Clear any cookie entries
     if (!object || object === 'cookie') {
       var regexpCookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -39,8 +39,8 @@ define(rqDef, function(settingsStore) {
      * @param {String} label The modal's label or title which appears in the header 
      * @param {String} message The alert message to display in the body of the modal 
      * @param {Boolean} isConfirm If true, the modal will be a confirm dialog box, otherwise it will be an alert 
-     * @param {String} declineButtonText The text to display on the decline button(optional, Default = "Cancel") 
-     * @param {String} approveButtonText  The text to display on the approve button(optional, Default = "Confirm")
+     * @param {String} declineButtonText The text to display on the decline button (optional, Default = "Cancel") 
+     * @param {String} approveButtonText  The text to display on the approve button (optional, Default = "Confirm")
      * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel, backdrop or the cross(x) button
      */
     function systemAlert(label, message, isConfirm, declineButtonText = "Cancel", approveButtonText = "Confirm") {
@@ -54,7 +54,7 @@ define(rqDef, function(settingsStore) {
             document.getElementById("approveModal").style.visibility = isConfirm ? "visible" : "hidden";
             $("#alertModal").modal("show");
             // When hide model is called, resolve promise with true if hidden using approve button, false otherwise
-            $('#alertModal').on("hide.bs.modal", function () {
+            $("#alertModal").on("hide.bs.modal", function () {
                 const closeSource = document.activeElement;
                 if (closeSource.id === "approveModal") {
                     resolve(true);

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -32,6 +32,35 @@ if (webpMachine) {
 }
 
 define(rqDef, function(settingsStore) {
+
+    /**
+     * Displays a Bootstrap alert or confirm dialog box depending on the options provided
+     * @param {*} node 
+     * @param {*} nodeAttribute 
+     * @param {*} content 
+     * @param {*} mimeType 
+     * @param {*} callback 
+     */
+    function systemAlert(label, message, isConfirm){
+        return new Promise(function(resolve, reject) {
+            document.getElementById("modalLabel").innerHTML = label;
+            document.getElementById("modalText").innerHTML = message;
+            if(isConfirm){
+                document.getElementById("confirmModal").style.visibility = "visible";
+                document.getElementById("confirmModal").onclick = function(){
+                    $("#alertModal").modal('hide');
+                    resolve(true);
+                };
+            }
+
+            $("#alertModal").modal('show');
+
+            document.getElementById("closeModal").onclick = function() {
+                $("#alertModal").modal('hide');
+                resolve(false);
+            };
+        });
+    }
   
     /**
      * Creates either a blob: or data: URI from the given content
@@ -491,6 +520,7 @@ define(rqDef, function(settingsStore) {
      * Functions and classes exposed by this module
      */
     return {
+        systemAlert: systemAlert,
         feedNodeWithBlob: feedNodeWithBlob,
         replaceCSSLinkWithInlineCSS: replaceCSSLinkWithInlineCSS,
         deriveZimUrlFromRelativeUrl: deriveZimUrlFromRelativeUrl,

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -45,9 +45,9 @@ define(rqDef, function(settingsStore) {
      * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel/Okay, backdrop or the cross(x) button
      */
     function systemAlert(message, label, isConfirm, declineConfirmLabel, approveConfirmLabel, closeMessageLabel) {
-        declineConfirmLabel = declineConfirmLabel || document.getElementById("declineConfirm").textContent;
-        approveConfirmLabel = approveConfirmLabel || document.getElementById("approveConfirm").textContent;
-        closeMessageLabel = closeMessageLabel || document.getElementById("closeMessage").textContent;
+        declineConfirmLabel = declineConfirmLabel || "Cancel";
+        approveConfirmLabel = approveConfirmLabel || "Confirm";
+        closeMessageLabel = closeMessageLabel || "Okay";
         label = label || (isConfirm ? "Confirmation" : "Message");
         return new Promise(function (resolve, reject) {
             if (!message) reject("Missing body message");

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -35,6 +35,7 @@ define(rqDef, function(settingsStore) {
 
     /**
      * Displays a Bootstrap alert or confirm dialog box depending on the options provided
+     * 
      * @param {String} label The modal's label or title which appears in the header 
      * @param {String} message The alert message to display in the body of the modal 
      * @param {Boolean} isConfirm If true, the modal will be a confirm dialog box, otherwise it will be an alert 
@@ -42,24 +43,23 @@ define(rqDef, function(settingsStore) {
      */
     function systemAlert(label, message, isConfirm){
         return new Promise(function (resolve, reject) {
+            if(!label || !message){
+                reject('Missing parameters');
+            }
             document.getElementById("modalLabel").innerHTML = label;
             document.getElementById("modalText").innerHTML = message;
-            if (isConfirm){
-                document.getElementById("confirmModal").style.visibility = "visible";
-                document.getElementById("confirmModal").onclick = function(){
-                    $("#alertModal").modal("hide");
-                    resolve(true);
-                };
-            } else {
-                document.getElementById("confirmModal").style.visibility = "hidden";
-            }
-
+            // Displays an additional Confirm button if isConfirm is true
+            document.getElementById("confirmModal").style.visibility = isConfirm ? "visible" : "hidden";
             $("#alertModal").modal("show");
-
-            document.getElementById("closeModal").onclick = function() {
-                $("#alertModal").modal("hide");
-                resolve(false);
-            };
+            // When the modal is hidden, resolve promise with true if hidden using Confirm button, false otherwise
+            $('#alertModal').on('hide.bs.modal', function() {
+                const closeSource = document.activeElement;
+                if (closeSource.id === "confirmModal"){
+                    resolve(true);
+                } else {
+                    resolve(false);
+                }
+            });
         });
     }
   

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -53,7 +53,7 @@ define(rqDef, function(settingsStore) {
             // Displays an additional Confirm button if isConfirm is true
             document.getElementById("approveModal").style.visibility = isConfirm ? "visible" : "hidden";
             $("#alertModal").modal("show");
-            // When the modal is hidden, resolve promise with true if hidden using Confirm button, false otherwise
+            // When hide model is called, resolve promise with true if hidden using approve button, false otherwise
             $('#alertModal').on("hide.bs.modal", function () {
                 const closeSource = document.activeElement;
                 if (closeSource.id === "approveModal") {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -39,6 +39,8 @@ define(rqDef, function(settingsStore) {
      * @param {String} label The modal's label or title which appears in the header 
      * @param {String} message The alert message to display in the body of the modal 
      * @param {Boolean} isConfirm If true, the modal will be a confirm dialog box, otherwise it will be an alert 
+     * @param {String} declineButtonText The text to display on the decline button(optional, Default = "Cancel") 
+     * @param {String} approveButtonText  The text to display on the approve button(optional, Default = "Confirm")
      * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel, backdrop or the cross(x) button
      */
     function systemAlert(label, message, isConfirm, declineButtonText = "Cancel", approveButtonText = "Confirm") {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -36,18 +36,19 @@ define(rqDef, function(settingsStore) {
     /**
      * Displays a Bootstrap alert or confirm dialog box depending on the options provided
      * 
-     * @param {String} label The modal's label or title which appears in the header 
      * @param {String} message The alert message to display in the body of the modal 
+     * @param {String} label The modal's label or title which appears in the header (optional, Default = "Confirmation" or "Message")
      * @param {Boolean} isConfirm If true, the modal will be a confirm dialog box, otherwise it will be an alert 
      * @param {String} declineButtonText The text to display on the decline button (optional, Default = "Cancel") 
      * @param {String} approveButtonText  The text to display on the approve button (optional, Default = "Confirm")
      * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel, backdrop or the cross(x) button
      */
-    function systemAlert(label, message, isConfirm, declineButtonText, approveButtonText) {
+    function systemAlert(message, label, isConfirm, declineButtonText, approveButtonText) {
         declineButtonText = declineButtonText || "Cancel";
         approveButtonText = approveButtonText || "Confirm";
+        label = label || (isConfirm ? "Confirmation" : "Message");
         return new Promise(function (resolve, reject) {
-            if (!label || !message) reject("Missing parameters");
+            if (!message) reject("Missing body message");
             document.getElementById("declineModal").innerHTML = declineButtonText;
             document.getElementById("approveModal").innerHTML = approveButtonText;
             document.getElementById("modalLabel").innerHTML = label;

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -35,11 +35,10 @@ define(rqDef, function(settingsStore) {
 
     /**
      * Displays a Bootstrap alert or confirm dialog box depending on the options provided
-     * @param {*} node 
-     * @param {*} nodeAttribute 
-     * @param {*} content 
-     * @param {*} mimeType 
-     * @param {*} callback 
+     * @param {String} label The modal's label or title which appears in the header 
+     * @param {String} message The alert message to display in the body of the modal 
+     * @param {Boolean} isConfirm If true, the modal will be a confirm dialog box, otherwise it will be an alert 
+     * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel, backdrop or the cross(x) button
      */
     function systemAlert(label, message, isConfirm){
         return new Promise(function (resolve, reject) {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -45,9 +45,7 @@ define(rqDef, function(settingsStore) {
      */
     function systemAlert(label, message, isConfirm, declineButtonText = "Cancel", approveButtonText = "Confirm") {
         return new Promise(function (resolve, reject) {
-            if(!label || !message){
-                reject("Missing parameters");
-            }
+            if (!label || !message) reject("Missing parameters");
             document.getElementById("declineModal").innerHTML = declineButtonText;
             document.getElementById("approveModal").innerHTML = approveButtonText;
             document.getElementById("modalLabel").innerHTML = label;
@@ -56,9 +54,9 @@ define(rqDef, function(settingsStore) {
             document.getElementById("approveModal").style.visibility = isConfirm ? "visible" : "hidden";
             $("#alertModal").modal("show");
             // When the modal is hidden, resolve promise with true if hidden using Confirm button, false otherwise
-            $('#alertModal').on("hide.bs.modal", function() {
+            $('#alertModal').on("hide.bs.modal", function () {
                 const closeSource = document.activeElement;
-                if (closeSource.id === "approveModal"){
+                if (closeSource.id === "approveModal") {
                     resolve(true);
                 } else {
                     resolve(false);

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -52,6 +52,9 @@ define(rqDef, function(settingsStore) {
                     resolve(true);
                 };
             }
+            else{
+                document.getElementById("confirmModal").style.visibility = "hidden";
+            }
 
             $("#alertModal").modal('show');
 

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -38,28 +38,35 @@ define(rqDef, function(settingsStore) {
      * 
      * @param {String} message The alert message to display in the body of the modal 
      * @param {String} label The modal's label or title which appears in the header (optional, Default = "Confirmation" or "Message")
-     * @param {Boolean} isConfirm If true, the modal will be a confirm dialog box, otherwise it will be an alert 
-     * @param {String} declineButtonText The text to display on the decline button (optional, Default = "Cancel") 
-     * @param {String} approveButtonText  The text to display on the approve button (optional, Default = "Confirm")
-     * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel, backdrop or the cross(x) button
+     * @param {Boolean} isConfirm If true, the modal will be a confirm dialog box, otherwise it will be a simple alert message 
+     * @param {String} declineConfirmButton The text to display on the decline confirmation button (optional, Default = "Cancel") 
+     * @param {String} approveConfirmButton  The text to display on the approve confirmation button (optional, Default = "Confirm")
+     * @param {String} closeMessageButton  The text to display on the close alert message button (optional, Default = "Okay")
+     * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel/Okay, backdrop or the cross(x) button
      */
-    function systemAlert(message, label, isConfirm, declineButtonText, approveButtonText) {
-        declineButtonText = declineButtonText || document.getElementById("declineModal").innerText;
-        approveButtonText = approveButtonText || document.getElementById("approveModal").innerText;
+    function systemAlert(message, label, isConfirm, declineConfirmButton, approveConfirmButton, closeMessageButton) {
+        declineConfirmButton = declineConfirmButton || document.getElementById("declineConfirm").innerText;
+        approveConfirmButton = approveConfirmButton || document.getElementById("approveConfirm").innerText;
+        closeMessageButton = closeMessageButton || document.getElementById("closeMessage").innerText;
         label = label || (isConfirm ? "Confirmation" : "Message");
         return new Promise(function (resolve, reject) {
             if (!message) reject("Missing body message");
-            document.getElementById("declineModal").textContent = declineButtonText;
-            document.getElementById("approveModal").textContent = approveButtonText;
+            // Set the text to the modal and it's buttons
+            document.getElementById("approveConfirm").textContent = approveConfirmButton;
+            document.getElementById("declineConfirm").textContent = declineConfirmButton;
+            document.getElementById("closeMessage").textContent = closeMessageButton;
             document.getElementById("modalLabel").textContent = label;
             document.getElementById("modalText").textContent = message;
-            // Displays an additional Confirm button if isConfirm is true
-            document.getElementById("approveModal").style.visibility = isConfirm ? "visible" : "hidden";
+            // Display buttons acc to the type of alert
+            document.getElementById("approveConfirm").style.display = isConfirm ? "block" : "none";
+            document.getElementById("declineConfirm").style.display = isConfirm ? "block" : "none";
+            document.getElementById("closeMessage").style.display = isConfirm ? "none" : "block";
+            // Display the modal
             $("#alertModal").modal("show");
             // When hide model is called, resolve promise with true if hidden using approve button, false otherwise
             $("#alertModal").on("hide.bs.modal", function () {
                 const closeSource = document.activeElement;
-                if (closeSource.id === "approveModal") {
+                if (closeSource.id === "approveConfirm") {
                     resolve(true);
                 } else {
                     resolve(false);

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -42,24 +42,23 @@ define(rqDef, function(settingsStore) {
      * @param {*} callback 
      */
     function systemAlert(label, message, isConfirm){
-        return new Promise(function(resolve, reject) {
+        return new Promise(function (resolve, reject) {
             document.getElementById("modalLabel").innerHTML = label;
             document.getElementById("modalText").innerHTML = message;
-            if(isConfirm){
+            if (isConfirm){
                 document.getElementById("confirmModal").style.visibility = "visible";
                 document.getElementById("confirmModal").onclick = function(){
-                    $("#alertModal").modal('hide');
+                    $("#alertModal").modal("hide");
                     resolve(true);
                 };
-            }
-            else{
+            } else {
                 document.getElementById("confirmModal").style.visibility = "hidden";
             }
 
-            $("#alertModal").modal('show');
+            $("#alertModal").modal("show");
 
             document.getElementById("closeModal").onclick = function() {
-                $("#alertModal").modal('hide');
+                $("#alertModal").modal("hide");
                 resolve(false);
             };
         });

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -43,7 +43,9 @@ define(rqDef, function(settingsStore) {
      * @param {String} approveButtonText  The text to display on the approve button (optional, Default = "Confirm")
      * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel, backdrop or the cross(x) button
      */
-    function systemAlert(label, message, isConfirm, declineButtonText = "Cancel", approveButtonText = "Confirm") {
+    function systemAlert(label, message, isConfirm, declineButtonText, approveButtonText) {
+        declineButtonText = declineButtonText || "Cancel";
+        approveButtonText = approveButtonText || "Confirm";
         return new Promise(function (resolve, reject) {
             if (!label || !message) reject("Missing parameters");
             document.getElementById("declineModal").innerHTML = declineButtonText;

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -46,7 +46,7 @@ define(rqDef, function(settingsStore) {
     function systemAlert(label, message, isConfirm, declineButtonText = "Cancel", approveButtonText = "Confirm") {
         return new Promise(function (resolve, reject) {
             if(!label || !message){
-                reject('Missing parameters');
+                reject("Missing parameters");
             }
             document.getElementById("declineModal").innerHTML = declineButtonText;
             document.getElementById("approveModal").innerHTML = approveButtonText;
@@ -56,7 +56,7 @@ define(rqDef, function(settingsStore) {
             document.getElementById("approveModal").style.visibility = isConfirm ? "visible" : "hidden";
             $("#alertModal").modal("show");
             // When the modal is hidden, resolve promise with true if hidden using Confirm button, false otherwise
-            $('#alertModal').on('hide.bs.modal', function() {
+            $('#alertModal').on("hide.bs.modal", function() {
                 const closeSource = document.activeElement;
                 if (closeSource.id === "approveModal"){
                     resolve(true);

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -45,9 +45,9 @@ define(rqDef, function(settingsStore) {
      * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel/Okay, backdrop or the cross(x) button
      */
     function systemAlert(message, label, isConfirm, declineConfirmButton, approveConfirmButton, closeMessageButton) {
-        declineConfirmButton = declineConfirmButton || document.getElementById("declineConfirm").innerText;
-        approveConfirmButton = approveConfirmButton || document.getElementById("approveConfirm").innerText;
-        closeMessageButton = closeMessageButton || document.getElementById("closeMessage").innerText;
+        declineConfirmButton = declineConfirmButton || document.getElementById("declineConfirm").textContent;
+        approveConfirmButton = approveConfirmButton || document.getElementById("approveConfirm").textContent;
+        closeMessageButton = closeMessageButton || document.getElementById("closeMessage").textContent;
         label = label || (isConfirm ? "Confirmation" : "Message");
         return new Promise(function (resolve, reject) {
             if (!message) reject("Missing body message");

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -41,20 +41,22 @@ define(rqDef, function(settingsStore) {
      * @param {Boolean} isConfirm If true, the modal will be a confirm dialog box, otherwise it will be an alert 
      * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel, backdrop or the cross(x) button
      */
-    function systemAlert(label, message, isConfirm){
+    function systemAlert(label, message, isConfirm, declineButtonText = "Cancel", approveButtonText = "Confirm") {
         return new Promise(function (resolve, reject) {
             if(!label || !message){
                 reject('Missing parameters');
             }
+            document.getElementById("declineModal").innerHTML = declineButtonText;
+            document.getElementById("approveModal").innerHTML = approveButtonText;
             document.getElementById("modalLabel").innerHTML = label;
             document.getElementById("modalText").innerHTML = message;
             // Displays an additional Confirm button if isConfirm is true
-            document.getElementById("confirmModal").style.visibility = isConfirm ? "visible" : "hidden";
+            document.getElementById("approveModal").style.visibility = isConfirm ? "visible" : "hidden";
             $("#alertModal").modal("show");
             // When the modal is hidden, resolve promise with true if hidden using Confirm button, false otherwise
             $('#alertModal').on('hide.bs.modal', function() {
                 const closeSource = document.activeElement;
-                if (closeSource.id === "confirmModal"){
+                if (closeSource.id === "approveModal"){
                     resolve(true);
                 } else {
                     resolve(false);

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -39,22 +39,22 @@ define(rqDef, function(settingsStore) {
      * @param {String} message The alert message to display in the body of the modal 
      * @param {String} label The modal's label or title which appears in the header (optional, Default = "Confirmation" or "Message")
      * @param {Boolean} isConfirm If true, the modal will be a confirm dialog box, otherwise it will be a simple alert message 
-     * @param {String} declineConfirmButton The text to display on the decline confirmation button (optional, Default = "Cancel") 
-     * @param {String} approveConfirmButton  The text to display on the approve confirmation button (optional, Default = "Confirm")
-     * @param {String} closeMessageButton  The text to display on the close alert message button (optional, Default = "Okay")
+     * @param {String} declineConfirmLabel The text to display on the decline confirmation button (optional, Default = "Cancel") 
+     * @param {String} approveConfirmLabel  The text to display on the approve confirmation button (optional, Default = "Confirm")
+     * @param {String} closeMessageLabel  The text to display on the close alert message button (optional, Default = "Okay")
      * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel/Okay, backdrop or the cross(x) button
      */
-    function systemAlert(message, label, isConfirm, declineConfirmButton, approveConfirmButton, closeMessageButton) {
-        declineConfirmButton = declineConfirmButton || document.getElementById("declineConfirm").textContent;
-        approveConfirmButton = approveConfirmButton || document.getElementById("approveConfirm").textContent;
-        closeMessageButton = closeMessageButton || document.getElementById("closeMessage").textContent;
+    function systemAlert(message, label, isConfirm, declineConfirmLabel, approveConfirmLabel, closeMessageLabel) {
+        declineConfirmLabel = declineConfirmLabel || document.getElementById("declineConfirm").textContent;
+        approveConfirmLabel = approveConfirmLabel || document.getElementById("approveConfirm").textContent;
+        closeMessageLabel = closeMessageLabel || document.getElementById("closeMessage").textContent;
         label = label || (isConfirm ? "Confirmation" : "Message");
         return new Promise(function (resolve, reject) {
             if (!message) reject("Missing body message");
             // Set the text to the modal and it's buttons
-            document.getElementById("approveConfirm").textContent = approveConfirmButton;
-            document.getElementById("declineConfirm").textContent = declineConfirmButton;
-            document.getElementById("closeMessage").textContent = closeMessageButton;
+            document.getElementById("approveConfirm").textContent = approveConfirmLabel;
+            document.getElementById("declineConfirm").textContent = declineConfirmLabel;
+            document.getElementById("closeMessage").textContent = closeMessageLabel;
             document.getElementById("modalLabel").textContent = label;
             document.getElementById("modalText").textContent = message;
             // Display buttons acc to the type of alert

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -44,15 +44,15 @@ define(rqDef, function(settingsStore) {
      * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel, backdrop or the cross(x) button
      */
     function systemAlert(message, label, isConfirm, declineButtonText, approveButtonText) {
-        declineButtonText = declineButtonText || "Cancel";
-        approveButtonText = approveButtonText || "Confirm";
+        declineButtonText = declineButtonText || document.getElementById("declineModal").innerText;
+        approveButtonText = approveButtonText || document.getElementById("approveModal").innerText;
         label = label || (isConfirm ? "Confirmation" : "Message");
         return new Promise(function (resolve, reject) {
             if (!message) reject("Missing body message");
-            document.getElementById("declineModal").innerHTML = declineButtonText;
-            document.getElementById("approveModal").innerHTML = approveButtonText;
-            document.getElementById("modalLabel").innerHTML = label;
-            document.getElementById("modalText").innerHTML = message;
+            document.getElementById("declineModal").textContent = declineButtonText;
+            document.getElementById("approveModal").textContent = approveButtonText;
+            document.getElementById("modalLabel").textContent = label;
+            document.getElementById("modalText").textContent = message;
             // Displays an additional Confirm button if isConfirm is true
             document.getElementById("approveModal").style.visibility = isConfirm ? "visible" : "hidden";
             $("#alertModal").modal("show");

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -58,9 +58,9 @@ define(rqDef, function(settingsStore) {
             document.getElementById("modalLabel").textContent = label;
             document.getElementById("modalText").textContent = message;
             // Display buttons acc to the type of alert
-            document.getElementById("approveConfirm").style.display = isConfirm ? "block" : "none";
-            document.getElementById("declineConfirm").style.display = isConfirm ? "block" : "none";
-            document.getElementById("closeMessage").style.display = isConfirm ? "none" : "block";
+            document.getElementById("approveConfirm").style.display = isConfirm ? "inline" : "none";
+            document.getElementById("declineConfirm").style.display = isConfirm ? "inline" : "none";
+            document.getElementById("closeMessage").style.display = isConfirm ? "none" : "inline";
             // Display the modal
             $("#alertModal").modal("show");
             // When hide model is called, resolve promise with true if hidden using approve button, false otherwise

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -94,13 +94,13 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8', 'uiUtil'],
                 that._searchArchiveParts(storage, path.slice(0, -2)).then(function(fileArray) {
                     createZimfile(fileArray);
                 }, function(error) {
-                    uiUtil.systemAlert("Error reading archive files", "Error reading files in split archive " + path + ": " + error, false);
+                    uiUtil.systemAlert("Error reading files in split archive " + path + ": " + error, "Error reading archive files");
                 });
             } else {
                 storage.get(path).then(function(file) {
                     createZimfile([file]);
                 }, function(error) {
-                    uiUtil.systemAlert("Error reading archive file", "Error reading ZIM file " + path + " : " + error, false);
+                    uiUtil.systemAlert("Error reading ZIM file " + path + " : " + error, "Error reading archive file");
                 });
             }
         }

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -94,13 +94,13 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8', 'uiUtil'],
                 that._searchArchiveParts(storage, path.slice(0, -2)).then(function(fileArray) {
                     createZimfile(fileArray);
                 }, function(error) {
-                    uiUtil.systemAlert("Alert", "Error reading files in split archive " + path + ": " + error, false);
+                    uiUtil.systemAlert("Error reading archive files", "Error reading files in split archive " + path + ": " + error, false);
                 });
             } else {
                 storage.get(path).then(function(file) {
                     createZimfile([file]);
                 }, function(error) {
-                    uiUtil.systemAlert("Alert", "Error reading ZIM file " + path + " : " + error, false);
+                    uiUtil.systemAlert("Error reading archive file", "Error reading ZIM file " + path + " : " + error, false);
                 });
             }
         }

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -20,8 +20,8 @@
  * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
  */
 'use strict';
-define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
-    function(zimfile, zimDirEntry, util, utf8) {
+define(['zimfile', 'zimDirEntry', 'util', 'utf8', 'uiUtil'],
+    function(zimfile, zimDirEntry, util, utf8, uiUtil) {
     
     /**
      * ZIM Archive
@@ -88,21 +88,19 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
             var fileArray = [].slice.call(fileList);
             // The constructor has been called with an array of File/Blob parameter
             createZimfile(fileArray);
-        }
-        else {
+        } else {
             if (/.*zim..$/.test(path)) {
                 // split archive
                 that._searchArchiveParts(storage, path.slice(0, -2)).then(function(fileArray) {
                     createZimfile(fileArray);
                 }, function(error) {
-                    alert("Error reading files in split archive " + path + ": " + error);
+                    uiUtil.systemAlert("Alert", "Error reading files in split archive " + path + ": " + error, false);
                 });
-            }
-            else {
+            } else {
                 storage.get(path).then(function(file) {
                     createZimfile([file]);
                 }, function(error) {
-                    alert("Error reading ZIM file " + path + " : " + error);
+                    uiUtil.systemAlert("Alert", "Error reading ZIM file " + path + " : " + error, false);
                 });
             }
         }

--- a/www/js/lib/zimArchiveLoader.js
+++ b/www/js/lib/zimArchiveLoader.js
@@ -69,7 +69,7 @@ define(['zimArchive', 'jquery', 'uiUtil'],
         jQuery.when.apply(null, promises).then(function() {
             callbackFunction(directories);
         }, function(error) {
-            uiUtil.systemAlert("Alert", "Error scanning your SD card : " + error
+            uiUtil.systemAlert("Error reading Device Storage", "Error scanning your device storage : " + error
             + ". If you're using the Firefox OS Simulator, please put the archives in "
             + "a 'fake-sdcard' directory inside your Firefox profile "
             + "(ex : ~/.mozilla/firefox/xxxx.default/extensions/fxos_2_x_simulator@mozilla.org/"

--- a/www/js/lib/zimArchiveLoader.js
+++ b/www/js/lib/zimArchiveLoader.js
@@ -20,8 +20,8 @@
  * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
  */
 'use strict';
-define(['zimArchive', 'jquery'],
-       function(zimArchive, jQuery) {
+define(['zimArchive', 'jquery', 'uiUtil'],
+       function(zimArchive, jQuery, uiUtil) {
 
     /**
      * Create a ZIMArchive from DeviceStorage location
@@ -69,12 +69,11 @@ define(['zimArchive', 'jquery'],
         jQuery.when.apply(null, promises).then(function() {
             callbackFunction(directories);
         }, function(error) {
-            alert("Error scanning your SD card : " + error
-                    + ". If you're using the Firefox OS Simulator, please put the archives in "
-                    + "a 'fake-sdcard' directory inside your Firefox profile "
-                    + "(ex : ~/.mozilla/firefox/xxxx.default/extensions/fxos_2_x_simulator@mozilla.org/"
-                    + "profile/fake-sdcard/wikipedia_en_ray_charles_2015-06.zim)");
-            callbackFunction(null);
+            uiUtil.systemAlert("Alert", "Error scanning your SD card : " + error
+            + ". If you're using the Firefox OS Simulator, please put the archives in "
+            + "a 'fake-sdcard' directory inside your Firefox profile "
+            + "(ex : ~/.mozilla/firefox/xxxx.default/extensions/fxos_2_x_simulator@mozilla.org/"
+            + "profile/fake-sdcard/wikipedia_en_ray_charles_2015-06.zim)", false).then(function() { callbackFunction(null); });
         });
     };
 

--- a/www/js/lib/zimArchiveLoader.js
+++ b/www/js/lib/zimArchiveLoader.js
@@ -69,11 +69,11 @@ define(['zimArchive', 'jquery', 'uiUtil'],
         jQuery.when.apply(null, promises).then(function() {
             callbackFunction(directories);
         }, function(error) {
-            uiUtil.systemAlert("Error reading Device Storage", "Error scanning your device storage : " + error
+            uiUtil.systemAlert("Error scanning your device storage : " + error
             + ". If you're using the Firefox OS Simulator, please put the archives in "
             + "a 'fake-sdcard' directory inside your Firefox profile "
             + "(ex : ~/.mozilla/firefox/xxxx.default/extensions/fxos_2_x_simulator@mozilla.org/"
-            + "profile/fake-sdcard/wikipedia_en_ray_charles_2015-06.zim)", false).then(function() { callbackFunction(null); });
+            + "profile/fake-sdcard/wikipedia_en_ray_charles_2015-06.zim)", "Error reading Device Storage").then(function() { callbackFunction(null); });
         });
     };
 


### PR DESCRIPTION
# Closes #821 
Added a message alert when the user shuffles without loading a ZIM file

### Changes
- Calling the `goToRandomArticle` only when `selectedArchive !== null && selectedArchive.isReady()` is true. Oherwise, calling the `uiUtil.systemAlert` with an apt message


### Screenshot
![127 0 0 1_5500_www_index html (5)](https://user-images.githubusercontent.com/45741026/152693554-ad9d1030-8fb8-494f-a941-481e1ac57b82.png)

### Related Issues
- Issue #821 