### PR TITLE
Exempt more content from active content warning

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1585,7 +1585,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     // (these strings are used widely in our fully supported wikimedia ZIMs, so they are excluded); 3) the script block is not of type "math"
     // (these are MathJax markup scripts used extensively in Stackexchange ZIMs). Note that the regex will match ReactJS <script type="text/html">
     // markup, which is common in unsupported packaged UIs, e.g. PhET ZIMs.
-    var regexpActiveContent = /<script\b(?:(?![^>]+src\b)|(?=[^>]+src\b=["'][^"']+?app\.js))(?!>[^<]+(?:importScript\(\)|toggleOpenSection|articleId\s?=\s?['"]))(?![^>]+type\s*=\s*["'](?:math\/|[^"']*?math))/i;
+    var regexpActiveContent = /<script\b(?:(?![^>]+src\b)|(?=[^>]+src\b=["'][^"']+?app\.js))(?![^<]+(?:importScript\(\)|toggleOpenSection|articleId\s?=\s?['"]|window.NREUM))(?![^>]+type\s*=\s*["'](?:math\/|[^"']*?math))/i;
     // DEV: The regex below matches ZIM links (anchor hrefs) that should have the html5 "donwnload" attribute added to
     // the link. This is currently the case for epub and pdf files in Project Gutenberg ZIMs -- add any further types you need
     // to support to this regex. The "zip" has been added here as an example of how to support further filetypes


### PR DESCRIPTION
Fixes display of unnecessary active content warning with mdWiki ZIMs. I think this more generally fixes #746, but not necessarily directly as a result of this PR... We first posted #746 because of new Type 1 Stackexchange ZIMs throwing the active content warning. But I just tested the master branch against `beer.stackexchange.com_en_all_2022-08.zim` (which I've verified is a Type 1 ZIM), and it doesn't throw any warnings. So perhaps those ZIM types no longer trigger the warning?