### PR TITLE
Changelog for v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Released on *TODO*
 
 * FEATURE: ServiceWorker Mode is now the default, and compatible clients upgrade automatically to this mode
 * FEATURE: On first run after update, the user is informed of the ServiceWorker Mode upgrade status (upgraded or incompatible)
+* COMPATIBILITY: Minimum Firefox version has been raised to >=52, due to lack of full Extension APIs in earlier versions 
 * UPDATE: Detection of active content updated for compatibility with more no-namespace ZIM archives
 * UPDATE: Nightly packages on the download server now include the date in their filenames
 * FIX: Kiwix icon now has an outline so that it is visible against dark OS backgrounds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Please note that this application has changed its name over time.
 It was first called Evopedia (and was using the file format of Evopedia).
 Then it was renamed Kiwix-html5 (and uses ZIM files), and then again was renamed to Kiwix-JS.
 
+## Kiwix-JS v3.6.0
+
+Released on *TODO*
+
+* FEATURE: ServiceWorker Mode is now the default, and compatible clients upgrade automatically to this mode
+* FEATURE: On first run after update, the user is informed of the ServiceWorker Mode upgrade status (upgraded or incompatible)
+* UPDATE: Detection of active content updated for compatibility with more no-namespace ZIM archives
+* UPDATE: Nightly packages on the download server now include the date in their filenames
+* FIX: Kiwix icon now has an outline so that it is visible against dark OS backgrounds
+
 ## Kiwix-JS v3.5.0
 
 Released on *2022-08-05*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Released on *TODO*
 
 * FEATURE: ServiceWorker Mode is now the default, and compatible clients upgrade automatically to this mode
 * FEATURE: On first run after update, the user is informed of the ServiceWorker Mode upgrade status (upgraded or incompatible)
+* NEW: A warning (with suggestions) is provided if user opens an incompatible Zimit (warc2zim) archive type
 * COMPATIBILITY: Minimum Firefox version has been raised to >=52, due to lack of full Extension APIs in earlier versions 
 * UPDATE: Detection of active content updated for compatibility with more no-namespace ZIM archives
 * UPDATE: Nightly packages on the download server now include the date in their filenames

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Then it was renamed Kiwix-html5 (and uses ZIM files), and then again was renamed
 
 ## Kiwix-JS v3.6.0
 
-Released on *TODO*
+Released on *2022-12-11*
 
 * FEATURE: ServiceWorker Mode is now the default, and compatible clients upgrade automatically to this mode
 * FEATURE: On first run after update, the user is informed of the ServiceWorker Mode upgrade status (upgraded or incompatible)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Kiwix",
-    "version": "3.6-WIP",
+    "version": "3.6",
 
     "description": "Kiwix : offline Wikipedia reader",
     

--- a/service-worker.js
+++ b/service-worker.js
@@ -29,7 +29,7 @@
  * download and install a new copy; we have to hard code this here because it is needed before any other file
  * is cached in APP_CACHE
  */
-const appVersion = '3.6-WIP';
+const appVersion = '3.6';
 
 /**
  * The name of the Cache API cache in which assets defined in regexpCachedContentTypes will be stored

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -71,7 +71,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
      * WARNING: Only change these paramaeters if you know what you are doing
      */
     // The current version number of this app
-    params['appVersion'] = '3.6-WIP'; // **IMPORTANT** Ensure this is the same as the version number in service-worker.js
+    params['appVersion'] = '3.6'; // **IMPORTANT** Ensure this is the same as the version number in service-worker.js
     // The PWA server (currently only for use with the Mozilla extension)
     params['PWAServer'] = 'https://moz-extension.kiwix.org/current/'; // Include final slash!
     // params['PWAServer'] = 'https://kiwix.github.io/kiwix-js/'; // DEV: Uncomment this line for testing code on GitHub Pages


### PR DESCRIPTION
Proposed changelog for v3.6.0.

I have not included the fact that I had to disable end-to-end Unit tests temporarily while we look for a new solution, as it is not a "feature" of the released client.