### PR TITLE
Exempt more latex images from re-inversion in dark mode

### DIFF
--- a/www/css/kiwixJS_mwInvert.css
+++ b/www/css/kiwixJS_mwInvert.css
@@ -29,7 +29,7 @@
  * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
  */
 
-img:not([class|="mwe-math-fallback-image"]),
+img:not([class|="mwe-math-fallback-image"], [class^="latex"]),
 video,
 canvas {
     filter: invert(1) hue-rotate(180deg);


### PR DESCRIPTION
Fixes #922. The added code exempts images with a class name beginning with `latex`. There are a number of `latex`-prefixed styles in the artofproblemsolving ZIMs such as `.latex` and `.latexcentered`, so we match any image style beginning with `latex` (`class^="latex"`).