### PR TITLE
Rename nightly packages to show date instead of revsion ID

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           # If user dispateched with "nightly", simulate a CRON run
           if [ "$INPUT_TARGET" = "nightly" ]; then
-            CRON_LAUNCHED = "nightly"
+            CRON_LAUNCHED="nightly"
           fi
           # Run xvfb to make Chrome/Chromium believe it has a display. Else it fails signing the package
           Xvfb -ac :99 -screen 0 1280x1024x16 &

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -13,6 +13,10 @@ on:
     - cron: '37 1 * * *'
   # Allows us to run this workflow manually from the Actions tab
   workflow_dispatch:
+      target:
+        description: Do you wish to build release or nightly?
+        required: false
+        default: 'nightly'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -52,14 +56,19 @@ jobs:
           MOZILLA_API_KEY: ${{ secrets.MOZILLA_API_KEY }}
           TAG_NAME: ${{ github.event.release.tag_name }}
           CRON_LAUNCHED: ${{ github.event.schedule }}
+          INPUT_TARGET: ${{ github.event.inputs.target }}
         shell: bash
         # Switch -t indicates a tag release (public release); add -d for dry run (for testing)
         # BEFORE the -v switch (because $TAG_NAME is empty for non-public builds)
         run: |
+          # If user dispateched with "nightly", simulate a CRON run
+          if [ "$INPUT_TARGET" = "nightly" ]; then
+            CRON_LAUNCHED = "nightly"
+          fi
           # Run xvfb to make Chrome/Chromium believe it has a display. Else it fails signing the package
           Xvfb -ac :99 -screen 0 1280x1024x16 &
           export DISPLAY=:99
-          if [ "x$TAG_NAME" = "x" ]; then
+          if [ -z "$TAG_NAME" ]; then
             ./scripts/create_all_packages.sh
           else
             ./scripts/create_all_packages.sh -t -v "$TAG_NAME"

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -13,6 +13,7 @@ on:
     - cron: '37 1 * * *'
   # Allows us to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
       target:
         description: Do you wish to build release or nightly?
         required: false

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -51,6 +51,7 @@ jobs:
           MOZILLA_API_SECRET: ${{ secrets.MOZILLA_API_SECRET }}
           MOZILLA_API_KEY: ${{ secrets.MOZILLA_API_KEY }}
           TAG_NAME: ${{ github.event.release.tag_name }}
