### PR TITLE
Fix libzim message handler to enable popovers and fix erratic sliding toolbars (fixes #1385, #1380)

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1106,8 +1106,8 @@ function handleMessageChannelByLibzim (event) {
             appstate.baseUrl = encodeURI(title.replace(/[^/]+$/, ''));
             appstate.expectedArticleURLToBeDisplayed = title;
         }
-    // Ensure the article onload event gets attached to the right iframe
-    articleLoader();
+        // Ensure the article onload event gets attached to the right iframe
+        articleLoader();
         // Let's send the content to the ServiceWorker
         const message = { action: 'giveContent', title: title, content: ret.content, mimetype: ret.mimetype };
         messagePort.postMessage(message);


### PR DESCRIPTION
Fix: Add articleLoader and appstate updates to libzim message handler

## Issues

Fixes #1385 and #1380

### Issue #1385: Popovers not working in libzim mode
Popovers were not working consistently in libzim mode with Service Worker. Specifically:
- When users opened a Wikivoyage ZIM and landed on the default landing page, popovers didn't work
- Clicking links to navigate to other articles would load the articles successfully, but popovers still wouldn't work
- Only after performing a search and navigating to an article would popovers start working

### Issue #1380: Erratic sliding toolbars with Zimit classic archives
Sliding away toolbars were erratic with Zimit classic archives when using libzim backend due to not attaching the correct iframe for postprocessing in the libzim message channel.

## Root Causes

### For #1385:
The `handleMessageChannelByLibzim()` function was not updating `appstate.expectedArticleURLToBeDisplayed` when delivering HTML content to the Service Worker. This caused the variable to remain stuck at the landing page URL even after navigating to different articles.

The popover module checks this variable to determine if the current page is a landing page (where popovers are intentionally disabled to avoid interfering with interactive maps). Since the variable was never updated, the check would always think the user was still on the landing page, blocking popovers on all subsequent pages.

### For #1380:
The libzim message channel was not calling `articleLoader()` to properly attach the iframe for postprocessing, causing the toolbar gesture detection to malfunction.

## Solution

Updated `handleMessageChannelByLibzim()` to:
1. Mirror the behavior of `handleMessageChannelMessage()` by updating `appstate.baseUrl` and `appstate.expectedArticleURLToBeDisplayed` when serving HTML content
2. Add `articleLoader()` call to attach the correct iframe for postprocessing

This ensures proper state tracking and iframe attachment during link-based navigation in Service Worker + libzim mode.

## Changes

- Added state updates in `handleMessageChannelByLibzim()` (lines 1094-1098 in app.js)
- Updates both `appstate.baseUrl` and `appstate.expectedArticleURLToBeDisplayed` for HTML content
- Maintains consistency between libzim and non-libzim backend implementations
- Added `articleLoader()` call to properly attach iframe for postprocessing