### PR TITLE
Add i189 for Chromium store entries

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,11 @@
+{
+  "extensionName": {
+    "message": "Kiwix JS Browser Extension",
+    "description": "Name of the extension."
+  },
+
+  "extensionDescription": {
+    "message": "Kiwix is an offline reader for content from Wikipedia, TED Talks, Stackexchange, and many other sources.",
+    "description": "Description of the extension."
+  }
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,11 @@
+{
+  "extensionName": {
+    "message": "Extensión de navegador Kiwix JS",
+    "description": "Nombre de la extensión."
+  },
+
+  "extensionDescription": {
+    "message": "Kiwix es un lector sin conexión para contenido de Wikipedia, TED Talks, Stackexchange y muchas otras fuentes.",
+    "description": "Descripción de la extensión."
+  }
+}

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,0 +1,11 @@
+{
+  "extensionName": {
+    "message": "Extension de navigateur Kiwix JS",
+    "description": "Nom de l'extension."
+  },
+
+  "extensionDescription": {
+    "message": "Kiwix est un lecteur hors ligne pour le contenu de Wikipédia, TED Talks, Stackexchange et de nombreuses autres sources.",
+    "description": "Déscription de l'extension."
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -42,6 +42,7 @@
         "matches": ["https://*.kiwix.org/*", "https://kiwix.github.io/*"]
     }],
 
+    "default_locale": "en",
     "author": "Kiwix",
     "homepage_url": "https://www.kiwix.org",
     "offline_enabled": true

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
     "manifest_version": 3,
-    "name": "Kiwix JS Browser Extension",
+    "name": "__MSG_extensionName__",
     "short_name": "Kiwix JS",
     "version": "4.0.1",
 
-    "description": "Kiwix is an offline reader for content from Wikipedia, TED Talks, Stackexchange, and many other sources.",
+    "description": "__MSG_extensionDescription__",
     
     "icons": {
         "16": "www/img/icons/kiwix-16.png",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -47,7 +47,7 @@ const config = {
                 dest: 'dist/www/js'
             },
             { src: ['node_modules/bootstrap/dist/css/bootstrap.min.*'], dest: 'dist/www/css' },
-            { src: ['i18n/*'], dest: 'dist/i18n' },
+            { src: ['i18n', '_locales'], dest: 'dist' },
             { src: ['archives', 'backgroundscript.js', 'index.html', 'manifest.json', 'manifest.fx.v3.json', 'manifest.v2.json', 'manifest.webapp', 'manifest.webmanifest', 'package.json', 'LICENSE-GPLv3.txt', 'CHANGELOG.md', 'README.md', '*.pfx', '*.cjs'], dest: 'dist' }
             ],
             flatten: true

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -59,7 +59,7 @@ fi
 # Copy only the necessary files in a temporary directory
 mkdir -p tmp
 rm -rf tmp/*
-cp -r www i18n manifest.json manifest.webapp LICENSE-GPLv3.txt service-worker.js README.md tmp/
+cp -r www i18n _locales manifest.json manifest.webapp LICENSE-GPLv3.txt service-worker.js README.md tmp/
 # Remove unwanted files (this line should not be necessary if building from dist/)
 rm -f tmp/www/js/lib/libzim-*dev.*
 

--- a/scripts/package_chrome_extension.sh
+++ b/scripts/package_chrome_extension.sh
@@ -21,12 +21,12 @@ if [ $MV -eq 2 ]; then
     echo "Packing MV2 extension"
     pwd & ls -l
     cat manifest.json
-    zip -r ../build/kiwix-chrome-unsigned-extension-$VERSION.zip www i18n backgroundscript.js manifest.json LICENSE-GPLv3.txt service-worker.js README.md
+    zip -r ../build/kiwix-chrome-unsigned-extension-$VERSION.zip www _locales i18n backgroundscript.js manifest.json LICENSE-GPLv3.txt service-worker.js README.md
 else
     echo "Packing MV3 extension"
     pwd & ls -l
     cat manifest.json
-    zip -r ../build/kiwix-chrome-unsigned-extension-$VERSION.zip www i18n manifest.json LICENSE-GPLv3.txt service-worker.js README.md
+    zip -r ../build/kiwix-chrome-unsigned-extension-$VERSION.zip www _locales i18n manifest.json LICENSE-GPLv3.txt service-worker.js README.md
 fi
 cd ..
 ls -l build/kiwix-chrome-unsigned-extension-$VERSION.zip

--- a/scripts/package_firefox_extension.sh
+++ b/scripts/package_firefox_extension.sh
@@ -27,7 +27,7 @@ fi
 cd tmp
 if [ "${TAG}zz" == "zz" ]; then
     echo "Packaging unsigned Firefox extension, version $VERSION"
-    zip -r ../build/kiwix-firefox-unsigned-extension-$VERSION.zip www i18n backgroundscript.js manifest.json LICENSE-GPLv3.txt service-worker.js README.md
+    zip -r ../build/kiwix-firefox-unsigned-extension-$VERSION.zip www _locales i18n backgroundscript.js manifest.json LICENSE-GPLv3.txt service-worker.js README.md
 
     if [ "${DRYRUN}zz" == "zz" ]; then
         # Sign the extension with the Mozilla API through web-ext, if we're not packaging a public version
@@ -73,6 +73,6 @@ else
     sed -i -e "s/kiwix-html5-unlisted@kiwix.org/kiwix-html5-listed@kiwix.org/" manifest.json
 
     echo "Packaging unsigned 'listed' Firefox extension, version $VERSION"
-    zip -r ../build/kiwix-firefox-unsigned-listed-extension-$VERSION.zip www i18n backgroundscript.js manifest.json LICENSE-GPLv3.txt service-worker.js README.md
+    zip -r ../build/kiwix-firefox-unsigned-listed-extension-$VERSION.zip www _locales i18n backgroundscript.js manifest.json LICENSE-GPLv3.txt service-worker.js README.md
     echo "*** This unsigned extension must be manually uploaded to Mozilla to be signed and distributed from their store ***"
 fi


### PR DESCRIPTION
Fixes #1118. According to the messages I receive when uploading an extension to the Edge or Chrome Stores, in order to internationalize the Store entry it is necessary to internationalize the manifests, adding those languages supported by the app. I've followed https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization, but I don't know for sure that this will do the trick until I attempt to upload the generated extension ZIPs.

We don't use the Chrome i18n module for i18n within the app, as we use a much simpler string-substitution system, and I'm not going to change that any time soon, especially as i18n for this app needs to work in multiple contexts, not just extensions.