### PR TITLE
Detect Zimit archive type and warn user

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2046,7 +2046,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $("#welcomeText").show();
             } else {
                 // For now, this code doesn't support reading Zimit archives without error, so we warn the user and suggest some solutions
-                if (selectedArchive._file.type === 'zimit') {
+                if (selectedArchive._file.zimType === 'zimit') {
                     uiUtil.systemAlert('<p>You are attempting to open a Zimit-style archive, which is currently unsupported in this app.</p>' +
                         '<p>There is experimental support for this kind of archive in the Kiwix JS PWA. Go to: ' +
                         '<a href="https://pwa.kiwix.org" target="_blank">https://pwa.kiwix.org</a>.</p>' +

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2045,14 +2045,27 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                 $("#searchingArticles").hide();
                 $("#welcomeText").show();
             } else {
-                // DEV: see comment above under goToRandomArticle()
-                if (dirEntry.redirect || dirEntry.getMimetype() === 'text/html' || dirEntry.namespace === 'A') {
-                    params.isLandingPage = true;
-                    readArticle(dirEntry);
-                } else {
-                    console.error("The main page of this archive does not seem to be an article");
+                // For now, this code doesn't support reading Zimit archives without error, so we warn the user and suggest some solutions
+                if (selectedArchive._file.type === 'zimit') {
+                    uiUtil.systemAlert('<p>You are attempting to open a Zimit-style archive, which is currently unsupported in this app.</p>' +
+                        '<p>There is experimental support for this kind of archive in the Kiwix JS PWA. Go to: ' +
+                        '<a href="https://pwa.kiwix.org" target="_blank">https://pwa.kiwix.org</a>.</p>' +
+                        '<p>Alternatively, you can use Kiwix Serve to serve this archive to your browser from localhost. ' + 
+                        'Kiwix Serve is included with <a href="https://www.kiwix.org/en/download/" target="_blank">Kiwix Desktop</a>.</p>',
+                        'Unsupported archive type!'
+                    );
                     $("#searchingArticles").hide();
                     $("#welcomeText").show();
+                } else {
+                    // DEV: see comment above under goToRandomArticle()
+                    if (dirEntry.redirect || dirEntry.getMimetype() === 'text/html' || dirEntry.namespace === 'A') {
+                        params.isLandingPage = true;
+                        readArticle(dirEntry);
+                    } else {
+                        console.error("The main page of this archive does not seem to be an article");
+                        $("#searchingArticles").hide();
+                        $("#welcomeText").show();
+                    }
                 }
             }
         });

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -140,7 +140,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
 
     /**
      * Detects whether the supplied archive is a Zimit-style archive or an OpenZIM archive and
-     * sets a file.type property accordingly; also returns the detected type. Extends ZIMFile.
+     * sets a _file.zimType property accordingly; also returns the detected type. Extends ZIMFile.
      * @returns {String} Either 'zimit' for a Zimit archive, or 'open' for an OpenZIM archive
      */
      ZIMArchive.prototype.setZimType = function () {
@@ -150,7 +150,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
             this._file.mimeTypes.forEach(function (v) {
                 if (/warc-headers/i.test(v)) fileType = 'zimit';
             });
-            this._file.type = fileType;
+            this._file.zimType = fileType;
             console.debug('Archive type set to: ' + fileType);
         } else {
             console.error('ZIMArchive is not ready! Cannot set ZIM type.');

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -76,6 +76,8 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
                         countName: 'articleCount'
                     }
                 ]);
+                // Set the archive file type ('open' or 'zimit')
+                that.setZimType();
                 // DEV: Currently, extended listings are only used for title (=article) listings when the user searches
                 // for an article or uses the Random button, by which time the listings will have been extracted.
                 // If, in the future, listings are used in a more time-critical manner, consider forcing a wait before
@@ -135,7 +137,26 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
     ZIMArchive.prototype.isReady = function() {
         return this._file !== null;
     };
