### PR TITLE
Fall back to MIME type when downloading doc in jQuery mode

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2116,12 +2116,13 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'settingsStore','abstractFilesys
     function goToArticle(path, download, contentType) {
         document.getElementById('searchingArticles').style.display = '';
         selectedArchive.getDirEntryByPath(path).then(function(dirEntry) {
+            var mimetype = contentType || dirEntry ? dirEntry.getMimetype() : '';
             if (dirEntry === null || dirEntry === undefined) {
                 document.getElementById('searchingArticles').style.display = 'none';
                 uiUtil.systemAlert("Article with url " + path + " not found in the archive", "Error: article not found");
-            } else if (download) {
+            } else if (download || /\/(epub|pdf|zip|.*opendocument|.*officedocument|tiff|mp4|webm|mpeg|mp3|octet-stream)\b/i.test(mimetype)) {
+                download = true;
                 selectedArchive.readBinaryFile(dirEntry, function (fileDirEntry, content) {
-                    var mimetype = contentType || fileDirEntry.getMimetype();
                     uiUtil.displayFileDownloadAlert(path, download, mimetype, content);
                 });
             } else {


### PR DESCRIPTION
Fixes #858 for jQuery mode. This does not touch ServiceWorker mode, as this should be handled natively in that mode. We cannot rely only on the filename extension, but must also consider the MIME type especially when there is no extension.