### PR TITLE
Fixed Brief Description Popover extraction Issue

### DIFF
--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -102,7 +102,7 @@ function cleanUpLedeContent (node) {
     // Define an array of exclusion filters
     // (note `.exclude-this-class` is a dummy class used as an example for any future exclusion filters)
     const exclusionFilters = ['#pcs-edit-section-title-description', '.exclude-this-class'];
-    // Constrct the :not() selector thing
+    // Construct the `:not()` CSS exclusion selector list
     const notSelector = exclusionFilters.map(filter => `:not(${filter})`).join('');
 
     // Remove all standalone style elements from the given DOM node, because their content is shown by innerText and textContent

--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -261,7 +261,7 @@ function populateKiwixPopoverDiv (ev, link, state, dark, archive) {
     const linkHref = link.getAttribute('href');
     // Do not show popover if there is no href or with certain landing pages
     if (!linkHref || /^wikivoyage/i.test(archive.file.name) &&
-       (state.expectedArticleURLToBeDisplayed === archive.landingPageUrl ||
+      (state.expectedArticleURLToBeDisplayed === archive.landingPageUrl ||
       state.expectedArticleURLToBeDisplayed === 'A/Wikivoyage:Offline_reader_Expedition/Home_page')) {
         return Promise.resolve();
     }

--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -109,7 +109,8 @@ function cleanUpLedeContent (node) {
         // DEV: Note that innerText is not supported in Firefox OS, so we need to use textContent as a fallback
         // The reason we prefer innerText is that it strips out hidden text and unnecessary whitespace, which is not the case with textContent
         const innerText = para.innerText ? para.innerText : para.textContent;
-        return innerText.length >= 50;
+        const text = innerText.trim();
+        return !/^\s*$/.test(text) && text.length >= 50;
     });
     return parasWithContent;
 }

--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -36,7 +36,7 @@ import uiUtil from './uiUtil.js';
  * @param {ZIMArchive} archive The archive from which to extract the lede
  * @returns {Promise<String>} A Promise for the linked article's lede HTML including first main image URL if any
  */
-function getArticleLede (href, baseUrl, articleDocument, archive) {
+function getArticleLede(href, baseUrl, articleDocument, archive) {
     const uriComponent = uiUtil.removeUrlParameters(href);
     const zimURL = uiUtil.deriveZimUrlFromRelativeUrl(uriComponent, baseUrl);
     console.debug('Previewing ' + zimURL);
@@ -98,7 +98,7 @@ function getArticleLede (href, baseUrl, articleDocument, archive) {
 };
 
 // Helper function to clean up the lede content
-function cleanUpLedeContent (node) {
+function cleanUpLedeContent(node) {
     // Remove all standalone style elements from the given DOM node, because their content is shown by innerText and textContent
     const styleElements = Array.from(node.querySelectorAll('style'));
     styleElements.forEach(style => {
@@ -111,13 +111,18 @@ function cleanUpLedeContent (node) {
         // The reason we prefer innerText is that it strips out hidden text and unnecessary whitespace, which is not the case with textContent
         const innerText = para.innerText ? para.innerText : para.textContent;
         const text = innerText.trim();
-        return !/^\s*$/.test(text) && text.length >= 50;
+
+        // removing the para with less than 50 characters
+        // regex to check the paragraph if its too short or a brief description
+        const briefDescriptionRegex = /^.{1,100}$/;
+
+        return !briefDescriptionRegex.test(text) && text.length >= 50;
     });
     return parasWithContent;
 }
 
 // Helper function to concatenate paragraphs to fill the balloon
-function fillBalloonString (paras, baseURL, pathPrefix) {
+function fillBalloonString(paras, baseURL, pathPrefix) {
     let cumulativeCharCount = 0;
     let concatenatedText = '';
     // Add enough paras to complete the word count
@@ -149,7 +154,7 @@ function fillBalloonString (paras, baseURL, pathPrefix) {
 }
 
 // Helper function to get the first main image from the given node
-function getImageHTMLFromNode (node, baseURL, pathPrefix) {
+function getImageHTMLFromNode(node, baseURL, pathPrefix) {
     const images = node.querySelectorAll('img');
     let firstImage = null;
     if (images) {
@@ -176,7 +181,7 @@ function getImageHTMLFromNode (node, baseURL, pathPrefix) {
  * @param {Document} doc The document to which to attach the popover stylesheet
  * @param {Boolean} dark An optional parameter to adjust the background colour for dark themes (generally not needed for inversion-based themes)
  */
-function attachKiwixPopoverCss (doc, dark) {
+function attachKiwixPopoverCss(doc, dark) {
     const colour = dark && !/invert/i.test(params.cssTheme) ? 'darkgray' : 'black';
     const backgroundColour = dark && !/invert/i.test(params.cssTheme) ? '#111' : '#ebf4fb';
     const borderColour = dark ? 'darkslategray' : 'skyblue';
@@ -237,8 +242,8 @@ function attachKiwixPopoverCss (doc, dark) {
             -webkit-touch-callout: none !important;
         }
         `,
-    // The id of the style element for easy manipulation
-    'kiwixtooltipstylesheet');
+        // The id of the style element for easy manipulation
+        'kiwixtooltipstylesheet');
 }
 
 /**
@@ -250,14 +255,14 @@ function attachKiwixPopoverCss (doc, dark) {
  * @param {ZIMArchive} archive The archive from which the popover information is extracted
  * @returns {Promise<div>} A Promise for the attached popover div or undefined if the popover is not attached
  */
-function populateKiwixPopoverDiv (ev, link, state, dark, archive) {
+function populateKiwixPopoverDiv(ev, link, state, dark, archive) {
     // Do not show popover if the user has initiated an article load (set in filterClickEvent)
     if (link.articleisloading || link.popoverisloading) return Promise.resolve();
     const linkHref = link.getAttribute('href');
     // Do not show popover if there is no href or with certain landing pages
     if (!linkHref || /^wikivoyage/i.test(archive.file.name) &&
-      (state.expectedArticleURLToBeDisplayed === archive.landingPageUrl ||
-      state.expectedArticleURLToBeDisplayed === 'A/Wikivoyage:Offline_reader_Expedition/Home_page')) {
+        (state.expectedArticleURLToBeDisplayed === archive.landingPageUrl ||
+            state.expectedArticleURLToBeDisplayed === 'A/Wikivoyage:Offline_reader_Expedition/Home_page')) {
         return Promise.resolve();
     }
     link.popoverisloading = true;
@@ -326,7 +331,7 @@ function populateKiwixPopoverDiv (ev, link, state, dark, archive) {
  * @param {Event} event The event which has fired this popover action
  * @returns {Object} An object containing the popover div and the arrow span elements
  */
-function createNewKiwixPopoverCointainer (win, anchor, event) {
+function createNewKiwixPopoverCointainer(win, anchor, event) {
     const div = document.createElement('div');
     const linkHref = anchor.getAttribute('href');
     const currentDocument = win.document;
@@ -418,7 +423,7 @@ function createNewKiwixPopoverCointainer (win, anchor, event) {
  * @param {Element} popover The containing element of the popover (div)
  * @param {Document} doc The doucment on which to operate
  */
-function addEventListenersToPopoverIcons (anchor, popover, doc) {
+function addEventListenersToPopoverIcons(anchor, popover, doc) {
     const breakout = function (e) {
         // Adding the newcontainer property to the anchor will be cauught by the filterClickEvent function and will open in new tab
         anchor.newcontainer = true;
@@ -438,7 +443,7 @@ function addEventListenersToPopoverIcons (anchor, popover, doc) {
  * Remove any preview popover DIVs found in the given document
  * @param {Document} doc The document from which to remove any popovers
  */
-function removeKiwixPopoverDivs (doc) {
+function removeKiwixPopoverDivs(doc) {
     const divs = doc.getElementsByClassName('kiwixtooltip');
     // Timeout is set to allow for a delay before removing popovers - so user can hover the popover itself to prevent it from closing,
     // or so that links and buttons in the popover can be clicked
@@ -466,7 +471,7 @@ function removeKiwixPopoverDivs (doc) {
  * Closes the specified popover div, with fadeout effect, and removes it from the DOM
  * @param {Element} div The div to close
  */
-function closePopover (div) {
+function closePopover(div) {
     div.style.opacity = '0';
     // Timeout allows the animation to complete before removing the div
     setTimeout(function () {

--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -261,8 +261,8 @@ function populateKiwixPopoverDiv (ev, link, state, dark, archive) {
     const linkHref = link.getAttribute('href');
     // Do not show popover if there is no href or with certain landing pages
     if (!linkHref || /^wikivoyage/i.test(archive.file.name) &&
-        (state.expectedArticleURLToBeDisplayed === archive.landingPageUrl ||
-        state.expectedArticleURLToBeDisplayed === 'A/Wikivoyage:Offline_reader_Expedition/Home_page')) {
+       (state.expectedArticleURLToBeDisplayed === archive.landingPageUrl ||
+      state.expectedArticleURLToBeDisplayed === 'A/Wikivoyage:Offline_reader_Expedition/Home_page')) {
         return Promise.resolve();
     }
     link.popoverisloading = true;

--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -99,12 +99,21 @@ function getArticleLede (href, baseUrl, articleDocument, archive) {
 
 // Helper function to clean up the lede content
 function cleanUpLedeContent (node) {
+    // Define an array of exclusion filters
+    // (note .exclude-this-class is a dummy class used as an exmple which will used to exclude classes in future)
+    const exclusionFilters = ['#pcs-edit-section-title-description', '.exclude-this-class'];
+    // Constrct the :not() selector thing
+    const notSelector = exclusionFilters.map(filter => `:not(${filter})`).join('');
+
     // Remove all standalone style elements from the given DOM node, because their content is shown by innerText and textContent
     const styleElements = Array.from(node.querySelectorAll('style'));
     styleElements.forEach(style => {
         style.parentNode.removeChild(style);
     });
-    const paragraphs = Array.from(node.querySelectorAll('p:not(#pcs-edit-section-title-description)'));
+    // Apply this style-based exclusion filter to remove unwanted paragraphs in the popover
+    const paragraphs = Array.from(node.querySelectorAll(`p${notSelector}`));
+
+    // Filter out empty paragraphs or those with less than 50 character
     const parasWithContent = paragraphs.filter(para => {
         // DEV: Note that innerText is not supported in Firefox OS, so we need to use textContent as a fallback
         // The reason we prefer innerText is that it strips out hidden text and unnecessary whitespace, which is not the case with textContent

--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -100,7 +100,7 @@ function getArticleLede (href, baseUrl, articleDocument, archive) {
 // Helper function to clean up the lede content
 function cleanUpLedeContent (node) {
     // Define an array of exclusion filters
-    // (note .exclude-this-class is a dummy class used as an exmple which will used to exclude classes in future)
+    // (note `.exclude-this-class` is a dummy class used as an example for any future exclusion filters)
     const exclusionFilters = ['#pcs-edit-section-title-description', '.exclude-this-class'];
     // Constrct the :not() selector thing
     const notSelector = exclusionFilters.map(filter => `:not(${filter})`).join('');

--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -113,7 +113,7 @@ function cleanUpLedeContent (node) {
     // Apply this style-based exclusion filter to remove unwanted paragraphs in the popover
     const paragraphs = Array.from(node.querySelectorAll(`p${notSelector}`));
 
-    // Filter out empty paragraphs or those with less than 50 character
+    // Filter out empty paragraphs or those with less than 50 characters
     const parasWithContent = paragraphs.filter(para => {
         // DEV: Note that innerText is not supported in Firefox OS, so we need to use textContent as a fallback
         // The reason we prefer innerText is that it strips out hidden text and unnecessary whitespace, which is not the case with textContent

--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -104,19 +104,12 @@ function cleanUpLedeContent (node) {
     styleElements.forEach(style => {
         style.parentNode.removeChild(style);
     });
-    const paragraphs = Array.from(node.querySelectorAll('p'));
-    // Filter out empty paragraphs or those with less than 50 characters
+    const paragraphs = Array.from(node.querySelectorAll('p:not(#pcs-edit-section-title-description)'));
     const parasWithContent = paragraphs.filter(para => {
         // DEV: Note that innerText is not supported in Firefox OS, so we need to use textContent as a fallback
         // The reason we prefer innerText is that it strips out hidden text and unnecessary whitespace, which is not the case with textContent
         const innerText = para.innerText ? para.innerText : para.textContent;
-        const text = innerText.trim();
-
-        // removing the para with less than 50 characters
-        // regex to check the paragraph if its too short or a brief description
-        const briefDescriptionRegex = /^.{1,100}$/;
-
-        return !briefDescriptionRegex.test(text) && text.length >= 50;
+        return innerText.length >= 50;
     });
     return parasWithContent;
 }

--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -36,7 +36,7 @@ import uiUtil from './uiUtil.js';
  * @param {ZIMArchive} archive The archive from which to extract the lede
  * @returns {Promise<String>} A Promise for the linked article's lede HTML including first main image URL if any
  */
-function getArticleLede(href, baseUrl, articleDocument, archive) {
+function getArticleLede (href, baseUrl, articleDocument, archive) {
     const uriComponent = uiUtil.removeUrlParameters(href);
     const zimURL = uiUtil.deriveZimUrlFromRelativeUrl(uriComponent, baseUrl);
     console.debug('Previewing ' + zimURL);
@@ -98,7 +98,7 @@ function getArticleLede(href, baseUrl, articleDocument, archive) {
 };
 
 // Helper function to clean up the lede content
-function cleanUpLedeContent(node) {
+function cleanUpLedeContent (node) {
     // Remove all standalone style elements from the given DOM node, because their content is shown by innerText and textContent
     const styleElements = Array.from(node.querySelectorAll('style'));
     styleElements.forEach(style => {
@@ -122,7 +122,7 @@ function cleanUpLedeContent(node) {
 }
 
 // Helper function to concatenate paragraphs to fill the balloon
-function fillBalloonString(paras, baseURL, pathPrefix) {
+function fillBalloonString (paras, baseURL, pathPrefix) {
     let cumulativeCharCount = 0;
     let concatenatedText = '';
     // Add enough paras to complete the word count
@@ -154,7 +154,7 @@ function fillBalloonString(paras, baseURL, pathPrefix) {
 }
 
 // Helper function to get the first main image from the given node
-function getImageHTMLFromNode(node, baseURL, pathPrefix) {
+function getImageHTMLFromNode (node, baseURL, pathPrefix) {
     const images = node.querySelectorAll('img');
     let firstImage = null;
     if (images) {
@@ -181,7 +181,7 @@ function getImageHTMLFromNode(node, baseURL, pathPrefix) {
  * @param {Document} doc The document to which to attach the popover stylesheet
  * @param {Boolean} dark An optional parameter to adjust the background colour for dark themes (generally not needed for inversion-based themes)
  */
-function attachKiwixPopoverCss(doc, dark) {
+function attachKiwixPopoverCss (doc, dark) {
     const colour = dark && !/invert/i.test(params.cssTheme) ? 'darkgray' : 'black';
     const backgroundColour = dark && !/invert/i.test(params.cssTheme) ? '#111' : '#ebf4fb';
     const borderColour = dark ? 'darkslategray' : 'skyblue';
@@ -242,8 +242,8 @@ function attachKiwixPopoverCss(doc, dark) {
             -webkit-touch-callout: none !important;
         }
         `,
-        // The id of the style element for easy manipulation
-        'kiwixtooltipstylesheet');
+    // The id of the style element for easy manipulation
+    'kiwixtooltipstylesheet');
 }
 
 /**
@@ -255,14 +255,14 @@ function attachKiwixPopoverCss(doc, dark) {
  * @param {ZIMArchive} archive The archive from which the popover information is extracted
  * @returns {Promise<div>} A Promise for the attached popover div or undefined if the popover is not attached
  */
-function populateKiwixPopoverDiv(ev, link, state, dark, archive) {
+function populateKiwixPopoverDiv (ev, link, state, dark, archive) {
     // Do not show popover if the user has initiated an article load (set in filterClickEvent)
     if (link.articleisloading || link.popoverisloading) return Promise.resolve();
     const linkHref = link.getAttribute('href');
     // Do not show popover if there is no href or with certain landing pages
     if (!linkHref || /^wikivoyage/i.test(archive.file.name) &&
         (state.expectedArticleURLToBeDisplayed === archive.landingPageUrl ||
-            state.expectedArticleURLToBeDisplayed === 'A/Wikivoyage:Offline_reader_Expedition/Home_page')) {
+        state.expectedArticleURLToBeDisplayed === 'A/Wikivoyage:Offline_reader_Expedition/Home_page')) {
         return Promise.resolve();
     }
     link.popoverisloading = true;
@@ -331,7 +331,7 @@ function populateKiwixPopoverDiv(ev, link, state, dark, archive) {
  * @param {Event} event The event which has fired this popover action
  * @returns {Object} An object containing the popover div and the arrow span elements
  */
-function createNewKiwixPopoverCointainer(win, anchor, event) {
+function createNewKiwixPopoverCointainer (win, anchor, event) {
     const div = document.createElement('div');
     const linkHref = anchor.getAttribute('href');
     const currentDocument = win.document;
@@ -423,7 +423,7 @@ function createNewKiwixPopoverCointainer(win, anchor, event) {
  * @param {Element} popover The containing element of the popover (div)
  * @param {Document} doc The doucment on which to operate
  */
-function addEventListenersToPopoverIcons(anchor, popover, doc) {
+function addEventListenersToPopoverIcons (anchor, popover, doc) {
     const breakout = function (e) {
         // Adding the newcontainer property to the anchor will be cauught by the filterClickEvent function and will open in new tab
         anchor.newcontainer = true;
@@ -443,7 +443,7 @@ function addEventListenersToPopoverIcons(anchor, popover, doc) {
  * Remove any preview popover DIVs found in the given document
  * @param {Document} doc The document from which to remove any popovers
  */
-function removeKiwixPopoverDivs(doc) {
+function removeKiwixPopoverDivs (doc) {
     const divs = doc.getElementsByClassName('kiwixtooltip');
     // Timeout is set to allow for a delay before removing popovers - so user can hover the popover itself to prevent it from closing,
     // or so that links and buttons in the popover can be clicked
@@ -471,7 +471,7 @@ function removeKiwixPopoverDivs(doc) {
  * Closes the specified popover div, with fadeout effect, and removes it from the DOM
  * @param {Element} div The div to close
  */
-function closePopover(div) {
+function closePopover (div) {
     div.style.opacity = '0';
     // Timeout allows the animation to complete before removing the div
     setTimeout(function () {


### PR DESCRIPTION
This PR Fixes #1276 

Hello Everyone!

## Description
In this PR i have fixed the popover inappropriate description extraction by adding regex logic so that only Required information will be shown. 
**NOTE**: This PR fixes almost every popover however there are still 3 - 5 popover's that i haven't able to fix for example calsacaus in Europe , Greenland and other 3 from USA. 

## Test
I have done all the necessary test 
1. Checked in both "**Restricted**" and "**ServiceWorker**" Everything is working fine check the ss below.
2. Unit tests `npm test` no issue 
3. End-to-end (e2e) `tests-e2e-iemode`-> There was some e2e.runner.js error which i have commented on this PR's Issue thread. I tried alternative http-server there wasn't any issue.
5. extension versions with production code tested
6. Browser Test -> Microsoft Edge, Chrome, Firefox and Brave

## Screenshots
### Before
![rail](https://github.com/user-attachments/assets/37bb243e-27ad-48a6-93ef-aedd35a38635)
![mount](https://github.com/user-attachments/assets/d143240c-78a0-408d-9fd0-d7690edf8573)
![safari](https://github.com/user-attachments/assets/a26ac739-b58b-426d-999e-9499b9daf154)


### After (Test - eServiceworker / Non restricted)
![rail](https://github.com/user-attachments/assets/a649adf8-80a7-4265-9fd4-199e035d62d0)
![mount](https://github.com/user-attachments/assets/f82c25da-6c68-4f68-9f81-e48d5f14ff02)
![safari](https://github.com/user-attachments/assets/b714780c-38d7-4141-a224-f992b1df81b6)

### After (Test - Restricted)
![high speed rail](https://github.com/user-attachments/assets/eb0db376-162e-4ea3-a91d-bc7dd0814748)
![asia](https://github.com/user-attachments/assets/083603da-436d-4141-9544-d3b721af9492)
![greece](https://github.com/user-attachments/assets/3eee3ca7-905f-4105-a12b-aa2668ad8bdc)

Thanks