### PR TITLE
Translation corrections and add tool tip explaining library

### DIFF
--- a/i18n/en.jsonp.js
+++ b/i18n/en.jsonp.js
@@ -19,6 +19,7 @@ document.localeJson = {
       "configure-title": "Configuration",
       "configure-about-usage-link": "About (Usage)",
       "configure-btn-library": "Browse ZIM Library",
+      "configure-btn-library-tip": "This will display a graphical library of ZIM archives for download if your browser can open it. Otherwise, it opens a text-only download library. If you are using the Chromium extension in ServiceWorkerLocal mode, you will only be able to use the text-based library (switch to ServiceWorker mode for the full graphical version).",
       "configure-btn-folderselect": "Select Folder",
       "configure-btn-rescan": "Rescan",
       "configure-about-rescan-tip": "Rescans your SD Cards and internal memory",

--- a/i18n/en.jsonp.js
+++ b/i18n/en.jsonp.js
@@ -19,7 +19,7 @@ document.localeJson = {
       "configure-title": "Configuration",
       "configure-about-usage-link": "About (Usage)",
       "configure-btn-library": "Browse ZIM Library",
-      "configure-btn-library-tip": "This will display a graphical library of ZIM archives for download if your browser can open it. Otherwise, it opens a text-only download library. If you are using the Chromium extension in ServiceWorkerLocal mode, you will only be able to use the text-based library (switch to ServiceWorker mode for the full graphical version).",
+      "configure-btn-library-tip": "This will display a graphical library of ZIM archives for download if your browser can open it. Otherwise, it opens a text-only version. If you are using the Chromium extension in ServiceWorkerLocal mode, you will only be able to use the latter (switch to ServiceWorker mode for the full graphical version).",
       "configure-btn-folderselect": "Select Folder",
       "configure-btn-rescan": "Rescan",
       "configure-about-rescan-tip": "Rescans your SD Cards and internal memory",

--- a/i18n/es.jsonp.js
+++ b/i18n/es.jsonp.js
@@ -19,6 +19,7 @@ document.localeJson = {
       "configure-title": "Configuración",
       "configure-about-usage-link": "Información (Uso)",
       "configure-btn-library": "Biblioteca ZIM",
+      "configure-btn-library-tip": "Esto muestra una biblioteca gráfica de archivos ZIM para descargar si su navegador puede abrirla. De lo contrario, muestra una biblioteca en formato texto. Si Ud está usando la extensión Chromium en modo ServiceWorkerLocal, sólo podrá usar la biblioteca en formato texto (cambie al modo ServiceWorker para la versión gráfica completa).",
       "configure-btn-folderselect": "Seleccione carpeta",
       "configure-btn-rescan": "Volver a escanear",
       "configure-about-rescan-tip": "Volver a escanear las tarjetas SD y la memoria interna",

--- a/i18n/es.jsonp.js
+++ b/i18n/es.jsonp.js
@@ -19,7 +19,7 @@ document.localeJson = {
       "configure-title": "Configuración",
       "configure-about-usage-link": "Información (Uso)",
       "configure-btn-library": "Biblioteca ZIM",
-      "configure-btn-library-tip": "Esto muestra una biblioteca gráfica de archivos ZIM para descargar si su navegador puede abrirla. De lo contrario, muestra una biblioteca en formato texto. Si Ud está usando la extensión Chromium en modo ServiceWorkerLocal, sólo podrá usar la biblioteca en formato texto (cambie al modo ServiceWorker para la versión gráfica completa).",
+      "configure-btn-library-tip": "Muestra una biblioteca gráfica de archivos ZIM para descargar si su navegador puede abrirla. De lo contrario, muestra una biblioteca en formato texto. Si está usando la extensión Chromium en modo ServiceWorkerLocal, sólo podrá usar el formato texto (cambie al modo ServiceWorker para la versión gráfica completa).",
       "configure-btn-folderselect": "Seleccione carpeta",
       "configure-btn-rescan": "Volver a escanear",
       "configure-about-rescan-tip": "Volver a escanear las tarjetas SD y la memoria interna",

--- a/i18n/es.jsonp.js
+++ b/i18n/es.jsonp.js
@@ -21,7 +21,7 @@ document.localeJson = {
       "configure-btn-library": "Biblioteca ZIM",
       "configure-btn-folderselect": "Seleccione carpeta",
       "configure-btn-rescan": "Volver a escanear",
-      "configure-about-rescan-tip": "Vuelve a escanear las tarjetas SD y la memoria interna",
+      "configure-about-rescan-tip": "Volver a escanear las tarjetas SD y la memoria interna",
       "configure-select-file-numbers": "archivo(s) encontrado(s) en la ubicación seleccionada. ",
       "configure-download-instructions": "Esta aplicación necesita un archivo ZIM para funcionar.<br />Para instrucciones completas, vea la sección",
       "configure-select-instructions": "Seleccione o arrastre y suelte un archivo .zim (o todos los .zimaa, .zimab etc en caso de un archivo dividido):",

--- a/i18n/fr.jsonp.js
+++ b/i18n/fr.jsonp.js
@@ -19,6 +19,7 @@ document.localeJson = {
       "configure-title": "Configuration",
       "configure-about-usage-link": "Informations (Utilisation)",
       "configure-btn-library": "Bibliothèque ZIM",
+      "configure-btn-library-tip": "Cela affiche une bibliothèque graphique d'archives ZIM à télécharger si votre navigateur peut l'ouvrir. Sinon, il affiche une bibliothèque de téléchargement en mode texte. Si vous utilisez l'extension Chromium en mode ServiceWorkerLocal, vous ne pourrez utiliser que la bibliothèque en mode texte (passez en mode ServiceWorker pour la version graphique complète).",
       "configure-btn-folderselect": "Sélectionner un dossier",
       "configure-btn-rescan": "Réanalyser",
       "configure-about-rescan-tip": "Réanalyser la carte SD et la mémoire interne",

--- a/i18n/fr.jsonp.js
+++ b/i18n/fr.jsonp.js
@@ -19,7 +19,7 @@ document.localeJson = {
       "configure-title": "Configuration",
       "configure-about-usage-link": "Informations (Utilisation)",
       "configure-btn-library": "Bibliothèque ZIM",
-      "configure-btn-library-tip": "Cela affiche une bibliothèque graphique d'archives ZIM à télécharger si votre navigateur peut l'ouvrir. Sinon, il affiche une bibliothèque de téléchargement en mode texte. Si vous utilisez l'extension Chromium en mode ServiceWorkerLocal, vous ne pourrez utiliser que la bibliothèque en mode texte (passez en mode ServiceWorker pour la version graphique complète).",
+      "configure-btn-library-tip": "Cela affiche une bibliothèque graphique d'archives ZIM à télécharger si votre navigateur peut l'ouvrir. Sinon, il affiche une bibliothèque de téléchargement en mode texte. Si vous utilisez l'extension Chromium en mode ServiceWorkerLocal, vous ne pourrez utiliser que la seconde (passez en mode ServiceWorker pour la version graphique complète).",
       "configure-btn-folderselect": "Sélectionner un dossier",
       "configure-btn-rescan": "Réanalyser",
       "configure-about-rescan-tip": "Réanalyser la carte SD et la mémoire interne",

--- a/www/index.html
+++ b/www/index.html
@@ -489,7 +489,7 @@
                                     <input type="file" id="archiveFolders" style="display: none;" webkitdirectory="true"/>
                                     <span data-i18n="configure-btn-folderselect">Select Folder</span>
                                 </label>
-                                <label tabindex="7" class="btn btn-light custom-file-upload" id="btnLibrary" data-i18n="configure-btn-library" data-i18n-tip="configure-btn-library-tip" title="This will open a graphical library of ZIM archives for download if your browser can open it. Otherwise, it opens a text-only download library. If you are using the Chromium extension in ServiceWorkerLocal mode, you will only be able to use the text-based library (switch to ServiceWorker mode for the full graphical version).">
+                                <label tabindex="7" class="btn btn-light custom-file-upload" id="btnLibrary" data-i18n="configure-btn-library" data-i18n-tip="configure-btn-library-tip" title="This will display a graphical library of ZIM archives for download if your browser can open it. Otherwise, it opens a text-only download library. If you are using the Chromium extension in ServiceWorkerLocal mode, you will only be able to use the text-based library (switch to ServiceWorker mode for the full graphical version).">
                                     Browse ZIM Library
                                 </label>
                             </span>

--- a/www/index.html
+++ b/www/index.html
@@ -489,7 +489,7 @@
                                     <input type="file" id="archiveFolders" style="display: none;" webkitdirectory="true"/>
                                     <span data-i18n="configure-btn-folderselect">Select Folder</span>
                                 </label>
-                                <label tabindex="7" class="btn btn-light custom-file-upload" id="btnLibrary" data-i18n="configure-btn-library" data-i18n-tip="configure-btn-library-tip" title="This will display a graphical library of ZIM archives for download if your browser can open it. Otherwise, it opens a text-only download library. If you are using the Chromium extension in ServiceWorkerLocal mode, you will only be able to use the text-based library (switch to ServiceWorker mode for the full graphical version).">
+                                <label tabindex="7" class="btn btn-light custom-file-upload" id="btnLibrary" data-i18n="configure-btn-library" data-i18n-tip="configure-btn-library-tip" title="This will display a graphical library of ZIM archives for download if your browser can open it. Otherwise, it opens a text-only version. If you are using the Chromium extension in ServiceWorkerLocal mode, you will only be able to use the latter (switch to ServiceWorker mode for the full graphical version).">
                                     Browse ZIM Library
                                 </label>
                             </span>

--- a/www/index.html
+++ b/www/index.html
@@ -489,7 +489,7 @@
                                     <input type="file" id="archiveFolders" style="display: none;" webkitdirectory="true"/>
                                     <span data-i18n="configure-btn-folderselect">Select Folder</span>
                                 </label>
-                                <label tabindex="7" class="btn btn-light custom-file-upload" id="btnLibrary" data-i18n="configure-btn-library">
+                                <label tabindex="7" class="btn btn-light custom-file-upload" id="btnLibrary" data-i18n="configure-btn-library" data-i18n-tip="configure-btn-library-tip" title="This will open a graphical library of ZIM archives for download if your browser can open it. Otherwise, it opens a text-only download library. If you are using the Chromium extension in ServiceWorkerLocal mode, you will only be able to use the text-based library (switch to ServiceWorker mode for the full graphical version).">
                                     Browse ZIM Library
                                 </label>
                             </span>


### PR DESCRIPTION
This adds a tooltip for the library button explaining, amongst other things, that in a Chromium extension in ServiceWorkerLocal mode, only the basic library will load.