### PR TITLE
Use latest GitHub workflow actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       # Clone the repo and checkout the commit for which the workflow was triggered
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Test integrity of app parameters
         shell: bash
@@ -36,7 +36,7 @@ jobs:
           ./scripts/test_pwa_server.sh
 
       # Install Node.js LTS
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 10.x
 
@@ -75,8 +75,8 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 10.x
       - name: Install dependencies
@@ -118,7 +118,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Test the list of offline files in Service Worker
         shell: pwsh
         run: ./scripts/Check-OfflineFilesList.ps1

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -32,7 +32,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up secret files from encrypted secrets
       - name: Set up secret files

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/publish-extension.yaml
+++ b/.github/workflows/publish-extension.yaml
@@ -37,7 +37,7 @@ jobs:
     name: Deploy Mozilla extension
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Modify version in source files
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
This was recommended to avoid warnings in the CI because old actions workflow rely on Node.js 12 which has been meanwhile deprecated