### PR TITLE
Do not jump to first file when using FSA API

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1617,7 +1617,7 @@ function displayFileSelect () {
         folderSelect.addEventListener('click', async function (e) {
             e.preventDefault();
             const previousZimFiles = await abstractFilesystemAccess.selectDirectoryFromPickerViaFileSystemApi()
-            if (previousZimFiles.length !== 0) setLocalArchiveFromFileList(previousZimFiles);
+            if (previousZimFiles.length === 1) setLocalArchiveFromFileList(previousZimFiles);
         });
     }
     if (params.isWebkitDirApiSupported) {


### PR DESCRIPTION
Fixes #1254.

This should be the last of the issue-fixing PRs prior to preparing release of v4.1.

It ensures that a ZIM file is not actually opened if the user selected a directory of archives using the File System Access `window.showDirectoryPicker()` method, and if that folder contains more than one archive. Without this fix, the first archive in the directory is inadvertently opened, which is unexpected and potentially insecure behaviour.

I need to test whether the same applies to the `webkitdirectory` method used by Firefox and Edge Legacy.