### PR TITLE
Make a generic browserAction for backgroundscript

### DIFF
--- a/backgroundscript.js
+++ b/backgroundscript.js
@@ -34,7 +34,7 @@ if (typeof browser !== 'undefined') {
 }
 // DEV: For a Mozilla MV3 extension, we have to use 'action' instead of 'browserAction'
 var genericAction = genericBrowser.browserAction || genericBrowser.action;
-genericBrowser[genericAction].onClicked.addListener(function () {
+genericAction.onClicked.addListener(function () {
     var newURL = chrome.runtime.getURL('www/index.html');
     chrome.tabs.create({ url: newURL });
 });

--- a/backgroundscript.js
+++ b/backgroundscript.js
@@ -35,6 +35,6 @@ if (typeof browser !== 'undefined') {
 // DEV: For a Mozilla MV3 extension, we have to use 'action' instead of 'browserAction'
 var genericAction = genericBrowser.browserAction || genericBrowser.action;
 genericAction.onClicked.addListener(function () {
-    var newURL = chrome.runtime.getURL('www/index.html');
-    chrome.tabs.create({ url: newURL });
+    var newURL = genericBrowser.runtime.getURL('www/index.html');
+    genericBrowser.tabs.create({ url: newURL });
 });

--- a/backgroundscript.js
+++ b/backgroundscript.js
@@ -32,8 +32,9 @@ if (typeof browser !== 'undefined') {
     // Chromium/Chrome
     genericBrowser = chrome;
 }
-// DEV: For a Mozilla MV3 extension, we have to change the event below to 'action'
-genericBrowser.browserAction.onClicked.addListener(function () {
+// DEV: For a Mozilla MV3 extension, we have to use 'action' instead of 'browserAction'
+var genericAction = genericBrowser.browserAction || genericBrowser.action;
+genericBrowser[genericAction].onClicked.addListener(function () {
     var newURL = chrome.runtime.getURL('www/index.html');
     chrome.tabs.create({ url: newURL });
 });


### PR DESCRIPTION
This attempts to make the browserAction generic, so that developers don't need to alter backgroundscript when testing manifest v2 and manifest v3 extensions.