### PR TITLE
Trigger webapp restart

### DIFF
--- a/.github/workflows/publish-extension.yaml
+++ b/.github/workflows/publish-extension.yaml
@@ -49,17 +49,17 @@ jobs:
       # Publish to docker only if explicitly requested or we are releasing
       - name: Build and push to docker
         if: github.event.inputs.target == 'docker' || github.event_name == 'release'
-        uses: openzim/docker-publish-action@v6
+        uses: openzim/docker-publish-action@v8
         with:
           image-name: kiwix/kiwix-moz-extension
           credentials: |
-            DOCKERIO_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
-            DOCKERIO_TOKEN=${{ secrets.DOCKERHUB_PASSWORD }}
+            GHCRIO_USERNAME=${{ secrets.GHCR_USERNAME }}
+            GHCRIO_TOKEN=${{ secrets.GHCR_TOKEN }}
           tag-pattern: /^v?([0-9.]+)$/
           latest-on-tag: true
           dockerfile: docker/dockerfile-moz-extension.pwa
           restrict-to: kiwix/kiwix-js
-          registries: docker.io
+          registries: ghcr.io
           manual-tag: ${{ github.event.inputs.version }}
       # Restart live webapp only if we pushed an image to registry
       - name: Restart live webapp

--- a/.github/workflows/publish-extension.yaml
+++ b/.github/workflows/publish-extension.yaml
@@ -61,6 +61,14 @@ jobs:
           restrict-to: kiwix/kiwix-js
           registries: docker.io
           manual-tag: ${{ github.event.inputs.version }}
+      # Restart live webapp only if we pushed an image to registry
+      - name: Restart live webapp
+        if: github.event.inputs.target == 'docker' || github.event_name == 'release'
+        uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: rollout restart deployments mozext-deployment -n pwa
       # Publish to GitHub Pages if explicitly requested, or if releasing, or if pushing to master
       - name: Publish to GitHub Pages
         if: github.event.inputs.target == 'ghpages' || github.event_name == 'release' || github.event_name == 'push'


### PR DESCRIPTION
**Note**: This app's hosting has **already** been migrated to our new (k8s-based) hosting. We can discuss different ways to offer this feature but as of now, your app is not reloading automatically on image pushes.

Manually trigger a *restart* on Kiwix k8s after a successful image push.
Previous behavior was to let Docker Hub trigger a restart on (former) hosting via a webhook:
- we don't want to rely on Docker Hub anymore
- hosting platform changed