### PR TITLE
update: webp-hero license link to mit

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -383,7 +383,7 @@
                         <li>Emscripten to generate XZ and ZSTD decompressors in javascript : <a href="https://github.com/kripken/emscripten" target="_blank">https://github.com/kripken/emscripten</a>, released under the <a href="https://github.com/kripken/emscripten" target="_blank">MIT Licence</a></li>
                         <li><a href="https://tukaani.org/xz/embedded.html">XZ Embedded</a> (the XZ library converted to Javascript with Emscripten), in public domain</li>
                         <li>The <a href="https://github.com/facebook/zstd" target="_blank">Zstandard library</a>, released under a <a href="https://github.com/facebook/zstd/blob/dev/LICENSE" target="_blank">BSD Licence</a> and a <a href="https://github.com/facebook/zstd/blob/dev/COPYING" target="_blank">GPLv2 Copying Licence</a></li>
-                        <li>The <a href="https://github.com/chase-moskal/webp-hero" target="_blank">WebP-Hero browser polyfill</a>, copyright Chase Moskal, released under an <a href="https://github.com/chase-moskal/webp-hero/blob/master/LICENSE" target="_blank">ISC Licence</a></li>
+                        <li>The <a href="https://github.com/chase-moskal/webp-hero" target="_blank">WebP-Hero browser polyfill</a>, copyright Chase Moskal, released under an <a href="https://github.com/chase-moskal/webp-hero/blob/master/LICENSE" target="_blank">MIT Licence</a></li>
                     </ul>
                     <p style="text-align: right"><a href="#contents">↑ Back to Contents</a></p>
                     


### PR DESCRIPTION
as of `v0.0.0`, webp-hero is now licensed under the mit license 🎉 

simply because mit license is more popular 🤷‍♂️ 