### PR TITLE
Fix errors in publish extension workflow and add logging

### DIFF
--- a/.github/workflows/publish-extension.yaml
+++ b/.github/workflows/publish-extension.yaml
@@ -44,26 +44,8 @@ jobs:
           TAG_VERSION: ${{ github.event.release.tag_name }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          # Use the override value by preference
-          VERSION=${INPUT_VERSION}
-          if [[ $VERSION =~ ^[0-9.]+$ ]]; then
-            echo "Using the valid override input and setting version to $VERSION"
-          else
-            # If no valid override input was entered, then try to use the release tag
-            VERSION=${TAG_VERSION}
-            if [[ $VERSION =~ ^[0-9.]+$ ]]; then
-              echo "Using the release tag and setting version to $VERSION"
-            else
-              echo "No valid override or tag was provided. File version numbers were unchanged."
-              echo "To rewrite version numbers in app, ensure the tag matches ^[0-9.]+$"
-            fi
-          fi
-          # If Version matches a release pattern, then set the appVersion in the files to be published
-          if [[ $VERSION =~ ^[0-9.]+ ]]; then
-            echo "Rewriting appVersion in service-worker.js and app.js to $VERSION ..."
-            sed -i -E "s/appVersion\s*=\s*[^;]+/appVersion = '$VERSION'/" ./service-worker.js
-            sed -i -E "s/params..appVersion[^=]+?=\s*[^;]+/params['appVersion'] = '$VERSION'/" ./www/js/app.js
-          fi
+          chmod +x ./scripts/rewrite_app_version_number.sh
+          ./scripts/rewrite_app_version_number.sh
       # Publish to docker only if explicitly requested or we are releasing
       - name: Build and push to docker
         if: github.event.inputs.target == 'docker' || github.event_name == 'release'

--- a/.github/workflows/publish-extension.yaml
+++ b/.github/workflows/publish-extension.yaml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Set any override version number to use (overrides on-master and tag-pattern). If it matches ^[0-9.]+, it will set the appVersion and will be visible to users. Non-matching values will cause appVersion to be used.
+        description: Set any override version number to use (overrides on-master and tag-pattern). If it matches ^v?[0-9.]+, it will set the appVersion (v will be removed) and will be visible to users. Non-matching values will cause appVersion to be used.
         required: true
         default: 'dev'
       target:
@@ -55,7 +55,7 @@ jobs:
           credentials: |
             DOCKERIO_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
             DOCKERIO_TOKEN=${{ secrets.DOCKERHUB_PASSWORD }}
-          tag-pattern: /^v*([0-9.]+)$/
+          tag-pattern: /^v?([0-9.]+)$/
           latest-on-tag: true
           dockerfile: docker/dockerfile-moz-extension.pwa
           restrict-to: kiwix/kiwix-js

--- a/.github/workflows/publish-extension.yaml
+++ b/.github/workflows/publish-extension.yaml
@@ -46,12 +46,21 @@ jobs:
         run: |
           # Use the override value by preference
           VERSION=${INPUT_VERSION}
-          # If no valid override input was entered, then try to use the release tag
-          if [[ ! $VERSION =~ ^[0-9.]+ ]]; then
+          if [[ $VERSION =~ ^[0-9.]+$ ]]; then
+            echo "Using the valid override input and setting version to $VERSION"
+          else
+            # If no valid override input was entered, then try to use the release tag
             VERSION=${TAG_VERSION}
+            if [[ $VERSION =~ ^[0-9.]+$ ]]; then
+              echo "Using the release tag and setting version to $VERSION"
+            else
+              echo "No valid override or tag was provided. File version numbers were unchanged."
+              echo "To rewrite version numbers in app, ensure the tag matches ^[0-9.]+$"
+            fi
           fi
           # If Version matches a release pattern, then set the appVersion in the files to be published
           if [[ $VERSION =~ ^[0-9.]+ ]]; then
+            echo "Rewriting appVersion in service-worker.js and app.js to $VERSION ..."
             sed -i -E "s/appVersion\s*=\s*[^;]+/appVersion = '$VERSION'/" ./service-worker.js
             sed -i -E "s/params..appVersion[^=]+?=\s*[^;]+/params['appVersion'] = '$VERSION'/" ./www/js/app.js
           fi
@@ -64,7 +73,7 @@ jobs:
           credentials: |
             DOCKERIO_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
             DOCKERIO_TOKEN=${{ secrets.DOCKERHUB_PASSWORD }}
-          tag-pattern: /^[0-9]([0-9.]+).*$/
+          tag-pattern: /^v*([0-9.]+)$/
           latest-on-tag: true
           dockerfile: docker/dockerfile-moz-extension.pwa
           restrict-to: kiwix/kiwix-js
@@ -75,6 +84,7 @@ jobs:
         if: github.event.inputs.target == 'ghpages' || github.event_name == 'release' || github.event_name == 'push'
         run: |
           # Set up username and email
+          echo "Publishing to GitHub pages..."
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           if [ ! -z "$(git status --porcelain)" ]; then

--- a/scripts/rewrite_app_version_number.sh
+++ b/scripts/rewrite_app_version_number.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# [Script run by publish-extension workflow]
+# Replaces the version numbers in app.js and service-worker.js with the following priority:
+#
+# 1. use the override value set in the workflow dispatch;
+# 2. use the tag pattern (if no override value was set)
+#
+# This script can be tested manually by replacing ${INPUT_VERSION} and ${TAG_VERSION}
+# with test strings
+ 
+# Use the override value by preference
+VERSION=${INPUT_VERSION}
+if [[ $VERSION =~ ^v*[0-9.]+ ]]; then
+  VERSION=$(sed 's/^v//' <<<"$VERSION") # Remove any leading v
+  echo "Using the valid override input and setting version to $VERSION"
+else
+  # If no valid override input was entered, then try to use the release tag
+  VERSION=${TAG_VERSION}
+  if [[ $VERSION =~ ^v*[0-9.]+ ]]; then
+    VERSION=$(sed 's/^v//' <<<"$VERSION")
+    echo "Using the release tag and setting version to $VERSION"
+  else
+    echo "No valid override or tag was provided. File version numbers were unchanged."
+    echo "To rewrite version numbers in app, ensure the tag matches ^[0-9.]+"
+  fi
+fi
+# If Version matches a release pattern, then set the appVersion in the files to be published
+if [[ $VERSION =~ ^[0-9.]+ ]]; then
+  echo "Rewriting appVersion in service-worker.js and app.js to $VERSION ..."
+  sed -i -E "s/appVersion\s*=\s*[^;]+/appVersion = '$VERSION'/" ../service-worker.js
+  sed -i -E "s/params..appVersion[^=]+?=\s*[^;]+/params['appVersion'] = '$VERSION'/" ../www/js/app.js
+fi

--- a/scripts/rewrite_app_version_number.sh
+++ b/scripts/rewrite_app_version_number.sh
@@ -28,6 +28,6 @@ fi
 # If Version matches a release pattern, then set the appVersion in the files to be published
 if [[ $VERSION =~ ^[0-9.]+ ]]; then
   echo "Rewriting appVersion in service-worker.js and app.js to $VERSION ..."
-  sed -i -E "s/appVersion\s*=\s*[^;]+/appVersion = '$VERSION'/" ../service-worker.js
-  sed -i -E "s/params..appVersion[^=]+?=\s*[^;]+/params['appVersion'] = '$VERSION'/" ../www/js/app.js
+  sed -i -E "s/appVersion\s*=\s*[^;]+/appVersion = '$VERSION'/" ./service-worker.js
+  sed -i -E "s/params..appVersion[^=]+?=\s*[^;]+/params['appVersion'] = '$VERSION'/" ./www/js/app.js
 fi

--- a/scripts/rewrite_app_version_number.sh
+++ b/scripts/rewrite_app_version_number.sh
@@ -11,7 +11,7 @@
  
 # Use the override value by preference
 VERSION=${INPUT_VERSION}
-if [[ $VERSION =~ ^v*[0-9.]+ ]]; then
+if [[ $VERSION =~ ^v?[0-9.]+ ]]; then
   VERSION=$(sed 's/^v//' <<<"$VERSION") # Remove any leading v
   echo "Using the valid override input and setting version to $VERSION"
 else

--- a/scripts/rewrite_app_version_number.sh
+++ b/scripts/rewrite_app_version_number.sh
@@ -17,12 +17,12 @@ if [[ $VERSION =~ ^v?[0-9.]+ ]]; then
 else
   # If no valid override input was entered, then try to use the release tag
   VERSION=${TAG_VERSION}
-  if [[ $VERSION =~ ^v*[0-9.]+ ]]; then
+  if [[ $VERSION =~ ^v?[0-9.]+ ]]; then
     VERSION=$(sed 's/^v//' <<<"$VERSION")
     echo "Using the release tag and setting version to $VERSION"
   else
     echo "No valid override or tag was provided. File version numbers were unchanged."
-    echo "To rewrite version numbers in app, ensure the tag matches ^[0-9.]+"
+    echo "To rewrite version numbers in app, ensure the tag matches ^v?[0-9.]+"
   fi
 fi
 # If Version matches a release pattern, then set the appVersion in the files to be published


### PR DESCRIPTION
This should fix #823.

* Corrects the regexp that decides which release tags to build and push to docker
* Adds logging in the form of "echo" statements that will be visible to us in the Workflow run log

@mossroy Kindly check the bash script statements carefully with your "Linux glasses" on! I'm not very familiar with it. If it can be simplified, happy to do so.

I will create a quick test script (copy of the rewrite script in the workflow) with some sample input to be sure the rewriting works, and will test in WSL on Windows.