### PR TITLE
Fix anomalous boot loop when app is in jQuery mode and no SW is registered

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -851,13 +851,15 @@ function initServiceWorkerMessaging () {
         window.location.reload();
     } else if (navigator && navigator.serviceWorker && !navigator.serviceWorker.controller) {
         uiUtil.systemAlert('<p>No Service Worker is registered, meaning this app will not currently work offline!</p><p>Would you like to switch to ServiceWorker mode?</p>',
-        'Offline use is disabled!', true).then(function (response) {
+            'Offline use is disabled!', true).then(function (response) {
             if (response) {
                 setContentInjectionMode('serviceworker');
-                setTimeout(function () {
-                    params.themeChanged = true;
-                    document.getElementById('btnHome').click();
-                }, 750);
+                if (selectedArchive) {
+                    setTimeout(function () {
+                        params.themeChanged = true;
+                        document.getElementById('btnHome').click();
+                    }, 750);
+                }
             }
         });
     }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -841,14 +841,25 @@ function initServiceWorkerMessaging () {
         });
     } else if (serviceWorkerRegistration) {
         // If this is the first time we are initiating the SW, allow Promises to complete by delaying potential reload till next tick
-        console.warn('The Service Worker needs more time to load, or else the app was force-refrshed...');
+        console.warn('The Service Worker needs more time to load, or else the app was force-refreshed...');
         serviceWorkerRegistration = null;
-        setTimeout(initServiceWorkerMessaging, 1200);
-    } else {
+        setTimeout(initServiceWorkerMessaging, 1600);
+    } else if (params.contentInjectionMode === 'serviceworker') {
         console.error('The Service Worker is not controlling the current page! We have to reload.');
         // Turn off failsafe, as this is a controlled reboot
         settingsStore.setItem('lastPageLoad', 'rebooting', Infinity);
         window.location.reload();
+    } else if (navigator && navigator.serviceWorker && !navigator.serviceWorker.controller) {
+        uiUtil.systemAlert('<p>No Service Worker is registered, meaning this app will not currently work offline!</p><p>Would you like to switch to ServiceWorker mode?</p>',
+        'Offline use is disabled!', true).then(function (response) {
+            if (response) {
+                setContentInjectionMode('serviceworker');
+                setTimeout(function () {
+                    params.themeChanged = true;
+                    document.getElementById('btnHome').click();
+                }, 750);
+            }
+        });
     }
 }
 


### PR DESCRIPTION
If the app is capable of ServiceWorker mode, but the user has switched to jQuery mode AND the Service Worker is unregistered (e.g. because the user has cleared data for the site), then the new code that initiates the Service Worker messaging causes a boot loop.

This PR fixes that by detecting the situation and showing a dialogue box warning the user that the app won't work offline in the current configuration, suggesting the user switch to ServiceWorker mode.