### PR TITLE
Non-file Dragging Bug Fix

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -94,10 +94,6 @@
     padding-top: 1rem;
 }
 
-/* #search-article * {
-    pointer-events: none;
-} */
-
 #configuration {
     margin: 0 1rem;
 }

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -65,7 +65,7 @@
 }
 
 .dragging-over * {
-    pointer-events: none !important;
+    pointer-events: none;
 }
 
 .form-control {

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -64,6 +64,10 @@
     padding-left: 1px !important;
 }
 
+.dragging-over * {
+    pointer-events: none !important;
+}
+
 .form-control {
     margin-top: 2px;
 }

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -94,6 +94,10 @@
     padding-top: 1rem;
 }
 
+/* #search-article * {
+    pointer-events: none;
+} */
+
 #configuration {
     margin: 0 1rem;
 }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1640,7 +1640,6 @@ function handleGlobalDragenter (e) {
 }
 
 function handleGlobalDragover (e) {
-    console.log('glb over')
     e.preventDefault();
 
     if (e.dataTransfer.types.includes('Files') && !hasInvalidType(e.dataTransfer.types)) {
@@ -1654,7 +1653,6 @@ function handleGlobalDragover (e) {
 function handleGlobalDragleave (e) {
     e.preventDefault();
     globalDropZone.style.border = '';
-    console.log(e.target)
     if (e.dataTransfer.types.includes('Files') && !hasInvalidType(e.dataTransfer.types)) {
         /** can we somehow check if a page has been loaded? no need to go home if no page loaded yet. just keep on config */
         if (lastenter === e.target) {
@@ -1666,7 +1664,6 @@ function handleGlobalDragleave (e) {
 
 function handleIframeDragover (e) {
     e.preventDefault();
-    // add type check for chromium browsers
     if (e.dataTransfer.types.includes('Files') && !hasInvalidType(e.dataTransfer.types)) {
         globalDropZone.classList.add('dragging-over')
         e.dataTransfer.dropEffect = 'link';
@@ -1674,6 +1671,7 @@ function handleIframeDragover (e) {
     }
 }
 
+// add type check for chromium browsers, since they count images on the same page as files
 function hasInvalidType (typesList) {
     for (var i = 0; i < typesList.length; i++) {
         if (typesList[i].startsWith('image') || typesList[i].startsWith('text') || typesList[i].startsWith('video')) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1524,6 +1524,7 @@ function displayFileSelect () {
         globalDropZone.addEventListener('dragover', handleGlobalDragover);
         globalDropZone.addEventListener('dragleave', handleGlobalDragleave);
         globalDropZone.addEventListener('drop', handleFileDrop);
+        globalDropZone.addEventListener('dragenter', handleGlobalDragenter);
     }
 
     if (isFireFoxOsNativeFileApiAvailable) {
@@ -1633,14 +1634,17 @@ let noPointerEventsStyle = '#search-article * { pointer-events: none; };'
 let noPointerEventsStyleSheet = document.createElement('style');
 noPointerEventsStyleSheet.innerText = noPointerEventsStyle;
 
+function handleGlobalDragenter (e) {
+    e.preventDefault();
+    document.head.append(noPointerEventsStyleSheet);
+}
+
 function handleGlobalDragover (e) {
     e.preventDefault();
-   
-    document.head.append(noPointerEventsStyleSheet);
 
     if (e.dataTransfer.types.includes('Files')) {
         e.dataTransfer.dropEffect = 'link';
-        globalDropZone.style.border = '3px dotted red';
+        globalDropZone.style.border = '3px dashed red';
         document.getElementById('btnConfigure').click();
     }
 }
@@ -1659,6 +1663,7 @@ function handleIframeDragover (e) {
     // add type check for chromium browsers
     if (e.dataTransfer.types.includes('Files') && !hasInvalidType(e.dataTransfer.types)) {
         e.dataTransfer.dropEffect = 'link';
+        document.head.append(noPointerEventsStyleSheet);
         document.getElementById('btnConfigure').click();
     }
 }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1655,9 +1655,8 @@ function handleGlobalDragover (e) {
 function handleGlobalDragleave (e) {
     e.preventDefault();
     globalDropZone.style.border = '';
-    if (hasType(e.dataTransfer.types, 'Files') && !hasInvalidType(e.dataTransfer.types) && enteredElement === e.target) {
+    if (enteredElement === e.target) {
         globalDropZone.classList.remove('dragging-over');
-            
         // Only return to page if a ZIM is actually loaded
         if (selectedArchive.isReady()) {
             returnToCurrentPage();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1521,6 +1521,7 @@ function displayFileSelect () {
 
     // Set the main drop zone
     if (!params.disableDragAndDrop) {
+        // do globally, since the whole page functions as a drop zone, so indicate properly
         globalDropZone.addEventListener('dragover', handleGlobalDragover);
         globalDropZone.addEventListener('dragleave', handleGlobalDragleave);
         globalDropZone.addEventListener('drop', handleFileDrop);
@@ -1628,15 +1629,17 @@ document.getElementById('archiveFilesLbl').addEventListener('keydown', function 
     }
 });
 
+/** Drag and Drop handling for ZIM files */
+
 // keep track of entrance event so we only fire the correct leave event 
-var lastenter;
+var enteredelement;
 
 function handleGlobalDragenter (e) {
     e.preventDefault();
     // disable pointer-events on children
     // so they don't interfere with dragleave events
-    globalDropZone.classList.add('dragging-over')
-    lastenter = e.target;
+    globalDropZone.classList.add('dragging-over');
+    enteredelement = e.target;
 }
 
 function handleGlobalDragover (e) {
@@ -1644,7 +1647,7 @@ function handleGlobalDragover (e) {
 
     if (e.dataTransfer.types.includes('Files') && !hasInvalidType(e.dataTransfer.types)) {
         e.dataTransfer.dropEffect = 'link';
-        globalDropZone.classList.add('dragging-over')
+        globalDropZone.classList.add('dragging-over');
         globalDropZone.style.border = '3px dashed red';
         document.getElementById('btnConfigure').click();
     }
@@ -1655,8 +1658,8 @@ function handleGlobalDragleave (e) {
     globalDropZone.style.border = '';
     if (e.dataTransfer.types.includes('Files') && !hasInvalidType(e.dataTransfer.types)) {
         /** can we somehow check if a page has been loaded? no need to go home if no page loaded yet. just keep on config */
-        if (lastenter === e.target) {
-            globalDropZone.classList.remove('dragging-over')
+        if (enteredelement === e.target) {
+            globalDropZone.classList.remove('dragging-over');
             document.getElementById('btnHome').click();
         }
     }
@@ -1665,10 +1668,15 @@ function handleGlobalDragleave (e) {
 function handleIframeDragover (e) {
     e.preventDefault();
     if (e.dataTransfer.types.includes('Files') && !hasInvalidType(e.dataTransfer.types)) {
-        globalDropZone.classList.add('dragging-over')
+        globalDropZone.classList.add('dragging-over');
         e.dataTransfer.dropEffect = 'link';
         document.getElementById('btnConfigure').click();
     }
+}
+
+function handleIframeDrop (e) {
+    e.preventDefault();
+    e.stopPropagation();
 }
 
 // add type check for chromium browsers, since they count images on the same page as files
@@ -1685,7 +1693,7 @@ async function handleFileDrop (packet) {
     packet.stopPropagation();
     packet.preventDefault();
     globalDropZone.style.border = '';
-    globalDropZone.classList.remove('dragging-over')
+    globalDropZone.classList.remove('dragging-over');
     var files = packet.dataTransfer.files;
     document.getElementById('selectInstructions').style.display = 'none';
     document.getElementById('fileSelectionButtonContainer').style.display = 'none';

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1521,7 +1521,7 @@ function displayFileSelect () {
 
     // Set the main drop zone
     if (!params.disableDragAndDrop) {
-        // Set a global drop zone, so that whole page is enabled for drag and drop.
+        // Set a global drop zone, so that whole page is enabled for drag and drop
         globalDropZone.addEventListener('dragover', handleGlobalDragover);
         globalDropZone.addEventListener('dragleave', handleGlobalDragleave);
         globalDropZone.addEventListener('drop', handleFileDrop);
@@ -1644,7 +1644,7 @@ function handleGlobalDragenter (e) {
 function handleGlobalDragover (e) {
     e.preventDefault();
 
-    if (e.dataTransfer.types.includes('Files') && !hasInvalidType(e.dataTransfer.types)) {
+    if (hasType(e.dataTransfer.types, 'Files') && !hasInvalidType(e.dataTransfer.types)) {
         e.dataTransfer.dropEffect = 'link';
         globalDropZone.classList.add('dragging-over');
         globalDropZone.style.border = '3px dashed red';
@@ -1655,21 +1655,19 @@ function handleGlobalDragover (e) {
 function handleGlobalDragleave (e) {
     e.preventDefault();
     globalDropZone.style.border = '';
-    if (e.dataTransfer.types.includes('Files') && !hasInvalidType(e.dataTransfer.types)) {
-        /** can we somehow check if a page has been loaded? no need to go home if no page loaded yet. just keep on config */
-        if (enteredElement === e.target) {
-            globalDropZone.classList.remove('dragging-over');
+    if (hasType(e.dataTransfer.types, 'Files') && !hasInvalidType(e.dataTransfer.types) && enteredElement === e.target) {
+        globalDropZone.classList.remove('dragging-over');
             
-            if (selectedArchive.isReady()) {
-                returnToCurrentPage();
-            }
+        // Only return to page if a ZIM is actually loaded
+        if (selectedArchive.isReady()) {
+            returnToCurrentPage();
         }
     }
 }
 
 function handleIframeDragover (e) {
     e.preventDefault();
-    if (e.dataTransfer.types.includes('Files') && !hasInvalidType(e.dataTransfer.types)) {
+    if (hasType(e.dataTransfer.types, 'Files') && !hasInvalidType(e.dataTransfer.types)) {
         globalDropZone.classList.add('dragging-over');
         e.dataTransfer.dropEffect = 'link';
         document.getElementById('btnConfigure').click();
@@ -1684,7 +1682,19 @@ function handleIframeDrop (e) {
 // Add type check for chromium browsers, since they count images on the same page as files
 function hasInvalidType (typesList) {
     for (var i = 0; i < typesList.length; i++) {
-        if (typesList[i].startsWith('image') || typesList[i].startsWith('text') || typesList[i].startsWith('video')) {
+        // Use indexOf() instead of startsWith() for IE11 support. Also, IE11 uses Text instead of text (and so does Opera).
+        // This is not comprehensive, but should cover most cases.
+        if (typesList[i].indexOf('image') === 0 || typesList[i].indexOf('text') === 0 || typesList[i].indexOf('Text') === 0|| typesList[i].indexOf('video') === 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// IE11 doesn't support .includes(), so custom function to check for presence of types
+function hasType (typesList, type) {
+    for (var i = 0; i < typesList.length; i++) {
+        if (typesList[i] === type) {
             return true;
         }
     }


### PR DESCRIPTION
For issue #1037 

Tests done:
`npm run serve`
`npm run preview`
`npm run build`, followed by` npm run serve` and using the localhost:xxxx/dist/? page. (should be same as running the extension)

Tested on both firefox and chromium.
Tested with both mdn web docs (which uses workers) and a smaller page that doesn't use workers. Tested in both jQuery and workers mode. Passed `npm test`. 

Ran `e2e-test` for firefox, just one error as seen below:
```
1) Gutenberg_ro test [ZSTD compression] [SW mode]
       Sorting books by name:

      AssertionError [ERR_ASSERTION]: 'Poezii' == 'Creierul, O Enigma Descifrata'
      + expected - actual

      -Poezii
      +Creierul, O Enigma Descifrata
```
On e2e-test for chromium, also just one error, as seen below:
```
1) Gutenberg_ro test [ZSTD compression] [SW mode]
       Change Language:
     JavascriptError: javascript error: {"status":11,"value":"Element is not currently visible and may not be manipulated"}
  (Session info: chrome=124.0.6367.91)
```

I suspect these are unrelated to my changes, but please let me know if I broke something.

Other than that, I do have one question; is there a way to know if the ZIM page has already been loaded? With my current solution, it takes them unnecessarily to home if they dragleave the page, even if no ZIM file has been loaded. Also, if there's a way to keep track of their last visited page, that could greatly improve the experience when having dragged a file over but not having dropped it on the page (right now, it will take you back to the home page of the ZIM). @Jaifroid 