### PR TITLE
Fix broken Wikipedia links with parentheses and anchors in Restricted mode

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -3291,8 +3291,22 @@ function displayArticleContentInIframe (dirEntry, htmlArticle) {
                 e.stopPropagation();
                 // Prevent display of any popovers because we're loading a new article
                 anchor.articleisloading = true;
-                anchorParameter = href.match(/#([^#;]+)$/);
-                anchorParameter = anchorParameter ? anchorParameter[1] : '';
+                // Extract anchor from href - match everything after # until end of string
+                // This handles anchors with semicolons, parentheses, and other special characters
+                var anchorMatch = href.match(/#(.+)$/);
+                var anchorParameterEncoded = anchorMatch ? anchorMatch[1] : '';
+                // Decode the anchor to match element IDs on the page.
+                // URLs may be encoded, but IDs are not. Keep the encoded value for the URL.
+                anchorParameter = anchorParameterEncoded;
+                if (anchorParameterEncoded) {
+                    try {
+                        anchorParameter = decodeURIComponent(anchorParameterEncoded);
+                    } catch (e) {
+                        // If decoding fails (e.g., malformed encoding), use the original value
+                        console.debug('Failed to decode anchor parameter, using original:', anchorParameterEncoded);
+                        anchorParameter = anchorParameterEncoded;
+                    }
+                }
                 var indexRoot = window.location.pathname.replace(/[^/]+$/, '') + encodeURI(selectedArchive.file.name) + '/';
                 var zimRoot = indexRoot.replace(/^.+?\/www\//, '/');
                 var zimUrl = href;
@@ -3301,10 +3315,11 @@ function displayArticleContentInIframe (dirEntry, htmlArticle) {
                 zimUrl = zimUrl.replace(/^\s+|\s+$/g, '');
                 if (/zimit/.test(params.zimType)) {
                     // Deal with root-relative URLs in zimit ZIMs
+                    // Use the encoded anchor for URL manipulation to ensure proper matching
                     if (!zimUrl.indexOf(indexRoot)) { // If begins with indexRoot
-                        zimUrl = zimUrl.replace(indexRoot, '').replace('#' + anchorParameter, '');
+                        zimUrl = zimUrl.replace(indexRoot, '').replace('#' + anchorParameterEncoded, '');
                     } else if (!zimUrl.indexOf(zimRoot)) { // If begins with zimRoot
-                        zimUrl = zimUrl.replace(zimRoot, '').replace('#' + anchorParameter, '');
+                        zimUrl = zimUrl.replace(zimRoot, '').replace('#' + anchorParameterEncoded, '');
                     } else if (/^\//.test(zimUrl)) {
                         zimUrl = zimUrl.replace(/^\//, selectedArchive.zimitPseudoContentNamespace + selectedArchive.zimitPrefix.replace(/^A\//, ''));
                     } else if (!~zimUrl.indexOf(selectedArchive.zimitPseudoContentNamespace)) { // Doesn't begin with pseudoContentNamespace
@@ -3312,7 +3327,7 @@ function displayArticleContentInIframe (dirEntry, htmlArticle) {
                         // deriveZimUrlFromRelativeUrls strips any querystring and decodes
                         var zimUrlToTransform = zimUrl;
                         zimUrl = encodeURI(uiUtil.deriveZimUrlFromRelativeUrl(zimUrlToTransform, appstate.baseUrl)) +
-                            href.replace(uriComponent, '').replace('#' + anchorParameter, '');
+                            href.replace(uriComponent, '').replace('#' + anchorParameterEncoded, '');
                         // zimUrlFullEncoding = encodeURI(uiUtil.deriveZimUrlFromRelativeUrl(zimUrlToTransform, appstate.baseUrl) +
                         //     href.replace(uriComponent, '').replace('#' + anchorParameter, ''));
                     }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -3303,7 +3303,7 @@ function displayArticleContentInIframe (dirEntry, htmlArticle) {
                         anchorParameter = decodeURIComponent(anchorParameterEncoded);
                     } catch (e) {
                         // If decoding fails (e.g., malformed encoding), use the original value
-                        console.debug('Failed to decode anchor parameter, using original:', anchorParameterEncoded);
+                        console.debug('Failed to decode anchor parameter, using original:', anchorParameterEncoded, e);
                         anchorParameter = anchorParameterEncoded;
                     }
                 }

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -602,10 +602,18 @@ function replaceCSSLinkWithInlineCSS (link, cssContent, id) {
  * @returns {String} The same URL without its parameters and anchors
  */
 function removeUrlParameters (url) {
+    if (typeof url !== 'string') return url;
     // Remove any querystring
     var strippedUrl = url.replace(/\?[^?]*$/, '');
-    // Remove any anchor parameters - note that we are deliberately excluding entity references, e.g. '&#39;'.
-    strippedUrl = strippedUrl.replace(/#[^#;]*$/, '');
+    // Find the first # character that starts a fragment (not part of a character reference like &#39;)
+    // This correctly handles anchors with semicolons and character references in the URL path
+    var hashIndex = -1;
+    while ((hashIndex = strippedUrl.indexOf('#', hashIndex + 1)) !== -1) {
+        // If # is at the start or not preceded by &, it's a fragment anchor
+        if (hashIndex === 0 || strippedUrl[hashIndex - 1] !== '&') {
+            return strippedUrl.substring(0, hashIndex);
+        }
+    }
     return strippedUrl;
 }
 


### PR DESCRIPTION
### Fixed the issue where links with parentheses and/or anchors failed in Restricted mode.

**Fixes #1405**

**Changes made:**
1. Fixed removeUrlParameters() in `uiUtil.js`:
- Replaced regex-based anchor stripping with a loop that finds the first `#` not preceded by `&`
- Handles anchors with semicolons
- Skips character references in paths
- Ensures anchors are fully stripped before article lookup
2. Improved anchor extraction in `app.js`:
- Updated regex to capture anchors with semicolons
- Extracts the full anchor fragment, including special characters
3. Added anchor decoding in `app.js`:
- Decodes anchor parameters using decodeURIComponent() before getElementById()
- Handles URL encoded characters like parentheses in anchors
- Keeps encoded version for URL manipulation to ensure proper string matching

**How it resolves the issue**
- `removeUrlParameters()` strips anchors correctly, preventing malformed paths
- Decoded anchors match HTML element IDs for proper scrolling
- Handles semicolons, parentheses, URL encoding, and character references