### PR TITLE
Ensure dockerfile serves jsonp with correct MIME type

### DIFF
--- a/docker/dockerfile-browser-extension.pwa
+++ b/docker/dockerfile-browser-extension.pwa
@@ -2,6 +2,7 @@ FROM nginx:latest
 
 EXPOSE 80
 
+RUN echo "application/javascript jsonp;" >> /etc/nginx/mime.types
 RUN mkdir /usr/share/nginx/html/current/
 COPY ./docker/index.nginx.html /usr/share/nginx/html/index.html
 COPY ./dist/manifest.json /usr/share/nginx/html/current/


### PR DESCRIPTION
Should partially fix #1099 for the GHCR container.