### PR TITLE
Temporarily remove i18next but leave instructions to reactivate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
         "@types/fs-extra": "^9.0.11",
         "bootstrap": "^4.6.2",
         "core-js": "3.30.2",
-        "i18next": "14.0.0",
         "jquery": "^3.7.0"
       },
       "devDependencies": {
@@ -5969,11 +5968,6 @@
       "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.28.0.tgz",
       "integrity": "sha512-jMAxraOOmHuPbffLVDKkEKi/NeG8dMqP8lGRd6Tbf7JgAeG33jjgPWDbXXU7ypCI0o+oNKJFgbSB9FKVdWNI2A==",
       "dev": true
-    },
-    "node_modules/i18next": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-14.0.0.tgz",
-      "integrity": "sha512-5ObcZNF0ksbBrgfeo4bMBcg0x/8O7kN/0vUBgmpB5WP8vcy0js4EQOMa/8nMyKrY7j3/NT491P+lraHl98TpvQ=="
     },
     "node_modules/iconv-lite": {
       "version": "0.5.1",
@@ -14855,11 +14849,6 @@
       "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.28.0.tgz",
       "integrity": "sha512-jMAxraOOmHuPbffLVDKkEKi/NeG8dMqP8lGRd6Tbf7JgAeG33jjgPWDbXXU7ypCI0o+oNKJFgbSB9FKVdWNI2A==",
       "dev": true
-    },
-    "i18next": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-14.0.0.tgz",
-      "integrity": "sha512-5ObcZNF0ksbBrgfeo4bMBcg0x/8O7kN/0vUBgmpB5WP8vcy0js4EQOMa/8nMyKrY7j3/NT491P+lraHl98TpvQ=="
     },
     "iconv-lite": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@types/fs-extra": "^9.0.11",
     "bootstrap": "^4.6.2",
     "core-js": "3.30.2",
-    "i18next": "14.0.0",
     "jquery": "^3.7.0"
   },
   "devDependencies": {

--- a/scripts/gitignore.patch
+++ b/scripts/gitignore.patch
@@ -30,12 +30,12 @@ index 69d180f..d93e57d 100644
 +!/node_modules/bootstrap/dist/js
 +/node_modules/bootstrap/dist/js/*
 +!/node_modules/bootstrap/dist/js/bootstrap.bundle.min.*
-+!/node_modules/i18next
-+/node_modules/i18next/*
-+!/node_modules/i18next/dist
-+/node_modules/i18next/dist/*
-+!/node_modules/i18next/dist/es
-+!/node_modules/i18next/dist/es/*
+# +!/node_modules/i18next
+# +/node_modules/i18next/*
+# +!/node_modules/i18next/dist
+# +/node_modules/i18next/dist/*
+# +!/node_modules/i18next/dist/es
+# +!/node_modules/i18next/dist/es/*
 +!/node_modules/jquery
 +/node_modules/jquery/*
 +!/node_modules/jquery/dist

--- a/www/js/lib/translateUI.js
+++ b/www/js/lib/translateUI.js
@@ -22,8 +22,16 @@
 
 'use strict';
 
-import i18next from '../../../node_modules/i18next/dist/es/i18next.js';
+// DEV: We are currently not using any features of i18next that cannot be provided simply by loading the translation strings
+// and looking up the key in the object. If you need more features, you can switch to using i18next by installing it, importing
+// it here, and using the commented-out code below. Instead of currentLanguage[string], use i18next.t(string). You will also need
+// to add a dependency on i18next in /scripts/gitignore.patch. To support IE11 and older browsers, you should use a version of
+// i18next that is no higher than 14.0.
+
+// import i18next from '../../../node_modules/i18next/dist/es/i18next.js';
 import util from './util.js';
+
+var currentLanguage = {};
 
 // Fallbacks come from the HTML, which is in English by default
 var fallback = true;
@@ -33,11 +41,12 @@ var fallback = true;
 // Load the translation strings as a JSON object for a given language code
 function loadTranslationStrings (langCode) {
     return util.getJSONObject('../i18n/' + langCode + '.json').then(function (translations) {
-        i18next.init({
-            lng: langCode, // if you're using a language detector, do not define the lng option
-            debug: true,
-            resources: translations
-        });
+        currentLanguage = translations[langCode]['translation'];
+        // i18next.init({
+        //     lng: langCode, // if you're using a language detector, do not define the lng option
+        //     debug: true,
+        //     resources: translations
+        // });
     }).catch(function (err) {
         console.error('Error loading translation strings for language code ' + langCode, err);
         console.warn('Falling back to English');
@@ -45,9 +54,14 @@ function loadTranslationStrings (langCode) {
     });
 }
 
+// Check if a translation exists for a given key
+function exists (key) {
+    return currentLanguage[key] !== undefined;
+};
+
 // Translate a single string
 function translateString (string) {
-    return (!fallback || i18next.exists(string)) ? i18next.t(string) : '';
+    return (!fallback || exists(string)) ? currentLanguage[string] : '';
 }
 
 // Translate the UI
@@ -56,14 +70,14 @@ function translateApp (languageCode) {
     return loadTranslationStrings(languageCode).then(function () {
         document.querySelectorAll('[data-i18n]').forEach(function (element) {
             var key = element.dataset.i18n;
-            if (!fallback || i18next.exists(key)) {
-                element.innerHTML = i18next.t(key);
+            if (!fallback || exists(key)) {
+                element.innerHTML = currentLanguage[key];
             }
         });
         document.querySelectorAll('[data-i18n-tip]').forEach(function (element) {
             var key = element.dataset.i18nTip;
-            if (!fallback || i18next.exists(key)) {
-                element.title = i18next.t(key);
+            if (!fallback || exists(key)) {
+                element.title = currentLanguage[key];
             }
         });
         document.getElementById('prefix').setAttribute('placeholder',


### PR DESCRIPTION
It turns out that we are not using any functions offered by i18next that cannot be used extremely simply by looking up the defined key in the language object. It therefore does not make sense to have the overhead of this (rather large) framework, until we actually need it.

This PR removes it, but leaves the (small amount) of code to interface with it commented out, with a comment explaining the steps needed to reactivate.