### PR TITLE
Add sandbox to iframe

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -327,8 +327,7 @@ function fetchUrlFromZIM(urlObject, range) {
                 var headers = new Headers();
                 if (contentLength) headers.set('Content-Length', contentLength);
                 // Set Content-Security-Policy to sandbox the content (prevent XSS attacks from malicious ZIMs)
-                headers.set('Content-Security-Policy', "default-src 'self' data: blob: about: https://moz-extension.kiwix.org https://kiwix.github.io 'unsafe-inline' 'unsafe-eval'; frame-src 'self'; object-src 'none';");
-                headers.set('Content-Security-Policy', 'sandbox allow-scripts allow-same-origin allow-modals allow-popups allow-forms allow-downloads');
+                headers.set('Content-Security-Policy', "default-src 'self' data: blob: about: https://moz-extension.kiwix.org https://kiwix.github.io 'unsafe-inline' 'unsafe-eval'; sandbox allow-scripts allow-same-origin allow-modals allow-popups allow-forms allow-downloads;");
                 headers.set('Referrer-Policy', 'no-referrer');
                 if (contentType) headers.set('Content-Type', contentType);
                 

--- a/service-worker.js
+++ b/service-worker.js
@@ -327,7 +327,7 @@ function fetchUrlFromZIM(urlObject, range) {
                 var headers = new Headers();
                 if (contentLength) headers.set('Content-Length', contentLength);
                 // Set Content-Security-Policy to sandbox the content (prevent XSS attacks from malicious ZIMs)
-                headers.set('Content-Security-Policy', "default-src 'self' data: blob: about: 'unsafe-inline' 'unsafe-eval'");
+                headers.set('Content-Security-Policy', "default-src 'self' data: blob: about: https://moz-extension.kiwix.org https://kiwix.github.io 'unsafe-inline' 'unsafe-eval'; frame-src 'self'; object-src 'none';");
                 headers.set('Content-Security-Policy', 'sandbox allow-scripts allow-same-origin allow-modals allow-popups allow-forms allow-downloads');
                 headers.set('Referrer-Policy', 'no-referrer');
                 if (contentType) headers.set('Content-Type', contentType);

--- a/service-worker.js
+++ b/service-worker.js
@@ -327,7 +327,7 @@ function fetchUrlFromZIM(urlObject, range) {
                 var headers = new Headers();
                 if (contentLength) headers.set('Content-Length', contentLength);
                 // Set Content-Security-Policy to sandbox the content (prevent XSS attacks from malicious ZIMs)
-                headers.set('Content-Security-Policy', "default-src 'self' data: blob: about: https://moz-extension.kiwix.org https://kiwix.github.io 'unsafe-inline' 'unsafe-eval'; sandbox allow-scripts allow-same-origin allow-modals allow-popups allow-forms allow-downloads;");
+                headers.set('Content-Security-Policy', "default-src 'self' data: blob: about: chrome-extension: https://moz-extension.kiwix.org https://kiwix.github.io 'unsafe-inline' 'unsafe-eval'; sandbox allow-scripts allow-same-origin allow-modals allow-popups allow-forms allow-downloads;");
                 headers.set('Referrer-Policy', 'no-referrer');
                 if (contentType) headers.set('Content-Type', contentType);
                 

--- a/service-worker.js
+++ b/service-worker.js
@@ -322,10 +322,13 @@ function fetchUrlFromZIM(urlObject, range) {
         messageChannel.port1.onmessage = function (msgPortEvent) {
             if (msgPortEvent.data.action === 'giveContent') {
                 // Content received from app.js
-                var contentLength = msgPortEvent.data.content ? msgPortEvent.data.content.byteLength : null;
+                var contentLength = msgPortEvent.data.content ? (msgPortEvent.data.content.byteLength || msgPortEvent.data.content.length) : null;
                 var contentType = msgPortEvent.data.mimetype;
                 var headers = new Headers();
                 if (contentLength) headers.set('Content-Length', contentLength);
+                // Set Content-Security-Policy to sandbox the content (prevent XSS attacks from malicious ZIMs)
+                headers.set('Content-Security-Policy', "default-src 'self' data: blob: about: 'unsafe-inline' 'unsafe-eval'");
+                headers.set('Content-Security-Policy', 'sandbox allow-scripts allow-same-origin allow-modals allow-popups allow-forms allow-downloads');
                 if (contentType) headers.set('Content-Type', contentType);
                 
                 // Test if the content is a video or audio file. In this case, Chrome & Edge need us to support ranges.

--- a/service-worker.js
+++ b/service-worker.js
@@ -329,6 +329,7 @@ function fetchUrlFromZIM(urlObject, range) {
                 // Set Content-Security-Policy to sandbox the content (prevent XSS attacks from malicious ZIMs)
                 headers.set('Content-Security-Policy', "default-src 'self' data: blob: about: 'unsafe-inline' 'unsafe-eval'");
                 headers.set('Content-Security-Policy', 'sandbox allow-scripts allow-same-origin allow-modals allow-popups allow-forms allow-downloads');
+                headers.set('Referrer-Policy', 'no-referrer');
                 if (contentType) headers.set('Content-Type', contentType);
                 
                 // Test if the content is a video or audio file. In this case, Chrome & Edge need us to support ranges.

--- a/www/index.html
+++ b/www/index.html
@@ -6,7 +6,7 @@
         <title>Kiwix</title>
         <meta name="description" content="Offline Wikipedia reader">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: https://download.kiwix.org https://master.download.kiwix.org https://moz-extension.kiwix.org https://kiwix.github.io 'unsafe-inline' 'unsafe-eval'; frame-src 'self' moz-extension:; object-src 'none';">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: https://download.kiwix.org https://master.download.kiwix.org https://moz-extension.kiwix.org https://kiwix.github.io 'unsafe-inline' 'unsafe-eval'; frame-src 'self' moz-extension: chrome-extension:; object-src 'none';">
         <meta name="referrer" content="none">
         <!--
         Kiwix (offline Wikipedia reader) - HTML5/Javascript version

--- a/www/index.html
+++ b/www/index.html
@@ -7,6 +7,7 @@
         <meta name="description" content="Offline Wikipedia reader">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://download.kiwix.org https://master.download.kiwix.org 'unsafe-inline' 'unsafe-eval'; img-src 'self' data:; frame-src 'self'; object-src 'none';">
+        <meta name="referrer" content="none">
         <!--
         Kiwix (offline Wikipedia reader) - HTML5/Javascript version
         Home page : https://www.kiwix.org
@@ -687,7 +688,7 @@
                         if your platform supports it. &nbsp;[<a id="stop" href="#expertSettingsDiv" class="alert-link">Permanently hide</a>]
                     </div>
                 </div>
-                <iframe id="articleContent" class="articleIFrame" src="article.html" referrerpolicy="same-origin" sandbox="allow-same-origin allow-scripts allow-modals allow-forms allow-popups allow-downloads"></iframe>
+                <iframe id="articleContent" class="articleIFrame" src="article.html" referrerpolicy="no-referrer" sandbox="allow-same-origin allow-scripts allow-modals allow-forms allow-popups allow-downloads"></iframe>
             </article>
             <footer>
                 <!-- Bootstrap alert box -->

--- a/www/index.html
+++ b/www/index.html
@@ -6,7 +6,7 @@
         <title>Kiwix</title>
         <meta name="description" content="Offline Wikipedia reader">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://download.kiwix.org https://master.download.kiwix.org 'unsafe-inline' 'unsafe-eval'; img-src 'self' data:; frame-src 'self'; object-src 'none';">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: https://download.kiwix.org https://master.download.kiwix.org https://moz-extension.kiwix.org https://kiwix.github.io 'unsafe-inline' 'unsafe-eval'; frame-src 'self'; object-src 'none';">
         <meta name="referrer" content="none">
         <!--
         Kiwix (offline Wikipedia reader) - HTML5/Javascript version

--- a/www/index.html
+++ b/www/index.html
@@ -6,7 +6,7 @@
         <title>Kiwix</title>
         <meta name="description" content="Offline Wikipedia reader">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: https://download.kiwix.org https://master.download.kiwix.org https://moz-extension.kiwix.org https://kiwix.github.io 'unsafe-inline' 'unsafe-eval'; frame-src 'self'; object-src 'none';">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: https://download.kiwix.org https://master.download.kiwix.org https://moz-extension.kiwix.org https://kiwix.github.io 'unsafe-inline' 'unsafe-eval'; frame-src 'self' moz-extension:; object-src 'none';">
         <meta name="referrer" content="none">
         <!--
         Kiwix (offline Wikipedia reader) - HTML5/Javascript version

--- a/www/index.html
+++ b/www/index.html
@@ -686,7 +686,7 @@
                         if your platform supports it. &nbsp;[<a id="stop" href="#expertSettingsDiv" class="alert-link">Permanently hide</a>]
                     </div>
                 </div>
-                <iframe id="articleContent" class="articleIFrame" src="article.html"></iframe>
+                <iframe id="articleContent" class="articleIFrame" src="article.html" referrerpolicy="same-origin" sandbox="allow-same-origin allow-scripts allow-modals allow-forms allow-popups"></iframe>
             </article>
             <footer>
                 <!-- Bootstrap alert box -->

--- a/www/index.html
+++ b/www/index.html
@@ -6,6 +6,7 @@
         <title>Kiwix</title>
         <meta name="description" content="Offline Wikipedia reader">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://download.kiwix.org https://master.download.kiwix.org 'unsafe-inline' 'unsafe-eval'; img-src 'self' data:; frame-src 'self'; object-src 'none';">
         <!--
         Kiwix (offline Wikipedia reader) - HTML5/Javascript version
         Home page : https://www.kiwix.org
@@ -686,7 +687,7 @@
                         if your platform supports it. &nbsp;[<a id="stop" href="#expertSettingsDiv" class="alert-link">Permanently hide</a>]
                     </div>
                 </div>
-                <iframe id="articleContent" class="articleIFrame" src="article.html" referrerpolicy="same-origin" sandbox="allow-same-origin allow-scripts allow-modals allow-forms allow-popups"></iframe>
+                <iframe id="articleContent" class="articleIFrame" src="article.html" referrerpolicy="same-origin" sandbox="allow-same-origin allow-scripts allow-modals allow-forms allow-popups allow-downloads"></iframe>
             </article>
             <footer>
                 <!-- Bootstrap alert box -->

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1595,6 +1595,11 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
                                 if (/^(?:http|ftp)/i.test(href)) {
                                     uiUtil.warnAndOpenExternalLinkInNewTab(event, clickedAnchor);
                                 }
+                                if (/\.pdf$/i.test(href)) {
+                                    // Due to the iframe sandbox, we have to prevent the PDF viewer from opening in the iframe and instead open it in a new tab
+                                    event.preventDefault();
+                                    window.open(clickedAnchor.href, '_blank');
+                                }
                             }
                         });
                     }


### PR DESCRIPTION
This addresses (but does not fix fully) #753 and #972. A full fix will require a separate PR implementing the Content Security Policy sandbox directive delivered via HTTP headers through the Service Worker.