+          CRON_LAUNCHED: ${{ github.event.schedule }}
         shell: bash
         # Switch -t indicates a tag release (public release); add -d for dry run (for testing)
         # BEFORE the -v switch (because $TAG_NAME is empty for non-public builds)

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -84,7 +84,7 @@ if [ "${DRYRUN}zz" == "zz" ]; then
         # It's a nightly build, so rename files to include the date and remove extraneous info so that permalinks can be generated
         for file in build/*; do
             target=$(sed -E "s/-[0-9.]+commit[^.]+/_$CURRENT_DATE/" <<<"$file")
-            mv "$file" "$target"
+            mv --backup=numbered "$file" "$target"
         done
     fi
     # Upload the files on master.download.kiwix.org

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -84,7 +84,7 @@ if [ "${DRYRUN}zz" == "zz" ]; then
         # It's a nightly build, so rename files to include the date and remove extraneous info so that permalinks can be generated
         for file in build/*; do
             target=$(sed -E "s/-[0-9.]+commit[^.]+/_$CURRENT_DATE/" <<<"$file")
-            mv --backup=numbered "$file" "$target"
+            mv "$file" "$target"
         done
     fi
     # Upload the files on master.download.kiwix.org

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -80,11 +80,11 @@ if [ "${DRYRUN}zz" == "zz" ]; then
     # Change permissions on source files to match those expected by the server
     chmod 644 build/*
     CURRENT_DATE=$(date +'%Y-%m-%d')
-    if [ "${TAG}zz" == "zz" ]; then
+    if [ ! "${CRON_LAUNCHED}zz" == "zz" ]; then
         # It's a nightly build, so rename files to include the date and remove extraneous info so that permalinks can be generated
         for file in build/*; do
             target=$(sed -E "s/-[0-9.]+commit[^.]+/_$CURRENT_DATE/" <<<"$file")
-            mv --backup=numbered "$file" "$target"
+            mv "$file" "$target"
         done
     fi
     # Upload the files on master.download.kiwix.org

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -37,7 +37,7 @@ else
     # and we have to comply with their version string : https://developer.mozilla.org/en-US/docs/Mozilla/Toolkit_version_format
     # So we need to replace every number of the commit id by another string (with 32 cars max)
     # We are allowed only a few special caracters : +*.-_ so we prefered to use capital letters
-    # (hopping this string is case-sensitive)
+    # (hoping this string is case-sensitive)
     COMMIT_ID_FOR_MOZILLA_MANIFEST=$(echo $COMMIT_ID | tr '[0123456789]' '[ABCDEFGHIJ]')
     VERSION_FOR_MOZILLA_MANIFEST="${MAJOR_NUMERIC_VERSION}commit${COMMIT_ID_FOR_MOZILLA_MANIFEST}"
     echo "Packaging version $VERSION"
@@ -80,6 +80,11 @@ if [ "${DRYRUN}zz" == "zz" ]; then
     # Change permissions on source files to match those expected by the server
     chmod 644 build/*
     CURRENT_DATE=$(date +'%Y-%m-%d')
+    # Rename files to include the date and remove extraneous info so that permalinks can be generated
+    for file in build/*; do
+        target=$(sed -E "s/-[0-9.]+commit[^.]+/_$CURRENT_DATE/" <<<"$file")
+        mv "$file" "$target"
+    done
     # Upload the files on master.download.kiwix.org
     echo "Uploading the files on https://download.kiwix.org/nightly/$CURRENT_DATE/"
     echo "mkdir /data/download/nightly/$CURRENT_DATE" | sftp -P 30022 -o StrictHostKeyChecking=no -i ./scripts/ssh_key ci@master.download.kiwix.org

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -80,7 +80,7 @@ if [ "${DRYRUN}zz" == "zz" ]; then
     # Change permissions on source files to match those expected by the server
     chmod 644 build/*
     CURRENT_DATE=$(date +'%Y-%m-%d')
-    if [ ! "${CRON_LAUNCHED}zz" == "zz" ]; then
+    if [ -n "${CRON_LAUNCHED}" ]; then
         # It's a nightly build, so rename files to include the date and remove extraneous info so that permalinks can be generated
         for file in build/*; do
             target=$(sed -E "s/-[0-9.]+commit[^.]+/_$CURRENT_DATE/" <<<"$file")

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -80,11 +80,13 @@ if [ "${DRYRUN}zz" == "zz" ]; then
     # Change permissions on source files to match those expected by the server
     chmod 644 build/*
     CURRENT_DATE=$(date +'%Y-%m-%d')
-    # Rename files to include the date and remove extraneous info so that permalinks can be generated
-    for file in build/*; do
-        target=$(sed -E "s/-[0-9.]+commit[^.]+/_$CURRENT_DATE/" <<<"$file")
-        mv "$file" "$target"
-    done
+    if [ "${TAG}zz" == "zz" ]; then
+        # It's a nightly build, so rename files to include the date and remove extraneous info so that permalinks can be generated
+        for file in build/*; do
+            target=$(sed -E "s/-[0-9.]+commit[^.]+/_$CURRENT_DATE/" <<<"$file")
+            mv "$file" "$target"
+        done
+    fi
     # Upload the files on master.download.kiwix.org
     echo "Uploading the files on https://download.kiwix.org/nightly/$CURRENT_DATE/"
     echo "mkdir /data/download/nightly/$CURRENT_DATE" | sftp -P 30022 -o StrictHostKeyChecking=no -i ./scripts/ssh_key ci@master.download.kiwix.org

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -24,10 +24,10 @@ if [ -r "$BASEDIR/scripts/set_secret_environment_variables.sh" ]; then
 fi
 
 # Use the passed version number, else use the commit id
-if [ ! "${VERSION}zz" == "zz" ]; then
+if [ -n "${VERSION}" ]; then
     echo "Packaging version $VERSION because it has been passed as an argument"
     VERSION_FOR_MOZILLA_MANIFEST="$VERSION"
-    if [ ! "${TAG}zz" == "zz" ]; then
+    if [ -n "${TAG}" ]; then
         echo "This version is a tag : we're releasing a public version"
     fi
 else
@@ -76,7 +76,7 @@ cp -f ubuntu_touch/* tmp/
 sed -i -e "s/$VERSION_TO_REPLACE/$VERSION/" tmp/manifest.json
 scripts/package_ubuntu_touch_app.sh $DRYRUN $TAG -v $VERSION
 
-if [ "${DRYRUN}zz" == "zz" ]; then
+if [ -z "${DRYRUN}" ]; then
     # Change permissions on source files to match those expected by the server
     chmod 644 build/*
     CURRENT_DATE=$(date +'%Y-%m-%d')


### PR DESCRIPTION
This was requested on https://github.com/kiwix/k8s/issues/50. It will provide the benefit that we will have permalinks to the latest nightly release, and is being implemented Kiwix-wide.

My Linux scripting skills are basic, but I think the included code should rename files like this:

```
build/kiwix-firefox-unsigned-extension-3.6commit-9a6e6f7.zip -->
build/kiwix-firefox-unsigned-extension_2022-10-06.zip
```

If you agree, I can test by dispatching the workflow on this branch.
