### PR TITLE
Build compact code by default

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -20,7 +20,8 @@ const config = {
             }
         ]
     ],
-    exclude: ['node_modules/**']
+    exclude: ['node_modules/**'],
+    compact: true // Force compacting for large files
 };
 
 export default config;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -89,7 +89,7 @@ if (process.env.BUILD === 'production') {
                             // Alter remaining lib references
                                 .replace(/([\\/])js[\\/]lib/g, '$1js')
                             // Remove unneeded ASM/WASM binaries
-                                .replace(/["']www[\\/]js[\\/].*dec.*js["'],\s*/g, '')
+                                .replace(/['"]www[\\/]js[\\/].*dec.*js['"],\s*/g, '')
                         );
                         return result.code;
                     }


### PR DESCRIPTION
Fixes #1337. This works by ensuring Babel always builds compacted code.