### PR TITLE
replaced localStorage with settingsStore method

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1388,7 +1388,7 @@ function displayFileSelect () {
 
     document.getElementById('archiveList').addEventListener('change', function (e) {
         // handle zim selection from dropdown if multiple files are loaded via webkitdirectory or filesystem api
-        localStorage.setItem('previousZimFileName', e.target.value);
+        settingsStore.setItem('previousZimFileName', e.target.value, Infinity);
         if (params.isFileSystemApiSupported) {
             return abstractFilesystemAccess.getSelectedZimFromCache(e.target.value).then(function (files) {
                 setLocalArchiveFromFileList(files);
@@ -1399,7 +1399,7 @@ function displayFileSelect () {
             });
         } else {
             if (webKitFileList === null) {
-                const element = localStorage.getItem('zimFilenames').split('|').length === 1 ? 'archiveFiles' : 'archiveFolders';
+                const element = settingsStore.getItem('zimFilenames').split('|').length === 1 ? 'archiveFiles' : 'archiveFolders';
                 if ('showPicker' in HTMLInputElement.prototype) {
                     document.getElementById(element).showPicker();
                     return;
@@ -1427,7 +1427,7 @@ function displayFileSelect () {
             const filenames = [];
 
             const previousZimFile = []
-            const lastFilename = localStorage.getItem('previousZimFileName') ?? '';
+            const lastFilename = settingsStore.getItem('previousZimFileName') ?? '';
             const filenameWithoutExtension = lastFilename.replace(/\.zim\w\w$/i, '');
             const regex = new RegExp(`\\${filenameWithoutExtension}.zim\\w\\w$`, 'i');
 
@@ -1436,7 +1436,7 @@ function displayFileSelect () {
                 if (regex.test(file.name) || file.name === lastFilename) previousZimFile.push(file);
             }
             webKitFileList = e.target.files;
-            localStorage.setItem('zimFilenames', filenames.join('|'));
+            settingsStogare.setItem('zimFilenames', filenames.join('|'), Infinity);
             // will load the old file if the selected folder contains the same file
             if (previousZimFile.length !== 0) setLocalArchiveFromFileList(previousZimFile);
             await abstractFilesystemAccess.updateZimDropdownOptions(filenames, previousZimFile.length !== 0 ? lastFilename : '');
@@ -1472,7 +1472,7 @@ function useLegacyFilePicker () {
     archiveFiles.addEventListener('change', async function (e) {
         if (params.isWebkitDirApiSupported || params.isFileSystemApiSupported) {
             const activeFilename = e.target.files[0].name;
-            localStorage.setItem('zimFilenames', [activeFilename].join('|'));
+            settingsStore.setItem('zimFilenames', [activeFilename].join('|'), Infinity);
             await abstractFilesystemAccess.updateZimDropdownOptions([activeFilename], activeFilename);
         }
         setLocalArchiveFromFileSelect();


### PR DESCRIPTION
resolves #1171
As the title says, replaced localStorage method with settingsStore method.
Heres a list of tests I performed:
- ran `npm run serve` and `npm run preview` and tested for chrome and firefox in both Jquery and serviceWorker modes.
- couldn't try the app in IE mode as I do not have a windows machine
- ran `npm test` all tests were successful
- tested the extension in developer mode on chrome
- tested the firefox extension

In all the tests, I was able to open the application and view .zim files. I also checked the localStorage and verified the presence of `kiwixjs-` prefix.