### PR TITLE
Handle user clicking on child element of list item

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2041,12 +2041,25 @@ function populateListOfArticles (dirEntryArray, reportingSearch) {
 /**
  * Handles the click on the title of an article in search results
  * @param {Event} event The click event to handle
- * @returns {Boolean} Always returns false for JQuery event handling
  */
 function handleTitleClick (event) {
-    var dirEntryId = decodeURIComponent(event.target.getAttribute('dirEntryId'));
+    event.preventDefault();
+    // User may have clicked on a child element of the list item if it contains HTML (for example, italics),
+    // so we may need to find the closest list item
+    let target = event.target;
+    if (target.className !== 'list-group-item') {
+        console.warn('User clicked on child element of list item, looking for parent...');
+        while (target && target.className !== 'list-group-item') {
+            target = target.parentNode;
+        }
+        if (!target) {
+            // No list item found, so we can't do anything
+            console.warn('No list item could be found for clicked event!');
+            return;
+        }
+    }
+    var dirEntryId = decodeURIComponent(target.getAttribute('dirEntryId'));
     findDirEntryFromDirEntryIdAndLaunchArticleRead(dirEntryId);
-    return false;
 }
 
 /**


### PR DESCRIPTION
When searching for articles, it may sometimes happen that the article list (with search results) contains HTML (e.g., italics). In that case, if a user happens to click on an italicized word, then the dirEntry ID of the search list item won't be found.

This PR handles that situation, and searches for the nearest parent with a `className` matching `list-group-item`, before attempting to extract the dirEntry ID.