### PR TITLE
Optimize Windows testing by starting single server instance

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -178,19 +178,23 @@ jobs:
           exit $AggregateExitCode
 
       - name: Start Web server locally in background
+        shell: pwsh
         run: npx http-server --silent -p 8080 &
       
       - name: End-to-end tests on Edge Chromium (Windows)
+        shell: pwsh
         env:
           GITHUB_ACTION: ${{ github.event_name }}
         run: npx mocha ./tests/e2e/runners/edge/microsoftEdge.e2e.runner.js --retries 2
 
       - name: End-to-end tests on Firefox (Windows)
+        shell: pwsh
         env:
           GITHUB_ACTION: ${{ github.event_name }}
         run: npx mocha ./tests/e2e/runners/firefox/firefox.e2e.runner.js --retries 2
   
       - name: End-to-end tests in IE11 Mode (Windows)
+        shell: pwsh
         env:
           GITHUB_ACTION: ${{ github.event_name }}
         run: npx mocha ./tests/e2e/runners/edge/ieMode.e2e.runner.js --retries 2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,7 +93,7 @@ jobs:
           local-testing: start
           local-identifier: random
 
-      - name: Run App locally in background
+      - name: Start Web server locally in background
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
@@ -177,20 +177,23 @@ jobs:
           }
           exit $AggregateExitCode
 
+      - name: Start Web server locally in background
+        run: npx http-server --silent -p 8080 &
+      
       - name: End-to-end tests on Edge Chromium (Windows)
         env:
           GITHUB_ACTION: ${{ github.event_name }}
-        run: npx start-server-and-test 'http-server --silent' 8080 'npx mocha ./tests/e2e/runners/edge/microsoftEdge.e2e.runner.js --retries 2'
+        run: npx mocha ./tests/e2e/runners/edge/microsoftEdge.e2e.runner.js --retries 2
 
       - name: End-to-end tests on Firefox (Windows)
         env:
           GITHUB_ACTION: ${{ github.event_name }}
-        run: npx start-server-and-test 'http-server --silent' 8080 'npx mocha ./tests/e2e/runners/firefox/firefox.e2e.runner.js --retries 2'
+        run: npx mocha ./tests/e2e/runners/firefox/firefox.e2e.runner.js --retries 2
   
       - name: End-to-end tests in IE11 Mode (Windows)
         env:
           GITHUB_ACTION: ${{ github.event_name }}
-        run: npx start-server-and-test 'http-server --silent' 8080 'npx mocha ./tests/e2e/runners/edge/ieMode.e2e.runner.js --retries 2'
+        run: npx mocha ./tests/e2e/runners/edge/ieMode.e2e.runner.js --retries 2
 
   # tests-unit-mac:
   #   if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
No need to start and stop server three times.