### PR TITLE
Fix errors enumerating ZIM archives in directory

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1528,7 +1528,7 @@ function displayFileSelect () {
     }
     if (params.isWebkitDirApiSupported) {
         // Handles Folder selection when webkitdirectory is supported but showDirectoryPicker is not
-        folderSelect.addEventListener('change', async function (e) {
+        folderSelect.addEventListener('change', function (e) {
             e.preventDefault();
             const filenames = [];
 
@@ -1545,7 +1545,7 @@ function displayFileSelect () {
             settingsStore.setItem('zimFilenames', filenames.join('|'), Infinity);
             // will load the old file if the selected folder contains the same file
             if (previousZimFile.length !== 0) setLocalArchiveFromFileList(previousZimFile);
-            await abstractFilesystemAccess.updateZimDropdownOptions(filenames, previousZimFile.length !== 0 ? lastFilename : '');
+            abstractFilesystemAccess.updateZimDropdownOptions(filenames, previousZimFile.length !== 0 ? lastFilename : '');
         })
     }
 
@@ -1575,11 +1575,11 @@ function displayFileSelect () {
  */
 function useLegacyFilePicker () {
     // Fallbacks to simple file input with multi file selection
-    archiveFiles.addEventListener('change', async function (e) {
+    archiveFiles.addEventListener('change', function (e) {
         if (params.isWebkitDirApiSupported || params.isFileSystemApiSupported) {
             const activeFilename = e.target.files[0].name;
             settingsStore.setItem('zimFilenames', [activeFilename].join('|'), Infinity);
-            await abstractFilesystemAccess.updateZimDropdownOptions([activeFilename], activeFilename);
+            abstractFilesystemAccess.updateZimDropdownOptions([activeFilename], activeFilename);
         }
         setLocalArchiveFromFileSelect();
     });

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1530,22 +1530,17 @@ function displayFileSelect () {
         // Handles Folder selection when webkitdirectory is supported but showDirectoryPicker is not
         folderSelect.addEventListener('change', function (e) {
             e.preventDefault();
-            const filenames = [];
-
-            const previousZimFile = []
-            const lastFilename = settingsStore.getItem('previousZimFileName') ?? '';
-            const filenameWithoutExtension = lastFilename.replace(/\.zim\w\w$/i, '');
-            const regex = new RegExp(`\\${filenameWithoutExtension}.zim\\w\\w$`, 'i');
-
-            for (const file of e.target.files) {
-                filenames.push(file.name);
-                if (regex.test(file.name) || file.name === lastFilename) previousZimFile.push(file);
+            var fileList = e.target.files;
+            if (fileList) {
+                var foundFiles = abstractFilesystemAccess.selectDirectoryFromPickerViaWebkit(fileList);
+                var selectedZimfile = foundFiles.selectedFile;
+                // This ensures the selected files are stored for use during this session (webKitFileList is a global object)
+                webKitFileList = foundFiles.files;
+                // This will load the old file if the selected folder contains the same file
+                if (selectedZimfile.length !== 0) {
+                    setLocalArchiveFromFileList(selectedZimfile);
+                }
             }
-            webKitFileList = e.target.files;
-            settingsStore.setItem('zimFilenames', filenames.join('|'), Infinity);
-            // will load the old file if the selected folder contains the same file
-            if (previousZimFile.length !== 0) setLocalArchiveFromFileList(previousZimFile);
-            abstractFilesystemAccess.updateZimDropdownOptions(filenames, previousZimFile.length !== 0 ? lastFilename : '');
         })
     }
 

--- a/www/js/lib/abstractFilesystemAccess.js
+++ b/www/js/lib/abstractFilesystemAccess.js
@@ -115,7 +115,7 @@ async function updateZimDropdownOptions (files, selectedFile) {
     };
 
     files.forEach((fileName) => {
-        if (fileName.endsWith('.zim') || fileName.endsWith('.zimaa')) {
+        if (/\.zim(aa)?$/i.test(fileName)) {
             options.push(new Option(fileName, fileName));
             select.appendChild(new Option(fileName, fileName));
             count++;


### PR DESCRIPTION
There are a few issues with the code that enumerates archives in a directory:

* The first is that the code stores ALL files in the directory in the zimFilenames key. This PR adds a filter so only files matching the pattern `.zim\w?\w?$` (case insensitive) will be stored;
* The second is that the code was unnecessarily calling await functions several times to get values that could simply be stored in a variable;
* The third is that to test for a previously selected archive, a regex was being made from filenames without filtering for regex meta-charecters, which could easily lead to errors. In fact that's not necessary, as we can simply use `indexOf` without needing to do a regex test on the whole filename;
* The fourth is a longstanding bug where permissions appeared not be being retrieved correctly on the first go. The cleanup in this PR **may** have fixed that, but it needs monitoring and testing;
* Fifth is that when loading a new `webkitdirectory`, the old contents are not cleared

Fixes #1220.
