### PR TITLE
resolves #1174 

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1388,7 +1388,7 @@ function displayFileSelect () {
 
     document.getElementById('archiveList').addEventListener('change', function (e) {
         // handle zim selection from dropdown if multiple files are loaded via webkitdirectory or filesystem api
-        localStorage.setItem('previousZimFileName', e.target.value);
+        settingsStore.setItem('previousZimFileName', e.target.value, Infinity);
         if (params.isFileSystemApiSupported) {
             return abstractFilesystemAccess.getSelectedZimFromCache(e.target.value).then(function (files) {
                 setLocalArchiveFromFileList(files);
@@ -1399,7 +1399,7 @@ function displayFileSelect () {
             });
         } else {
             if (webKitFileList === null) {
-                const element = localStorage.getItem('zimFilenames').split('|').length === 1 ? 'archiveFiles' : 'archiveFolders';
+                const element = settingsStore.getItem('zimFilenames').split('|').length === 1 ? 'archiveFiles' : 'archiveFolders';
                 if ('showPicker' in HTMLInputElement.prototype) {
                     document.getElementById(element).showPicker();
                     return;
@@ -1427,7 +1427,7 @@ function displayFileSelect () {
             const filenames = [];
 
             const previousZimFile = []
-            const lastFilename = localStorage.getItem('previousZimFileName') ?? '';
+            const lastFilename = settingsStore.getItem('previousZimFileName') ?? '';
             const filenameWithoutExtension = lastFilename.replace(/\.zim\w\w$/i, '');
             const regex = new RegExp(`\\${filenameWithoutExtension}.zim\\w\\w$`, 'i');
 
@@ -1436,7 +1436,7 @@ function displayFileSelect () {
                 if (regex.test(file.name) || file.name === lastFilename) previousZimFile.push(file);
             }
             webKitFileList = e.target.files;
-            localStorage.setItem('zimFilenames', filenames.join('|'));
+            settingsStogare.setItem('zimFilenames', filenames.join('|'), Infinity);
             // will load the old file if the selected folder contains the same file
             if (previousZimFile.length !== 0) setLocalArchiveFromFileList(previousZimFile);
             await abstractFilesystemAccess.updateZimDropdownOptions(filenames, previousZimFile.length !== 0 ? lastFilename : '');
@@ -1472,7 +1472,7 @@ function useLegacyFilePicker () {
     archiveFiles.addEventListener('change', async function (e) {
         if (params.isWebkitDirApiSupported || params.isFileSystemApiSupported) {
             const activeFilename = e.target.files[0].name;
-            localStorage.setItem('zimFilenames', [activeFilename].join('|'));
+            settingsStore.setItem('zimFilenames', [activeFilename].join('|'), Infinity);
             await abstractFilesystemAccess.updateZimDropdownOptions([activeFilename], activeFilename);
         }
         setLocalArchiveFromFileSelect();

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -273,3 +273,24 @@ if (/PWA_launch=/.test(window.location.search)) {
         }
     });
 }
+// A few browsers donot support the use of String.prototype.replaceAll method. Hence we define it once we verify that it isn't supported. 
+// For documentation visit https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll
+if (!String.prototype.replaceAll) {
+    String.prototype.replaceAll = function (pattern, replacement) {
+        // verify parameter: It must either be a string or a RegExp with a global flag.
+        if (typeof pattern[Symbol.replace] === 'function') {
+            // the pattern is a RegExp check for the presence of g flag. 
+            if (pattern.global) {
+                return this.replace(pattern, replacement);
+            }
+            else {
+                throw new TypeError('Global flag for regular expressions')
+            }
+        }
+        // the pattern is not a RegExp, hence it must be a string.
+        if (typeof pattern !== 'string') {
+            throw new TypeError('pattern must either be a string or a RegExp with a global (g) flag.')
+        }    
+        return this.replace(new RegExp(pattern, 'g'), replacement);
+    }
+}


### PR DESCRIPTION
Added String.prototype.replaceAll method in case a browser doesn't support it by default. 
Here are the tests I performed:
- Ran `npm run serve`
- Ran `npm run preview`
- Tested with `npm test`
In all the above cases I was able to browse and open zim files in both serviceWorker and JQuery modes in Chrome, Firefox (only JQuery) and Brave. I could't test the magnet link generation for older browsers.
- Tested the extension for Firefox.
- Tested the extension for Chrome in both JQuery and ServiceWorker modes.
