### PR TITLE
Removed usage of jquery while opening and closing bootstrap modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Please note that this application has changed its name over time.
 It was first called Evopedia (and was using the file format of Evopedia).
 Then it was renamed Kiwix-html5 (and uses ZIM files), and then again was renamed to Kiwix-JS.
 
+## Interim: Kiwix-JS v3.7.2
+
+This version is only published to the moz-extension PWA, and will be part of v3.8.0 when ready
+
+* NEW: Expert/troubleshooting setting to disable drag-and-drop
+* UPDATE: API status panel now displays the PWA origin
+* UPDATE: The PWA version now notifies more reliably that an update is available
+* DEV: CI now uses the latest GitHub workflow actions
+
 ## Kiwix-JS v3.7.0
 
 Released on *2023-01-04*

--- a/www/index.html
+++ b/www/index.html
@@ -51,7 +51,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="modalLabel">Modal title goes here</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <button type="button" id="modalCloseBtn" class="close" data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
                     </div>

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -80,37 +80,37 @@ define(rqDef, function(settingsStore) {
             modal.setAttribute('role', 'dialog');
 
             // Hide modal handlers
-            function closeModalHandler(){
-              document.body.classList.remove('modal-open');
-              modal.classList.remove('show');
-              modal.style.display = 'none';
-              backdrop.classList.remove('show');
-              if(Array.from(document.body.children).indexOf(backdrop)>=0){ 
-                document.body.removeChild(backdrop);
-              }
-              //remove event listeners
-              document.getElementById('modalCloseBtn').removeEventListener('click', close);
-              document.getElementById('declineConfirm').removeEventListener('click', close);
-              document.getElementById('closeMessage').removeEventListener('click', close);
-              document.getElementById('approveConfirm').removeEventListener('click', closeConfirm);
-              modal.removeEventListener('click', close);
-              document.getElementsByClassName('modal-dialog')[0].removeEventListener('click', stopOutsideModalClick);
-              modal.removeEventListener('keyup', keyHandler);
-            }
+            let closeModalHandler = function (){
+                document.body.classList.remove('modal-open');
+                modal.classList.remove('show');
+                modal.style.display = 'none';
+                backdrop.classList.remove('show');
+                if(Array.from(document.body.children).indexOf(backdrop)>=0){ 
+                    document.body.removeChild(backdrop);
+                }
+                //remove event listeners
+                document.getElementById('modalCloseBtn').removeEventListener('click', close);
+                document.getElementById('declineConfirm').removeEventListener('click', close);
+                document.getElementById('closeMessage').removeEventListener('click', close);
+                document.getElementById('approveConfirm').removeEventListener('click', closeConfirm);
+                modal.removeEventListener('click', close);
+                document.getElementsByClassName('modal-dialog')[0].removeEventListener('click', stopOutsideModalClick);
+                modal.removeEventListener('keyup', keyHandler);
+            };
 
             // function to call when modal is closed
-            function close(){
-              closeModalHandler();
-              resolve(false);
-            }
-            function closeConfirm(){
-              closeModalHandler();
-              resolve(true);
-            }
-            function stopOutsideModalClick(e){
-              e.stopPropagation();
-            }
-            function keyHandler(e) {
+            let close = function (){
+                closeModalHandler();
+                resolve(false);
+            };
+            let closeConfirm = function (){
+                closeModalHandler();
+                resolve(true);
+            };
+            let stopOutsideModalClick = function (e){
+                e.stopPropagation();
+            };
+            let keyHandler = function (e) {
                 if (/Enter/.test(e.key)){
                     // We need to focus before clicking the button, because the handler above is based on document.activeElement
                     if (isConfirm) {
@@ -124,7 +124,7 @@ define(rqDef, function(settingsStore) {
                     document.getElementById('modalCloseBtn').focus();
                     document.getElementById('modalCloseBtn').click();
                 }
-            }
+            };
 
             // When hide modal is called, resolve promise with true if hidden using approve button, false otherwise
             document.getElementById('modalCloseBtn').addEventListener('click', close);

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -117,7 +117,7 @@ define(rqDef, function(settingsStore) {
               e.stopPropagation();
             })
 
-            document.addEventListener('keyup', function (e) {
+            modal.addEventListener('keyup', function (e) {
                 if (/Enter/.test(e.key)){
                     // We need to focus before clicking the button, because the handler above is based on document.activeElement
                     if (isConfirm) {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -112,6 +112,14 @@ define(rqDef, function(settingsStore) {
               closeModalHandler();
               resolve(true);
             });
+            
+            modal.addEventListener("click", function (e) {
+              closeModalHandler();
+              resolve(false);
+            });
+            document.getElementsByClassName("modal-dialog")[0].addEventListener("click", function(e){
+              e.stopPropagation();
+            })
 
             document.getElementById('alertModal').addEventListener('keyup', function (e) {
                 if (/Enter/.test(e.key)){

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -92,38 +92,25 @@ define(rqDef, function(settingsStore) {
               document.getElementById('modalCloseBtn').removeEventListener('click', close);
               document.getElementById('declineConfirm').removeEventListener('click', close);
               document.getElementById('closeMessage').removeEventListener('click', close);
-              document.getElementById('approveConfirm').removeEventListener('click', close);
+              document.getElementById('approveConfirm').removeEventListener('click', closeConfirm);
               modal.removeEventListener('click', close);
-              document.getElementsByClassName('modal-dialog')[0].removeEventListener('click', close);
-              modal.removeEventListener('keyup', close);
+              document.getElementsByClassName('modal-dialog')[0].removeEventListener('click', stopOutsideModalClick);
+              modal.removeEventListener('keyup', keyHandler);
             }
-            // When hide modal is called, resolve promise with true if hidden using approve button, false otherwise
-            document.getElementById('modalCloseBtn').addEventListener('click', function close(){
+
+            // function to call when modal is closed
+            function close(){
               closeModalHandler();
               resolve(false);
-            });
-            document.getElementById('declineConfirm').addEventListener('click', function close() {
-              closeModalHandler();
-              resolve(false);
-            });
-            document.getElementById('closeMessage').addEventListener('click', function close() {
-              closeModalHandler();
-              resolve(false);
-            });
-            document.getElementById('approveConfirm').addEventListener('click', function close() {
+            }
+            function closeConfirm(){
               closeModalHandler();
               resolve(true);
-            });
-            
-            modal.addEventListener('click', function close() {
-              closeModalHandler();
-              resolve(false);
-            });
-            document.getElementsByClassName('modal-dialog')[0].addEventListener('click', function close(e){
+            }
+            function stopOutsideModalClick(e){
               e.stopPropagation();
-            })
-
-            modal.addEventListener('keyup', function close(e) {
+            }
+            function keyHandler(e) {
                 if (/Enter/.test(e.key)){
                     // We need to focus before clicking the button, because the handler above is based on document.activeElement
                     if (isConfirm) {
@@ -137,7 +124,18 @@ define(rqDef, function(settingsStore) {
                     document.getElementById('modalCloseBtn').focus();
                     document.getElementById('modalCloseBtn').click();
                 }
-            });
+            }
+
+            // When hide modal is called, resolve promise with true if hidden using approve button, false otherwise
+            document.getElementById('modalCloseBtn').addEventListener('click', close);
+            document.getElementById('declineConfirm').addEventListener('click', close);
+            document.getElementById('closeMessage').addEventListener('click', close);
+            document.getElementById('approveConfirm').addEventListener('click', closeConfirm);
+            
+            modal.addEventListener('click', close);
+            document.getElementsByClassName('modal-dialog')[0].addEventListener('click', stopOutsideModalClick);
+
+            modal.addEventListener('keyup', keyHandler);
             // Set focus to the first focusable element inside the modal
             modal.focus();
         });

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -113,7 +113,7 @@ define(rqDef, function(settingsStore) {
               resolve(true);
             });
             
-            modal.addEventListener("click", function (e) {
+            modal.addEventListener("click", function (_e) {
               closeModalHandler();
               resolve(false);
             });

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -45,34 +45,30 @@ define(rqDef, function(settingsStore) {
      * @returns {Promise<Boolean>} A promise which resolves to true if the user clicked Confirm, false if the user clicked Cancel/Okay, backdrop or the cross(x) button
      */
     function systemAlert(message, label, isConfirm, declineConfirmLabel, approveConfirmLabel, closeMessageLabel) {
-        declineConfirmLabel = declineConfirmLabel || "Cancel";
-        approveConfirmLabel = approveConfirmLabel || "Confirm";
-        closeMessageLabel = closeMessageLabel || "Okay";
-        label = label || (isConfirm ? "Confirmation" : "Message");
+        declineConfirmLabel = declineConfirmLabel || 'Cancel';
+        approveConfirmLabel = approveConfirmLabel || 'Confirm';
+        closeMessageLabel = closeMessageLabel || 'Okay';
+        label = label || (isConfirm ? 'Confirmation' : 'Message');
         return new Promise(function (resolve, reject) {
-            if (!message) reject("Missing body message");
+            if (!message) reject('Missing body message');
             // Set the text to the modal and its buttons
-            document.getElementById("approveConfirm").textContent = approveConfirmLabel;
-            document.getElementById("declineConfirm").textContent = declineConfirmLabel;
-            document.getElementById("closeMessage").textContent = closeMessageLabel;
-            document.getElementById("modalLabel").textContent = label;
+            document.getElementById('approveConfirm').textContent = approveConfirmLabel;
+            document.getElementById('declineConfirm').textContent = declineConfirmLabel;
+            document.getElementById('closeMessage').textContent = closeMessageLabel;
+            document.getElementById('modalLabel').textContent = label;
             // Using innerHTML to set the message to allow HTML formatting
-            document.getElementById("modalText").innerHTML = message;
+            document.getElementById('modalText').innerHTML = message;
             // Display buttons acc to the type of alert
-            document.getElementById("approveConfirm").style.display = isConfirm ? "inline" : "none";
-            document.getElementById("declineConfirm").style.display = isConfirm ? "inline" : "none";
-            document.getElementById("closeMessage").style.display = isConfirm ? "none" : "inline";
+            document.getElementById('approveConfirm').style.display = isConfirm ? 'inline' : 'none';
+            document.getElementById('declineConfirm').style.display = isConfirm ? 'inline' : 'none';
+            document.getElementById('closeMessage').style.display = isConfirm ? 'none' : 'inline';
             // Display the modal
             const modal = document.querySelector('#alertModal');
             const backdrop = document.createElement('div');
             backdrop.classList.add('modal-backdrop');
             document.body.appendChild(backdrop);
-
-            modal.addEventListener('shown.bs.modal', function () {
-              // Set focus to the first focusable element inside the modal
-              const firstFocusableElement = modal.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-              firstFocusableElement.focus();
-            });
+            // Set focus to the first focusable element inside the modal
+            modal.focus();
 
             // Show the modal
             document.body.classList.add('modal-open');
@@ -96,32 +92,32 @@ define(rqDef, function(settingsStore) {
               }
             }
             // When hide model is called, resolve promise with true if hidden using approve button, false otherwise
-            document.getElementById("modalCloseBtn").addEventListener("click", function close(){
+            document.getElementById('modalCloseBtn').addEventListener('click', function close(){
               closeModalHandler();
               resolve(false);
             });
-            document.getElementById("declineConfirm").addEventListener("click", function () {
+            document.getElementById('declineConfirm').addEventListener('click', function () {
               closeModalHandler();
               resolve(false);
             });
-            document.getElementById("closeMessage").addEventListener("click", function () {
+            document.getElementById('closeMessage').addEventListener('click', function () {
               closeModalHandler();
               resolve(false);
             });
-            document.getElementById("approveConfirm").addEventListener("click", function () {
+            document.getElementById('approveConfirm').addEventListener('click', function () {
               closeModalHandler();
               resolve(true);
             });
             
-            modal.addEventListener("click", function () {
+            modal.addEventListener('click', function () {
               closeModalHandler();
               resolve(false);
             });
-            document.getElementsByClassName("modal-dialog")[0].addEventListener("click", function(e){
+            document.getElementsByClassName('modal-dialog')[0].addEventListener('click', function(e){
               e.stopPropagation();
             })
 
-            document.getElementById('alertModal').addEventListener('keyup', function (e) {
+            document.addEventListener('keyup', function (e) {
                 if (/Enter/.test(e.key)){
                     // We need to focus before clicking the button, because the handler above is based on document.activeElement
                     if (isConfirm) {
@@ -131,6 +127,9 @@ define(rqDef, function(settingsStore) {
                         document.getElementById('closeMessage').focus();
                         document.getElementById('closeMessage').click();
                     }
+                } else if (/Esc/.test(e.key)) {
+                    document.getElementById('modalCloseBtn').focus();
+                    document.getElementById('modalCloseBtn').click();
                 }
             });
         });

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -68,7 +68,7 @@ define(rqDef, function(settingsStore) {
             backdrop.classList.add('modal-backdrop');
             document.body.appendChild(backdrop);
 
-            modal.addEventListener('shown.bs.modal', function (_event) {
+            modal.addEventListener('shown.bs.modal', function () {
               // Set focus to the first focusable element inside the modal
               const firstFocusableElement = modal.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
               firstFocusableElement.focus();
@@ -113,7 +113,7 @@ define(rqDef, function(settingsStore) {
               resolve(true);
             });
             
-            modal.addEventListener("click", function (_e) {
+            modal.addEventListener("click", function () {
               closeModalHandler();
               resolve(false);
             });

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -104,6 +104,10 @@ define(rqDef, function(settingsStore) {
               closeModalHandler();
               resolve(false);
             });
+            document.getElementById("closeMessage").addEventListener("click", function () {
+              closeModalHandler();
+              resolve(false);
+            });
             document.getElementById("approveConfirm").addEventListener("click", function () {
               closeModalHandler();
               resolve(true);

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -67,8 +67,6 @@ define(rqDef, function(settingsStore) {
             const backdrop = document.createElement('div');
             backdrop.classList.add('modal-backdrop');
             document.body.appendChild(backdrop);
-            // Set focus to the first focusable element inside the modal
-            modal.focus();
 
             // Show the modal
             document.body.classList.add('modal-open');
@@ -91,7 +89,7 @@ define(rqDef, function(settingsStore) {
                 document.body.removeChild(backdrop);
               }
             }
-            // When hide model is called, resolve promise with true if hidden using approve button, false otherwise
+            // When hide modal is called, resolve promise with true if hidden using approve button, false otherwise
             document.getElementById('modalCloseBtn').addEventListener('click', function close(){
               closeModalHandler();
               resolve(false);
@@ -132,6 +130,8 @@ define(rqDef, function(settingsStore) {
                     document.getElementById('modalCloseBtn').click();
                 }
             });
+            // Set focus to the first focusable element inside the modal
+            modal.focus();
         });
     }
   

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -63,16 +63,53 @@ define(rqDef, function(settingsStore) {
             document.getElementById("declineConfirm").style.display = isConfirm ? "inline" : "none";
             document.getElementById("closeMessage").style.display = isConfirm ? "none" : "inline";
             // Display the modal
-            $("#alertModal").modal("show");
-            // When hide model is called, resolve promise with true if hidden using approve button, false otherwise
-            $("#alertModal").on("hide.bs.modal", function () {
-                const closeSource = document.activeElement;
-                if (closeSource.id === "approveConfirm") {
-                    resolve(true);
-                } else {
-                    resolve(false);
-                }
+            const modal = document.querySelector('#alertModal');
+            const backdrop = document.createElement('div');
+            backdrop.classList.add('modal-backdrop');
+            document.body.appendChild(backdrop);
+
+            modal.addEventListener('shown.bs.modal', function (_event) {
+              // Set focus to the first focusable element inside the modal
+              const firstFocusableElement = modal.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+              firstFocusableElement.focus();
             });
+
+            // Show the modal
+            document.body.classList.add('modal-open');
+            modal.classList.add('show');
+            modal.style.display = 'block';
+            backdrop.classList.add('show');
+
+            // Set the ARIA attributes for the modal
+            modal.setAttribute('aria-hidden', 'false');
+            modal.setAttribute('aria-modal', 'true');
+            modal.setAttribute('role', 'dialog');
+
+            // Hide modal handlers
+            function closeModalHandler(){
+              document.body.classList.remove('modal-open');
+              modal.classList.remove('show');
+              modal.style.display = 'none';
+              backdrop.classList.remove('show');
+              if(Array.from(document.body.children).indexOf(backdrop)>=0){ 
+                document.body.removeChild(backdrop);
+              }
+            }
+            // When hide model is called, resolve promise with true if hidden using approve button, false otherwise
+            document.getElementById("modalCloseBtn").addEventListener("click", function close(){
+              closeModalHandler();
+              resolve(false);
+            });
+            document.getElementById("declineConfirm").addEventListener("click", function () {
+              closeModalHandler();
+              resolve(false);
+            });
+            document.getElementById("approveConfirm").addEventListener("click", function () {
+              closeModalHandler();
+              resolve(true);
+            });
+
+          
             document.getElementById('alertModal').addEventListener('keyup', function (e) {
                 if (/Enter/.test(e.key)){
                     // We need to focus before clicking the button, because the handler above is based on document.activeElement

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -80,7 +80,7 @@ define(rqDef, function(settingsStore) {
             modal.setAttribute('role', 'dialog');
 
             // Hide modal handlers
-            let closeModalHandler = function () {
+            var closeModalHandler = function () {
                 document.body.classList.remove('modal-open');
                 modal.classList.remove('show');
                 modal.style.display = 'none';
@@ -99,18 +99,18 @@ define(rqDef, function(settingsStore) {
             };
 
             // function to call when modal is closed
-            let close = function () {
+            var close = function () {
                 closeModalHandler();
                 resolve(false);
             };
-            let closeConfirm = function () {
+            var closeConfirm = function () {
                 closeModalHandler();
                 resolve(true);
             };
-            let stopOutsideModalClick = function (e) {
+            var stopOutsideModalClick = function (e) {
                 e.stopPropagation();
             };
-            let keyHandler = function (e) {
+            var keyHandler = function (e) {
                 if (/Enter/.test(e.key)) {
                     // We need to focus before clicking the button, because the handler above is based on document.activeElement
                     if (isConfirm) {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -80,7 +80,7 @@ define(rqDef, function(settingsStore) {
             modal.setAttribute('role', 'dialog');
 
             // Hide modal handlers
-            let closeModalHandler = function (){
+            let closeModalHandler = function () {
                 document.body.classList.remove('modal-open');
                 modal.classList.remove('show');
                 modal.style.display = 'none';
@@ -99,19 +99,19 @@ define(rqDef, function(settingsStore) {
             };
 
             // function to call when modal is closed
-            let close = function (){
+            let close = function () {
                 closeModalHandler();
                 resolve(false);
             };
-            let closeConfirm = function (){
+            let closeConfirm = function () {
                 closeModalHandler();
                 resolve(true);
             };
-            let stopOutsideModalClick = function (e){
+            let stopOutsideModalClick = function (e) {
                 e.stopPropagation();
             };
             let keyHandler = function (e) {
-                if (/Enter/.test(e.key)){
+                if (/Enter/.test(e.key)) {
                     // We need to focus before clicking the button, because the handler above is based on document.activeElement
                     if (isConfirm) {
                         document.getElementById('approveConfirm').focus();

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -88,34 +88,42 @@ define(rqDef, function(settingsStore) {
               if(Array.from(document.body.children).indexOf(backdrop)>=0){ 
                 document.body.removeChild(backdrop);
               }
+              //remove event listeners
+              document.getElementById('modalCloseBtn').removeEventListener('click', close);
+              document.getElementById('declineConfirm').removeEventListener('click', close);
+              document.getElementById('closeMessage').removeEventListener('click', close);
+              document.getElementById('approveConfirm').removeEventListener('click', close);
+              modal.removeEventListener('click', close);
+              document.getElementsByClassName('modal-dialog')[0].removeEventListener('click', close);
+              modal.removeEventListener('keyup', close);
             }
             // When hide modal is called, resolve promise with true if hidden using approve button, false otherwise
             document.getElementById('modalCloseBtn').addEventListener('click', function close(){
               closeModalHandler();
               resolve(false);
             });
-            document.getElementById('declineConfirm').addEventListener('click', function () {
+            document.getElementById('declineConfirm').addEventListener('click', function close() {
               closeModalHandler();
               resolve(false);
             });
-            document.getElementById('closeMessage').addEventListener('click', function () {
+            document.getElementById('closeMessage').addEventListener('click', function close() {
               closeModalHandler();
               resolve(false);
             });
-            document.getElementById('approveConfirm').addEventListener('click', function () {
+            document.getElementById('approveConfirm').addEventListener('click', function close() {
               closeModalHandler();
               resolve(true);
             });
             
-            modal.addEventListener('click', function () {
+            modal.addEventListener('click', function close() {
               closeModalHandler();
               resolve(false);
             });
-            document.getElementsByClassName('modal-dialog')[0].addEventListener('click', function(e){
+            document.getElementsByClassName('modal-dialog')[0].addEventListener('click', function close(e){
               e.stopPropagation();
             })
 
-            modal.addEventListener('keyup', function (e) {
+            modal.addEventListener('keyup', function close(e) {
                 if (/Enter/.test(e.key)){
                     // We need to focus before clicking the button, because the handler above is based on document.activeElement
                     if (isConfirm) {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -109,7 +109,6 @@ define(rqDef, function(settingsStore) {
               resolve(true);
             });
 
-          
             document.getElementById('alertModal').addEventListener('keyup', function (e) {
                 if (/Enter/.test(e.key)){
                     // We need to focus before clicking the button, because the handler above is based on document.activeElement


### PR DESCRIPTION
Replaced use of jquery with native javascript calls while invoking and closing bootstrap modals. Although bootstrap 4.3 uses jquery under the hood, so complete removal is not possible until bootstrap is upgraded. 
closes #921 