### PR TITLE
Switch to Manifest V3 for Firefox

### DIFF
--- a/backgroundscript.js
+++ b/backgroundscript.js
@@ -32,8 +32,8 @@ if (typeof browser !== 'undefined') {
     // Chromium/Chrome
     genericBrowser = chrome;
 }
-
-genericBrowser.action.onClicked.addListener(function () {
+// DEV: For a Mozilla MV3 extension, we have to change the event below to 'action'
+genericBrowser.browserAction.onClicked.addListener(function () {
     var newURL = chrome.runtime.getURL('www/index.html');
     chrome.tabs.create({ url: newURL });
 });

--- a/backgroundscript.js
+++ b/backgroundscript.js
@@ -33,7 +33,7 @@ if (typeof browser !== 'undefined') {
     genericBrowser = chrome;
 }
 
-genericBrowser.browserAction.onClicked.addListener(function () {
+genericBrowser.action.onClicked.addListener(function () {
     var newURL = chrome.runtime.getURL('www/index.html');
     chrome.tabs.create({ url: newURL });
 });

--- a/manifest.fx.v3.json
+++ b/manifest.fx.v3.json
@@ -1,0 +1,47 @@
+{
+    "manifest_version": 3,
+    "name": "Kiwix",
+    "version": "3.10.2",
+
+    "description": "Kiwix Offline Browser",
+    
+    "icons": {
+        "16": "www/img/icons/kiwix-16.png",
+        "19": "www/img/icons/kiwix-19.png",
+        "32": "www/img/icons/kiwix-32.png",
+        "38": "www/img/icons/kiwix-38.png",
+        "48": "www/img/icons/kiwix-48.png",
+        "64": "www/img/icons/kiwix-64.png",
+        "90": "www/img/icons/kiwix-90.png",
+        "128": "www/img/icons/kiwix-128.png"
+    },
+
+    "action": {
+        "default_icon": {
+            "16": "www/img/icons/kiwix-16.png",
+            "19": "www/img/icons/kiwix-19.png",
+            "32": "www/img/icons/kiwix-32.png",
+            "38": "www/img/icons/kiwix-38.png",
+            "64": "www/img/icons/kiwix-64.png"
+        },
+        "default_title": "Kiwix"
+    },
+
+    "background": {
+        "scripts": ["backgroundscript.js"]
+    },
+
+    "content_security_policy": {
+        "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';",
+        "sandbox": "sandbox allow-scripts allow-downloads allow-forms allow-popups allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval'; child-src 'self';"
+    },
+
+    "web_accessible_resources": [{
+        "resources": ["www/index.html", "www/article.html"],
+        "matches": ["https://*.kiwix.org/*"]
+    }],
+
+    "author": "Kiwix",
+    "homepage_url": "https://www.kiwix.org",
+    "offline_enabled": true
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,7 +46,7 @@ const config = {
             },
             { src: ['node_modules/bootstrap/dist/css/bootstrap.min.*'], dest: 'dist/www/css' },
             { src: ['i18n/*'], dest: 'dist/i18n' },
-            { src: ['archives', 'backgroundscript.js', 'index.html', 'manifest.json', 'manifest.v2.json', 'manifest.webapp', 'package.json', 'LICENSE-GPLv3.txt', 'CHANGELOG.md', 'README.md', '*.pfx', '*.cjs'], dest: 'dist' }
+            { src: ['archives', 'backgroundscript.js', 'index.html', 'manifest.json', 'manifest.fx.v3.json', 'manifest.v2.json', 'manifest.webapp', 'package.json', 'LICENSE-GPLv3.txt', 'CHANGELOG.md', 'README.md', '*.pfx', '*.cjs'], dest: 'dist' }
             ],
             flatten: true
         })

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -85,7 +85,7 @@ scripts/package_chrome_extension.sh -m 2 $DRYRUN $TAG -v $VERSION
 echo "The following extensions have been built so far:"
 pwd & ls -l build
 
-# Package for Firefox and Firefox OS
+# Package for Firefox MV2
 # We have to put a unique version string inside the manifest.json (which Chrome might not have accepted)
 # So we take the original manifest v2 again, and replace the version inside it again
 cp manifest.v2.json tmp/manifest.json
@@ -94,8 +94,11 @@ echo "Manifest version for Firefox MV2 extension:"
 cat tmp/manifest.json
 echo -e "\nPacking for Firefox MV2..."
 scripts/package_firefox_extension.sh -m 2 $DRYRUN $TAG -v $VERSION
+
 # Package for Firefox MV3
 cp manifest.fx.v3.json tmp/manifest.json
+# Replace the browserAction key which is no longer supported in MV3
+sed -i -E "s/browserAction/action/" tmp/backgroundscript.js
 # Note that MV3 requires a numeric version number
 sed -i -E "s/$VERSION_TO_REPLACE/$MAJOR_NUMERIC_VERSION/" tmp/manifest.json
 echo "Manifest version for Firefox MV3 extension:"

--- a/scripts/package_firefox_extension.sh
+++ b/scripts/package_firefox_extension.sh
@@ -6,11 +6,16 @@ pwd
 # Reading arguments
 while getopts tdv: option; do
     case "${option}" in
+        m) MV=$OPTARG;; # Optionally indicates the manifest version we're using (2 or 3); if present, the version will be added to filename
         t) TAG="-t";; # Indicates that we're releasing a public version from a tag
         d) DRYRUN="-d";; # Indicates a dryrun test, that does not modify anything on the network
         v) VERSION=${OPTARG};;
     esac
 done
+if [ -n $MV ]; then
+    echo -e "\nManifest version requested: $MV"
+    VERSION="mv$MV-$VERSION"
+fi
 
 # Install web-ext if it's not already installed (and if we're not doing a dryrun test)
 if [ ! -f node_modules/web-ext/bin/web-ext ] && [ "${DRYRUN}zz" == "zz" ]; then

--- a/scripts/package_firefox_extension.sh
+++ b/scripts/package_firefox_extension.sh
@@ -4,7 +4,7 @@ cd "$BASEDIR"
 pwd
 
 # Reading arguments
-while getopts tdv: option; do
+while getopts m:tdv: option; do
     case "${option}" in
         m) MV=$OPTARG;; # Optionally indicates the manifest version we're using (2 or 3); if present, the version will be added to filename
         t) TAG="-t";; # Indicates that we're releasing a public version from a tag


### PR DESCRIPTION
This is for testing the MV3 extension in Firefox, as discussed in #1120.

To test, rename `manifest.json` to `manifest.cr.v3.json`, and then rename `manifest.fx.v3.json` to `manifest.json`. Then install a temporary Firefox extension in the usual way.

In sum: it works just like the old extension. It still requires using the remote PWA to run Service Workes as they are still completely disabled in Firefox MV3 extensions.