### PR TITLE
Fix some anomalies in tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,10 +68,11 @@ jobs:
           GITHUB_ACTION: ${{ github.event_name }}
         run: npm run test-e2e-chrome
 
-      - name: End-to-end tests on Edge (Linux)
-        env:
-          GITHUB_ACTION: ${{ github.event_name }}
-        run: npm run test-e2e-edge
+      # Disabling Edge tests for now, as they are very flaky on Linux, but pass fine on Windows
+      # - name: End-to-end tests on Edge (Linux)
+      #   env:
+      #     GITHUB_ACTION: ${{ github.event_name }}
+      #   run: npm run test-e2e-edge
 
       - name: End-to-end tests on Firefox (Linux)
         env:

--- a/tests/e2e/runners/chrome/chrome60.bs.runner.js
+++ b/tests/e2e/runners/chrome/chrome60.bs.runner.js
@@ -12,7 +12,7 @@ const capabilities = {
         osVersion: 'Mojave',
         browserVersion: '60.0',
         projectName: 'BStack Project Name: Kiwix JS e2e tests',
-        buildName: 'BStack Build Name: Chrome 58 on Mojave',
+        buildName: 'BStack Build Name: Chrome 60 on Mojave',
         local: true,
         localIdentifier: process.env.BROWSERSTACK_LOCAL_IDENTIFIER,
         userName: process.env.BROWSERSTACK_USERNAME,

--- a/tests/e2e/runners/firefox/firefox70.bs.runner.js
+++ b/tests/e2e/runners/firefox/firefox70.bs.runner.js
@@ -33,5 +33,5 @@ async function loadFirefoxDriver () {
 const driver_gutenberg_fx = await loadFirefoxDriver();
 
 // Run test in SW mode only
-console.log('Running tests in Service Worker mode only for this browser version');
-await gutenbergRo.runTests(driver_gutenberg_fx);
+console.log('Running Gutenberg tests in ServiceWorker mode only for this browser version');
+await gutenbergRo.runTests(driver_gutenberg_fx, ['serviceworker']);

--- a/tests/e2e/runners/firefox/firefox70.bs.runner.js
+++ b/tests/e2e/runners/firefox/firefox70.bs.runner.js
@@ -9,7 +9,7 @@ const capabilities = {
         osVersion: '10',
         browserVersion: '70.0',
         projectName: 'BStack Project Name: Kiwix JS e2e tests',
-        buildName: 'BStack Build Name: Firefox 61',
+        buildName: 'BStack Build Name: Firefox 70',
         local: true,
         localIdentifier: process.env.BROWSERSTACK_LOCAL_IDENTIFIER,
         userName: process.env.BROWSERSTACK_USERNAME,

--- a/tests/e2e/spec/gutenberg_ro.e2e.spec.js
+++ b/tests/e2e/spec/gutenberg_ro.e2e.spec.js
@@ -178,7 +178,7 @@ function runTests (driver, modes) {
             // Loads the ZIM archive for the mode if the mode is not skipped
             it('Load Modern zim file', async function () {
                 if (!serviceWorkerAPI) {
-                    console.log('\x1b[33m%s\x1b[0m', '      Test skipped.');
+                    console.log('\x1b[33m%s\x1b[0m', '      Following test skipped:');
                     return;
                 }
                 // Wait until files have loaded
@@ -219,7 +219,7 @@ function runTests (driver, modes) {
 
             it('Sorting books by popularity', async function () {
                 if (isJqueryMode) {
-                    console.log('\x1b[33m%s\x1b[0m', '      Test skipped.');
+                    console.log('\x1b[33m%s\x1b[0m', '      Following test skipped:');
                     return;
                 }
                 await driver.switchTo().frame('articleContent');
@@ -233,7 +233,7 @@ function runTests (driver, modes) {
 
             it('Sorting books by name', async function () {
                 if (isJqueryMode) {
-                    console.log('\x1b[33m%s\x1b[0m', '      Test skipped.');
+                    console.log('\x1b[33m%s\x1b[0m', '      Following test skipped:');
                     return;
                 }
                 // We switch to default Content and back to Iframe because the If we are retrying the test
@@ -252,7 +252,7 @@ function runTests (driver, modes) {
 
             it('Change Language', async function () {
                 if (isJqueryMode) {
-                    console.log('\x1b[33m%s\x1b[0m', '      Test skipped.');
+                    console.log('\x1b[33m%s\x1b[0m', '      Following test skipped:');
                     return;
                 }
                 // click on the language dropdown and select option French
@@ -325,7 +325,7 @@ function runTests (driver, modes) {
 
             it('Author search Autocomplete', async function () {
                 if (isJqueryMode) {
-                    console.log('\x1b[33m%s\x1b[0m', '      Test skipped.');
+                    console.log('\x1b[33m%s\x1b[0m', '      Following test skipped:');
                     return;
                 }
                 const filter = await driver.wait(until.elementIsVisible(driver.findElement(By.id('author_filter'))), 1500);
@@ -336,7 +336,7 @@ function runTests (driver, modes) {
 
             it('Author search Results', async function () {
                 if (isJqueryMode) {
-                    console.log('\x1b[33m%s\x1b[0m', '      Test skipped.');
+                    console.log('\x1b[33m%s\x1b[0m', '      Following test skipped:');
                     return;
                 }
                 // search by author name and press enter to apply the filter

--- a/tests/e2e/spec/legacy-ray_charles.e2e.spec.js
+++ b/tests/e2e/spec/legacy-ray_charles.e2e.spec.js
@@ -192,7 +192,7 @@ function runTests (driver, modes) {
 
             it('Load legacy Ray Charles and check index contains specified article', async function () {
                 if (!serviceWorkerAPI) {
-                    console.log('\x1b[33m%s\x1b[0m', '      Test skipped.');
+                    console.log('\x1b[33m%s\x1b[0m', '      Following test skipped:');
                     return;
                 }
                 const archiveFiles = await driver.findElement(By.id('archiveFiles'));
@@ -221,7 +221,7 @@ function runTests (driver, modes) {
 
             it('Navigate to "This Little Girl of Mine"', async function () {
                 if (!serviceWorkerAPI) {
-                    console.log('\x1b[33m%s\x1b[0m', '      Test skipped.');
+                    console.log('\x1b[33m%s\x1b[0m', '      Following test skipped:');
                     return;
                 }
                 // console.log('FilesLength outer: ' + filesLength);
@@ -259,7 +259,7 @@ function runTests (driver, modes) {
 
             it('Search for Ray Charles in title index and go to article', async function () {
                 if (!serviceWorkerAPI) {
-                    console.log('\x1b[33m%s\x1b[0m', '      Test skipped.');
+                    console.log('\x1b[33m%s\x1b[0m', '      Following test skipped:');
                     return;
                 }
                 await driver.switchTo().defaultContent();


### PR DESCRIPTION
This disables Edge testing on Linux in GitHub, because we already test on Windows extensively in Edge, and there is a Chrome test in Linux which is the same thing.

It also fixes some of the descriptions of tests, and restricts the Firefox 70 test on BrowserStack to SW mode as stated in the test title.