### PR TITLE
Add content warning for zimit2 in service worker local mode

### DIFF
--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -451,7 +451,13 @@ function deriveZimUrlFromRelativeUrl (url, base) {
  * Displays a Bootstrap warning alert with information about how to access content in a ZIM with unsupported active UI
  */
 var activeContentWarningSetup = false;
-function displayActiveContentWarning () {
+function displayActiveContentWarning (mode) {
+    // Adapt the text for other modes (e.g., ServiceWorkerLocal)
+    if (mode) {
+        activeContent.innerHTML = activeContent.innerHTML.replace(/JQuery/i, mode);
+        // We have to set up event listeners again
+        activeContentWarningSetup = false;
+    }
     activeContent.style.display = '';
     if (!activeContentWarningSetup) {
         // We are setting up the active content warning for the first time


### PR DESCRIPTION
Although mostly static archives work well in Chromium extensions in ServiceWorkerLocal mode, highly dynamic ZIMs that contain inline JS (a poor coding practice, but highly prevalent) will have non-functional elements. This is because inline JS is banned in Chromium extensions, even in MV3.

But we have a workaround, which is to reload the app as a PWA from browser-extension.kiwix.org. We should therefore warn users opening zimit2 archives.

This PR modifies the JQuery "active content warning", so that it also shows on zimit2 landing pages when a user is in ServiceWorkerLocal mode.