### PR TITLE
Changelog for v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Released on *yyy-mm-dd*
 * NOTICE: This is a bugfix release to fix critical errors with the Ubuntu Touch app. For main changelog, see v3.3.0 below.
 * FIX: Improve packaging for the Ubuntu Touch app
 * FIX: Provide platform-compliant ID for Ubuntu Touch app
-* FIX: Correct the handling of version numbers in GitHub publishing workflow
+* BUGFIX: Correct the handling of version numbers in GitHub publishing workflow
 * BUGFIX: Correct race condition preventing initialization of decompressors in some contexts (e.g. file:// protocol)
 
 Detailed changelog: https://github.com/kiwix/kiwix-js/milestone/26?closed=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Released on *yyy-mm-dd*
 * FIX: Improve packaging for the Ubuntu Touch app
 * FIX: Provide platform-compliant ID for Ubuntu Touch app
 * FIX: Correct the handling of version numbers in GitHub publishing workflow
-* BUGFIX: Corrected race condition preventing initialization of decompressors in some contexts (e.g. file:// protocol)
+* BUGFIX: Correct race condition preventing initialization of decompressors in some contexts (e.g. file:// protocol)
 
 Detailed changelog: https://github.com/kiwix/kiwix-js/milestone/26?closed=1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ Then it was renamed Kiwix-html5 (and uses ZIM files), and then again was renamed
 
 ## Kiwix-JS v3.3.1
 
-Released on *yyy-mm-dd*
+Released on *2022-02-12*
 
 * NOTICE: This is a bugfix release to fix critical errors with the Ubuntu Touch app. For main changelog, see v3.3.0 below.
 * FIX: Improve packaging for the Ubuntu Touch app
-* FIX: Provide platform-compliant ID for Ubuntu Touch app
+* FIX: Provide a platform-compliant hook name for the Ubuntu Touch app (note that settings may be lost when upgrading to this version)
 * BUGFIX: Correct the handling of version numbers in GitHub publishing workflow
 * BUGFIX: Correct race condition preventing initialization of decompressors in some contexts (e.g. file:// protocol)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Please note that this application has changed its name over time.
 It was first called Evopedia (and was using the file format of Evopedia).
 Then it was renamed Kiwix-html5 (and uses ZIM files), and then again was renamed to Kiwix-JS.
 
+## Kiwix-JS v3.3.1
+
+Released on *yyy-mm-dd*
+
+* NOTICE: This is a bugfix release to fix critical errors with the Ubuntu Touch app. For main changelog, see v3.3.0 below.
+* FIX: Improve packaging for the Ubuntu Touch app
+* FIX: Provide platform-compliant ID for Ubuntu Touch app
+* FIX: Correct the handling of version numbers in GitHub publishing workflow
+* BUGFIX: Corrected race condition preventing initialization of decompressors in some contexts (e.g. file:// protocol)
+
+Detailed changelog: https://github.com/kiwix/kiwix-js/milestone/26?closed=1
+
 ## Kiwix-JS v3.3.0
 
 Released on *2022-02-06*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Released on *yyy-mm-dd*
 * BUGFIX: Correct the handling of version numbers in GitHub publishing workflow
 * BUGFIX: Correct race condition preventing initialization of decompressors in some contexts (e.g. file:// protocol)
 
-Detailed changelog: https://github.com/kiwix/kiwix-js/milestone/26?closed=1
+Detailed changelog: https://github.com/kiwix/kiwix-js/milestone/28?closed=1
 
 ## Kiwix-JS v3.3.0
 


### PR DESCRIPTION
Please check if the descriptions are accurate for the changes regarding the Ubuntu Touch app.

I include 3.3.1 under the 3.3 milestone, so if people check the closed milestones, they will see all the commits for 3.3.0 and 3.3.1. I think this makes more sense than creating a specific milestone for 3.3.1, given that it is a minor version.