-    
+
+    /**
+     * Detects whether the supplied archive is a Zimit-style archive or an OpenZIM archive and
+     * sets a file.type property accordingly; also returns the detected type
+     * @returns {String} Either 'zimit' for a Zimit archive, or 'open' for an OpenZIM archive
+     */
+     ZIMArchive.prototype.setZimType = function () {
+        var fileType = null;
+        if (this.isReady()) {
+            this._file.mimeTypes.forEach(function (v) {
+                if (/warc-headers/i.test(v)) fileType = 'zimit';
+            });
+            this._file.type = fileType;
+            console.debug('Archive type set to: ' + fileType);
+        } else {
+            console.error('ZIMArchive is not ready! Cannot set ZIM type.');
+        }
+        return fileType;
+    };
+
     /**
      * Looks for the DirEntry of the main page
      * @param {callbackDirEntry} callback

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -146,6 +146,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      ZIMArchive.prototype.setZimType = function () {
         var fileType = null;
         if (this.isReady()) {
+            fileType = 'open';
             this._file.mimeTypes.forEach(function (v) {
                 if (/warc-headers/i.test(v)) fileType = 'zimit';
             });

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -140,7 +140,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
 
     /**
      * Detects whether the supplied archive is a Zimit-style archive or an OpenZIM archive and
-     * sets a file.type property accordingly; also returns the detected type
+     * sets a file.type property accordingly; also returns the detected type. Extends ZIMFile.
      * @returns {String} Either 'zimit' for a Zimit archive, or 'open' for an OpenZIM archive
      */
      ZIMArchive.prototype.setZimType = function () {

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -102,7 +102,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'zimDirEntry', 'file
      * @property {Integer} mimeListPos Position of the MIME type list (also header size)
      * @property {Integer} mainPage Main page or 0xffffffff if no main page
      * @property {Integer} layoutPage Layout page or 0xffffffffff if no layout page
-     * @property {String} type Extended property: either 'open' for OpenZIM file type, or 'zimit' for the warc2zim file type used by Zimit (set in zimArchive.js)
+     * @property {String} zimType Extended property: currently either 'open' for OpenZIM file type, or 'zimit' for the warc2zim file type used by Zimit (set in zimArchive.js)
      * @property {Map} mimeTypes Extended property: the ZIM file's MIME type table rendered as a Map (calculated entry)
      */
     

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -102,7 +102,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'zimDirEntry', 'file
      * @property {Integer} mimeListPos Position of the MIME type list (also header size)
      * @property {Integer} mainPage Main page or 0xffffffff if no main page
      * @property {Integer} layoutPage Layout page or 0xffffffffff if no layout page
-     * @property {String} type Extended property: either 'open' for OpenZIM file type, or 'zimit' for the WARC file type used by Zimit (set in zimArchive.js)
+     * @property {String} type Extended property: either 'open' for OpenZIM file type, or 'zimit' for the warc2zim file type used by Zimit (set in zimArchive.js)
      * @property {Map} mimeTypes The ZIM file's MIME type table rendered as a Map (calculated entry)
      */
     

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -86,6 +86,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'zimDirEntry', 'file
      * A ZIM File
      * 
      * See https://wiki.openzim.org/wiki/ZIM_file_format#Header
+     * Some properties below are extended and are not part of the official OpenZIM specification
      * 
      * @typedef {Object} ZIMFile
      * @property {Array<File>} _files Array of ZIM files
@@ -101,6 +102,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'zimDirEntry', 'file
      * @property {Integer} mimeListPos Position of the MIME type list (also header size)
      * @property {Integer} mainPage Main page or 0xffffffff if no main page
      * @property {Integer} layoutPage Layout page or 0xffffffffff if no layout page
+     * @property {String} type Extended property: either 'open' for OpenZIM file type, or 'zimit' for the WARC file type used by Zimit (set in zimArchive.js)
      * @property {Map} mimeTypes The ZIM file's MIME type table rendered as a Map (calculated entry)
      */
     

--- a/www/js/lib/zimfile.js
+++ b/www/js/lib/zimfile.js
@@ -103,7 +103,7 @@ define(['xzdec_wrapper', 'zstddec_wrapper', 'util', 'utf8', 'zimDirEntry', 'file
      * @property {Integer} mainPage Main page or 0xffffffff if no main page
      * @property {Integer} layoutPage Layout page or 0xffffffffff if no layout page
      * @property {String} type Extended property: either 'open' for OpenZIM file type, or 'zimit' for the warc2zim file type used by Zimit (set in zimArchive.js)
-     * @property {Map} mimeTypes The ZIM file's MIME type table rendered as a Map (calculated entry)
+     * @property {Map} mimeTypes Extended property: the ZIM file's MIME type table rendered as a Map (calculated entry)
      */
     
     /**


### PR DESCRIPTION
Fixes #883. I have included some information for the user about how to open Zimit archive types. Clearly this would need to be kept up to date, but I think it's better to be helpful to users to avoid the kind of frustrating exchange you see in this [reddit comment](https://www.reddit.com/r/Kiwix/comments/wj8ivr/comment/ijwwyfs/?utm_source=share&utm_medium=web2x&context=3).