### PR TITLE
Handle setting version number explicitly in release workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -18,6 +18,9 @@ on:
         description: Do you wish to build release or nightly?
         required: false
         default: 'nightly'
+      version:
+        description: If building a release version, please set the version number here, like 9.9 (ignored if you selected nightly build)
+        required: false
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -58,6 +61,7 @@ jobs:
           TAG_NAME: ${{ github.event.release.tag_name }}
           CRON_LAUNCHED: ${{ github.event.schedule }}
           INPUT_TARGET: ${{ github.event.inputs.target }}
+          RELEASE_VERSION: ${{ github.event.inputs.version }}
         shell: bash
         # Switch -t indicates a tag release (public release); add -d for dry run (for testing)
         # BEFORE the -v switch (because $TAG_NAME is empty for non-public builds)
@@ -65,12 +69,15 @@ jobs:
           # If user dispateched with "nightly", simulate a CRON run
           if [ "$INPUT_TARGET" = "nightly" ]; then
             CRON_LAUNCHED="nightly"
+          # Else if use entered a release version, override any tag version
+          elif [ -n "$RELEASE_VERSION" ]; then
+            TAG_NAME="$RELEASE_VERSION"
           fi
           # Run xvfb to make Chrome/Chromium believe it has a display. Else it fails signing the package
           Xvfb -ac :99 -screen 0 1280x1024x16 &
           export DISPLAY=:99
           if [ -z "$TAG_NAME" ]; then
-            ./scripts/create_all_packages.sh
+            ./scripts/create_all_packages.sh -d
           else
-            ./scripts/create_all_packages.sh -t -v "$TAG_NAME"
+            ./scripts/create_all_packages.sh -d -t -v "$TAG_NAME"
           fi

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -77,7 +77,7 @@ jobs:
           Xvfb -ac :99 -screen 0 1280x1024x16 &
           export DISPLAY=:99
           if [ -z "$TAG_NAME" ]; then
-            ./scripts/create_all_packages.sh -d
+            ./scripts/create_all_packages.sh
           else
-            ./scripts/create_all_packages.sh -d -t -v "$TAG_NAME"
+            ./scripts/create_all_packages.sh -t -v "$TAG_NAME"
           fi


### PR DESCRIPTION
Fixes #914. This has the dry-run switch added for testing. Remove before merge.