### PR TITLE
Completely exit local code on comms with remote

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -36,6 +36,11 @@ import settingsStore from './lib/settingsStore.js';
 import abstractFilesystemAccess from './lib/abstractFilesystemAccess.js';
 import translateUI from './lib/translateUI.js';
 
+if (params.abort) {
+    // If the app was loaded only to pass a message from the remote code, then we exit immediately
+    throw new Error('Managed error: exiting local extension code.')
+}
+
 /**
  * The delay (in milliseconds) between two "keepalive" messages sent to the ServiceWorker (so that it is not stopped
  * by the browser, and keeps the MessageChannel to communicate with the application)

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -198,7 +198,8 @@ if (/PWA_launch=/.test(window.location.search)) {
     localStorage.setItem(params.keyPrefix + 'PWA_launch', match[1]);
     // If we have successfully launched the PWA (even if there was no SW mode available), we prevent future default mode change alerts
     if (match[1] === 'success') localStorage.setItem(params.keyPrefix + 'defaultModeChangeAlertDisplayed', true);
-    console.warn('Launch of PWA has been registered as "' + match[1] + '" by the extension. Exiting local code.');
+    console.warn('Launch of PWA has been registered as "' + match[1] + '" by the extension.');
+    throw new Error('Exiting local extension code.');
 } else {
     // Test if WebP is natively supported, and if not, load a webpMachine instance. This is used in uiUtils.js.
     var webpMachine = false;

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -199,7 +199,8 @@ if (/PWA_launch=/.test(window.location.search)) {
     // If we have successfully launched the PWA (even if there was no SW mode available), we prevent future default mode change alerts
     if (match[1] === 'success') localStorage.setItem(params.keyPrefix + 'defaultModeChangeAlertDisplayed', true);
     console.warn('Launch of PWA has been registered as "' + match[1] + '" by the extension.');
-    throw new Error('Exiting local extension code.');
+    // Set a flag to prevent further processing in app.js
+    params.abort = true;
 } else {
     // Test if WebP is natively supported, and if not, load a webpMachine instance. This is used in uiUtils.js.
     var webpMachine = false;


### PR DESCRIPTION
The only way discovered so far, short of writing an API, is to use a throw so that the bundle.js (or app.js) stops execution after the message is received from remote.