### PR TITLE
feat: added toc dropup like in Kiwix-PWA

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -385,6 +385,57 @@ iframe._invert, iframe._mwInvert {
     font-weight: bold;
 }
 
+.btn-group.btn-block {
+    padding-left: 5%;
+}
+
+.dropdown-menu.flex-container {
+    overflow-y:auto;
+    padding: 2px 4px;
+    position: absolute;
+    margin: 0 !important;
+}
+
+/* to fix its alignment with other buttons */
+.dropup button{
+    padding-top: 12px;
+}
+@media (max-width:768px) {
+    .dropup button{
+        padding-top: 0px;
+    }
+}
+
+#ToCList{
+    line-height: 1.7;
+}
+
+#ToCList a {
+    display: block;
+}
+
+.toc-item-h1{
+    font-size: 18px;
+}
+
+.toc-item-h2{
+    font-size: 16px;
+    margin-top:6px;
+    margin-left:6px;
+}
+
+.toc-item-h3{
+    font-size: 14px;
+    margin-left:12px;
+    font-weight:350;
+}
+
+.toc-item-h4{
+    font-size: 12px;
+    margin-left:16px;
+    font-weight:300;
+}
+
 .container {
     margin-bottom: 1.5em;
 }

--- a/www/index.html
+++ b/www/index.html
@@ -808,6 +808,13 @@
                     </div>
                 </div>
                 <div id="navigationButtons" class="btn-group btn-block">
+                    <div class="dropup">
+                        <button class="btn btn-lg dropdown-toggle col-xs-4" id="dropup" data-toggle="dropdown"
+                            aria-haspopup="true" aria-expanded="true" style="font-size: 14px;">
+                            <i class="fas fa-list-alt fa-lg"></i>
+                        </button>
+                        <ul id="ToCList" class="dropdown-menu flex-container"></ul>
+                    </div>
                     <a href="#" data-i18n-tip="home" class="btn btn-lg" id="btnHomeBottom" title="Home"><i class="fas fa-home"></i></a>
                     <a href="#" class="btn btn-lg" data-i18n-tip="home-btn-back" id="btnBack" title="Back"><i class="fas fa-arrow-left"></i></a>
                     <a href="#" class="btn btn-lg" data-i18n-tip="home-btn-forward" id="btnForward" title="Forward"><i class="fas fa-arrow-right"></i></a>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -3240,6 +3240,9 @@ function pushBrowserHistoryState (title, titleSearch) {
     window.history.pushState(stateObj, stateLabel, urlParameters);
 }
 
+// Setup table of contents and display the list when the dropup button is clicked
+uiUtil.setUpTOC();
+
 /**
  * Extracts the content of the given article pathname, or a downloadable file, from the ZIM
  *


### PR DESCRIPTION
fix #1212 

- Implemented a fully functional TOC drop-up, inspired by Kiwix-PWA and PR #1241


- When user clicks on drop-up button, TOC List is set up and displayed as drop-up menu.
- It is closed when drop-up button loses focus or when a section is clicked.
- Clicking a section scrolls the view to that section.

![image](https://github.com/user-attachments/assets/75dec5ce-3d94-4f90-86df-7c8c5c1a5a48)
