### PR TITLE
Explicitly set max supported dirEntry size

### DIFF
--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -25,7 +25,7 @@
  * This code makes an assumption that no Directory Entry will be larger that MAX_SUPPORTED_DIRENTRY_SIZE bytes.
  * If a larger dirEntry is encountered, an error will display in console. Increase this value if necessary.
  */
-const MAX_SUPPORTED_DIRENTRY_SIZE = 4096;
+const MAX_SUPPORTED_DIRENTRY_SIZE = 5120;
 
 /**
  * Add Polyfill currently required by IE11 to run zstddec-asm and xzdec-asm
@@ -196,6 +196,9 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'zimDirEntry', 'file
                 for (pos; pos <= MAX_SUPPORTED_DIRENTRY_SIZE; pos++) {
                     if (data[pos] === 0) break;
                 }
+                // DEBUG
+                if (pos > 2048)  console.debug('Found dirEntry.url of size > 2048 bytes!' + (!data[pos] ? ' (' + pos + ')' : ''), dirEntry.url);
+                // END DEGUG
                 if (data[pos] !== 0) {
                     console.warn('WARNING! A Directory Entry URL larger than ' + MAX_SUPPORTED_DIRENTRY_SIZE + ' bytes was encountered! ' +
                         'The dirEntry.url is likely to be invalid.', dirEntry.url

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -23,7 +23,7 @@
 
 /**
  * This code makes an assumption that no Directory Entry will be larger that MAX_SUPPORTED_DIRENTRY_SIZE bytes.
- * If a larger dirEntry is encountered, an error will display in console. Increase this value if necessary.
+ * If a larger dirEntry is encountered, a warning will display in console. Increase this value if necessary.
  */
 const MAX_SUPPORTED_DIRENTRY_SIZE = 5120;
 
@@ -197,7 +197,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'zimDirEntry', 'file
                     if (data[pos] === 0) break;
                 }
                 // DEBUG
-                if (pos > 2048)  console.debug('Found dirEntry.url of size > 2048 bytes!' + (!data[pos] ? ' (' + pos + ')' : ''), dirEntry.url);
+                if (pos > 2048)  console.debug('Found dirEntry.url of size > 2KB!' + (!data[pos] ? ' (' + pos + ')' : ''), dirEntry.url);
                 // END DEGUG
                 if (data[pos] !== 0) {
                     console.warn('WARNING! A Directory Entry URL larger than ' + MAX_SUPPORTED_DIRENTRY_SIZE + ' bytes was encountered! ' +
@@ -311,7 +311,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'zimDirEntry', 'file
      * This supports reading a subset of user content that might be ordered differently from the main URL pointerlist.
      * In particular, it supports the v1 article pointerlist, which contains articles sorted by title, superseding the article
      * namespace ('A') in legazy ZIM archives.  
-     * @param {Array<DirListing>} listings An array of DirListing objects (see zimArchive.js for examples)  
+     * @param {Array<DirListing>} listings An array of DirListing objects (see zimArchive.js for examples)
      * @returns {Promise} A promise that populates calculated entries in the ZIM file header
      */
     ZIMFile.prototype.setListings = function (listings) {

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -198,7 +198,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'zimDirEntry', 'file
                 }
                 // DEBUG
                 if (pos > 2048)  console.debug('Found dirEntry.url of size > 2KB!' + (!data[pos] ? ' (' + pos + ')' : ''), dirEntry.url);
-                // END DEGUG
+                // END DEBUG
                 if (data[pos] === 0) {
                     dirEntry.title = utf8.parse(data.subarray(pos + 1), true);
                 } else {

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -24,6 +24,8 @@
 /**
  * This code makes an assumption that no Directory Entry will be larger that MAX_SUPPORTED_DIRENTRY_SIZE bytes.
  * If a larger dirEntry is encountered, a warning will display in console. Increase this value if necessary.
+ * See https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers to understand
+ * why 5120 has been chosen here (maximum that IE11 can deal with in code).
  */
 const MAX_SUPPORTED_DIRENTRY_SIZE = 5120;
 
@@ -196,9 +198,6 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'zimDirEntry', 'file
                 for (pos; pos <= MAX_SUPPORTED_DIRENTRY_SIZE; pos++) {
                     if (data[pos] === 0) break;
                 }
-                // DEBUG
-                if (pos > 2048)  console.debug('Found dirEntry.url of size > 2KB!' + (!data[pos] ? ' (' + pos + ')' : ''), dirEntry.url);
-                // END DEBUG
                 if (data[pos] === 0) {
                     dirEntry.title = utf8.parse(data.subarray(pos + 1), true);
                 } else {

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -199,12 +199,14 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'zimDirEntry', 'file
                 // DEBUG
                 if (pos > 2048)  console.debug('Found dirEntry.url of size > 2KB!' + (!data[pos] ? ' (' + pos + ')' : ''), dirEntry.url);
                 // END DEGUG
-                if (data[pos] !== 0) {
+                if (data[pos] === 0) {
+                    dirEntry.title = utf8.parse(data.subarray(pos + 1), true);
+                } else {
+                    // DEV: If you encounter this warning in console, it means that a very large dirEntry.url has exceeded the maximum supported
+                    // dirEntry size. Consider increasing MAX_SUPPORTED_DIRENTRY_SIZE if such warnings are encountered regularly with a ZIM.
                     console.warn('WARNING! A Directory Entry URL larger than ' + MAX_SUPPORTED_DIRENTRY_SIZE + ' bytes was encountered! ' +
                         'The dirEntry.url is likely to be invalid.', dirEntry.url
                     );
-                } else {
-                    dirEntry.title = utf8.parse(data.subarray(pos + 1), true);
                 }
                 return new zimDirEntry.DirEntry(that, dirEntry);
             }


### PR DESCRIPTION
Simple proposed fix for #875. This PR does the following:

* Increases the maximum supported dirEntry size to ~~4096 bytes~~ EDIT: now 5120 bytes
* Allows setting the size via a constant MAX_SUPPORTED_DIRENTRY_SIZE at the head of the file, thus making devs aware of the issue
* Provides a console warning if the dirEntry.url is longer than MAX_SUPPORTED_DIRENTRY_SIZE (url will be truncated, and no title will be found)
* Does not enter an infinite loop if dirEntry.url is longer than permitted size, but still returns the dirEntry.

The advantage of not throwing an error here, but instead printing a warning, is that often the dirEntry may be being accessed merely for search purposes, in which case no harm will come of returning a truncated dirEntry.url. However, a developer will be alerted to the fact that MAX_SUPPORTED_DIRENTRY_SIZE needs to be increased.