### PR TITLE
Fix missing full text search cancellation

### DIFF
--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -253,6 +253,10 @@ define(['zimfile', 'zimDirEntry', 'util', 'uiUtil', 'utf8'],
         search.scanCount = 0;
         // Launch a full-text search if possible
         if (LZ) that.findDirEntriesFromFullTextSearch(search, dirEntries).then(function (fullTextDirEntries) {
+            // If user initiated a new search, cancel this one
+            // In particular, do not set the search status back to 'complete'
+            // as that would cause outdated results to unexpectedly pop up
+            if (search.status === 'cancelled') return callback([], search);
             dirEntries = fullTextDirEntries;
             search.status = 'complete';
             callback(dirEntries, search);


### PR DESCRIPTION
This fixes the corruption of the `search.status` variable due to an illegal state transition `cancelled -> complete` in the full text search callback. Before it was causing the search results list to show around 10% of the time when I press enter quickly, and 100% if I cause the full text search to be delayed artificially. After this PR, the search results list cancellation bug for the full text search occurs 0% of the time.

Closes #977