### PR TITLE
Detect more ZIMs for active content warning

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -662,7 +662,7 @@
                     <div id="activeContent" style="display:none;" class="kiwix-alert alert alert-warning alert-dismissible fade show">
                         <button type="button" class="close" data-hide="alert">&times;</button>
                         <strong>Unable to display active content:</strong> This ZIM is not fully supported in jQuery mode.<br />
-                        Content may be available by searching above (type a space or a letter of the alphabet), or else 
+                        Content may be available by searching above (type a letter of the alphabet), or else 
                         <a id="swModeLink" href="#contentInjectionModeDiv" class="alert-link">switch to Service Worker mode</a>
                         if your platform supports it. &nbsp;[<a id="stop" href="#expertSettingsDiv" class="alert-link">Permanently hide</a>]
                     </div>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1580,12 +1580,12 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     // quote marks (') in the URL.
     var regexpTagsWithZimUrl = /(<(?:img|script|link|track)\b[^>]*?\s)(?:src|href)(\s*=\s*(["']))(?![a-z][a-z0-9+.-]+:)(.+?)(?=\3|\?|#)/ig;
     // Regex below tests the html of an article for active content [kiwix-js #466]
-    // It inspects every <script> block in the html and matches in the following cases: 1) the script loads a UI application called app.js
-    // or init.js; 2) the script block has inline content that does not contain "importScript()", "toggleOpenSection" or an "articleId"
-    // assignment (these strings are used widely in our fully supported wikimedia ZIMs, so they are excluded); 3) the script block is not
-    // of type "math" (these are MathJax markup scripts used extensively in Stackexchange ZIMs). Note that the regex will match ReactJS
-    // <script type="text/html"> markup, which is common in unsupported packaged UIs, e.g. PhET ZIMs.
-    var regexpActiveContent = /<script\b(?:(?![^>]+src\b)|(?=[^>]+src\b=["'][^"']+?\b(?:app|init)\.js))(?![^<]+(?:importScript\(\)|toggleOpenSection|articleId\s?=\s?['"]|window.NREUM))(?![^>]+type\s*=\s*["'](?:math\/|[^"']*?math))/i;
+    // It inspects every <script> block in the html and matches in the following cases: 1) the script loads a UI application called app.js,
+    // init.js, or other common scripts found in unsupported ZIMs; 2) the script block has inline content that does not contain
+    // "importScript()", "toggleOpenSection" or an "articleId" assignment (these strings are used widely in our fully supported wikimedia ZIMs,
+    // so they are excluded); 3) the script block is not of type "math" (these are MathJax markup scripts used extensively in Stackexchange
+    // ZIMs). Note that the regex will match ReactJS <script type="text/html"> markup, which is common in unsupported packaged UIs, e.g. PhET ZIMs.
+    var regexpActiveContent = /<script\b(?:(?![^>]+src\b)|(?=[^>]+src\b=["'][^"']+?\b(?:app|init|l1[08]9)\.js))(?![^<]+(?:importScript\(\)|toggleOpenSection|articleId\s?=\s?['"]|window.NREUM))(?![^>]+type\s*=\s*["'](?:math\/|[^"']*?math))/i;
     // DEV: The regex below matches ZIM links (anchor hrefs) that should have the html5 "donwnload" attribute added to
     // the link. This is currently the case for epub and pdf files in Project Gutenberg ZIMs -- add any further types you need
     // to support to this regex. The "zip" has been added here as an example of how to support further filetypes

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1580,12 +1580,12 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     // quote marks (') in the URL.
     var regexpTagsWithZimUrl = /(<(?:img|script|link|track)\b[^>]*?\s)(?:src|href)(\s*=\s*(["']))(?![a-z][a-z0-9+.-]+:)(.+?)(?=\3|\?|#)/ig;
     // Regex below tests the html of an article for active content [kiwix-js #466]
-    // It inspects every <script> block in the html and matches in the following cases: 1) the script loads a UI application called app.js;
-    // 2) the script block has inline content that does not contain "importScript()", "toggleOpenSection" or an "articleId" assignment
-    // (these strings are used widely in our fully supported wikimedia ZIMs, so they are excluded); 3) the script block is not of type "math"
-    // (these are MathJax markup scripts used extensively in Stackexchange ZIMs). Note that the regex will match ReactJS <script type="text/html">
-    // markup, which is common in unsupported packaged UIs, e.g. PhET ZIMs.
-    var regexpActiveContent = /<script\b(?:(?![^>]+src\b)|(?=[^>]+src\b=["'][^"']+?app\.js))(?![^<]+(?:importScript\(\)|toggleOpenSection|articleId\s?=\s?['"]|window.NREUM))(?![^>]+type\s*=\s*["'](?:math\/|[^"']*?math))/i;
+    // It inspects every <script> block in the html and matches in the following cases: 1) the script loads a UI application called app.js
+    // or init.js; 2) the script block has inline content that does not contain "importScript()", "toggleOpenSection" or an "articleId"
+    // assignment (these strings are used widely in our fully supported wikimedia ZIMs, so they are excluded); 3) the script block is not
+    // of type "math" (these are MathJax markup scripts used extensively in Stackexchange ZIMs). Note that the regex will match ReactJS
+    // <script type="text/html"> markup, which is common in unsupported packaged UIs, e.g. PhET ZIMs.
+    var regexpActiveContent = /<script\b(?:(?![^>]+src\b)|(?=[^>]+src\b=["'][^"']+?\b(?:app|init)\.js))(?![^<]+(?:importScript\(\)|toggleOpenSection|articleId\s?=\s?['"]|window.NREUM))(?![^>]+type\s*=\s*["'](?:math\/|[^"']*?math))/i;
     // DEV: The regex below matches ZIM links (anchor hrefs) that should have the html5 "donwnload" attribute added to
     // the link. This is currently the case for epub and pdf files in Project Gutenberg ZIMs -- add any further types you need
     // to support to this regex. The "zip" has been added here as an example of how to support further filetypes

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1609,7 +1609,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         if (!params.hideActiveContentWarning && params.isLandingPage) {
             if (regexpActiveContent.test(htmlArticle)) {
                 // Exempted scripts: active content warning will not be displayed if any listed script is in the html [kiwix-js #889]
-                if (!/<script\b[^'"]+['"][^'"]*?mooc.js/i.test(htmlArticle)) {
+                if (!/<script\b[^'"]+['"][^'"]*?mooc\.js/i.test(htmlArticle)) {
                     uiUtil.displayActiveContentWarning();
                 }
             }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1607,7 +1607,12 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
         }
         // Display Bootstrap warning alert if the landing page contains active content
         if (!params.hideActiveContentWarning && params.isLandingPage) {
-            if (regexpActiveContent.test(htmlArticle)) uiUtil.displayActiveContentWarning();
+            if (regexpActiveContent.test(htmlArticle)) {
+                // Exempted scripts: active content warning will not be displayed if any listed script is in the html [kiwix-js #889]
+                if (!/<script\b[^'"]+['"][^'"]*?mooc.js/i.test(htmlArticle)) {
+                    uiUtil.displayActiveContentWarning();
+                }
+            }
         }
 
         // Calculate the current article's ZIM baseUrl to use when processing relative links


### PR DESCRIPTION
New nautilus-based ZIMs don't trigger the active content warning in jQuery mode. This adds detection. There is also an incorrect instruction in the warning to "type a space". This doesn't do anything in Kiwix JS (in Kiwix JS Windows, typing a space opens a special Archive Index UI, and I think this instruction is a left-over from that).

We could make it so that typing a space displays the title index starting from the first entry within the current UI, but that would be a different PR.