### PR TITLE
fix: prevent white flash on startup by pre-applying dark theme

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -135,6 +135,7 @@ const precacheFiles = [
     'www/topFrame.html',
     'www/js/app.js',
     'www/js/init.js',
+    'www/js/theme-init.js',
     'www/js/lib/abstractFilesystemAccess.js',
     'www/js/lib/arrayFromPolyfill.js',
     'www/js/lib/filecache.js',

--- a/www/index.html
+++ b/www/index.html
@@ -36,26 +36,9 @@
         along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <https://www.gnu.org/licenses/>
 
         -->
-        <!--Adding script before CSS links to solve flash problem-->
-    <script>
-     (function() {
-
-      var theme = localStorage.getItem('kiwixjs-appTheme');
-      if (theme && theme.includes('dark')) {
-      document.documentElement.style.setProperty('background-color', '#1c1c1e', 'important');
-      document.documentElement.classList.add('dark');
-      var observer = new MutationObserver(function(mutations, obs) {
-        if (document.body) {
-          document.body.classList.add('dark');
-          document.body.style.backgroundColor = '#1c1c1e';
-          obs.disconnect();
-        }
-      });
-      observer.observe(document.documentElement, { childList: true });
-    }
-    })();
-</script>
-        
+        <!--Adding external script to solve flash problem-->
+    
+        <script type="text/javascript" src="js/theme-init.js"></script>
         <!-- Bootstrap -->
         <link rel="manifest" href="../manifest.webmanifest" />
         <link href="../node_modules/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" media="screen"/>

--- a/www/index.html
+++ b/www/index.html
@@ -36,7 +36,26 @@
         along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <https://www.gnu.org/licenses/>
 
         -->
+        <!--Adding script before CSS links to solve flash problem-->
+    <script>
+     (function() {
 
+      var theme = localStorage.getItem('kiwixjs-appTheme');
+      if (theme && theme.includes('dark')) {
+      document.documentElement.style.setProperty('background-color', '#1c1c1e', 'important');
+      document.documentElement.classList.add('dark');
+      var observer = new MutationObserver(function(mutations, obs) {
+        if (document.body) {
+          document.body.classList.add('dark');
+          document.body.style.backgroundColor = '#1c1c1e';
+          obs.disconnect();
+        }
+      });
+      observer.observe(document.documentElement, { childList: true });
+    }
+    })();
+</script>
+        
         <!-- Bootstrap -->
         <link rel="manifest" href="../manifest.webmanifest" />
         <link href="../node_modules/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" media="screen"/>

--- a/www/index.html
+++ b/www/index.html
@@ -36,8 +36,7 @@
         along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <https://www.gnu.org/licenses/>
 
         -->
-        <!--Adding external script to solve flash problem-->
-    
+        <!-- Pre-apply theme to prevent flash of unstyled content -->
         <script type="text/javascript" src="js/theme-init.js"></script>
         <!-- Bootstrap -->
         <link rel="manifest" href="../manifest.webmanifest" />

--- a/www/js/theme-init.js
+++ b/www/js/theme-init.js
@@ -1,0 +1,49 @@
+(function() {
+    // Immediately apply theme background to prevent flash
+    try {
+        var theme = localStorage.getItem('kiwixjs-appTheme');
+        console.log('Theme init: Retrieved theme =', theme); 
+        
+       
+        var bgColor = '#FBEAEA'; 
+        var isDark = false;
+        
+        if (theme && theme.includes('dark')) {
+            bgColor = '#300000';
+            isDark = true;
+            console.log('Theme init: Applying dark theme');
+        } else {
+            console.log('Theme init: Applying light theme');
+        }
+        
+      
+        var html = document.documentElement;
+        html.style.backgroundColor = bgColor;
+        
+        if (isDark) {
+            html.classList.add('dark');
+        }
+        
+       
+        var style = document.createElement('style');
+        style.textContent = 'html, body { background-color: ' + bgColor +';}';
+        document.head.appendChild(style);
+        
+       
+        if (document.body) {
+            document.body.style.backgroundColor = bgColor;
+            if (isDark) {
+                document.body.classList.add('dark');
+            }
+        } else {
+            document.addEventListener('DOMContentLoaded', function() {
+                document.body.style.backgroundColor = bgColor;
+                if (isDark) {
+                    document.body.classList.add('dark');
+                }
+            });
+        }
+    } catch (e) {
+        console.error('Theme init error:', e);
+    }
+})();

--- a/www/js/theme-init.js
+++ b/www/js/theme-init.js
@@ -8,7 +8,7 @@
         try {
             var val = localStorage.getItem(keyPrefix + key);
             if (val !== null) return val;
-        } catch (e) {
+        } catch (e) { // eslint-disable-line no-unused-vars
             // Ignore errors when localStorage is unavailable
         }
 

--- a/www/js/theme-init.js
+++ b/www/js/theme-init.js
@@ -1,25 +1,55 @@
 // Prevent white flash on reload by applying correct background
-(
-    function () {
-        var storedTheme = localStorage.getItem('kiwixjs-appTheme') || "light";
-        var htmlEl = document.documentElement;
-        if (localStorage.getItem('kiwixjs-appCache') === 'true') {
-            if (storedTheme.includes('dark')) {
+(function () {
 
-                htmlEl.classList.add('dark');
+    // DEV: keyPrefix must match params['keyPrefix'] in init.js
+    var keyPrefix = 'kiwixjs-';
 
+    function getStoredValue(key) {
+        try {
+            var val = localStorage.getItem(keyPrefix + key);
+            if (val !== null) return val;
+        } catch (e) {}
+
+        var match = document.cookie.match(
+            new RegExp('(?:^|; )' + encodeURIComponent(key) + '=([^;]*)')
+        );
+
+        return match ? decodeURIComponent(match[1]) : null;
+    }
+
+    var storedTheme = getStoredValue('appTheme') || 'light';
+    var appCache = getStoredValue('appCache');
+
+    function prefersDark() {
+        return window.matchMedia &&
+            window.matchMedia('(prefers-color-scheme: dark)').matches;
+    }
+
+    var isDark = false;
+
+    if (storedTheme.includes('dark') ) {
+        isDark = true;
+    } else if (  storedTheme.includes('auto')  || storedTheme.includes('auto_wikimediaNative')  ) {
+        isDark = prefersDark();
+    }
+
+    var htmlEl = document.documentElement;
+
+    
+    if ( appCache === null || appCache === 'true') {
+        if (isDark) {
+            htmlEl.classList.add('dark');
+        } else {
+            if(htmlEl.classList.contains('dark')){
+                 htmlEl.classList.remove('dark');
             }
-            else {
-                if (htmlEl.classList.contains('dark')) {
-                    htmlEl.classList.remove('dark');
-                };
-            }
-        }
-        else {
-            htmlEl.style.backgroundColor =
-                storedTheme.includes('dark')
-                    ? '#300000'
-                    : 'mistyrose';
         }
     }
-)();
+
+   
+    else {
+        htmlEl.style.backgroundColor =
+            isDark ? '#300000' : 'mistyrose';
+    }
+
+})();

--- a/www/js/theme-init.js
+++ b/www/js/theme-init.js
@@ -40,11 +40,7 @@
     if (appCache === null || appCache === 'true') {
         if (isDark) {
             htmlEl.classList.add('dark');
-        } else {
-            if (htmlEl.classList.contains('dark')) {
-                htmlEl.classList.remove('dark');
-            }
-        }
+        } 
     } else {
         htmlEl.style.backgroundColor =
             isDark ? '#300000' : 'mistyrose';

--- a/www/js/theme-init.js
+++ b/www/js/theme-init.js
@@ -8,7 +8,9 @@
         try {
             var val = localStorage.getItem(keyPrefix + key);
             if (val !== null) return val;
-        } catch (e) {}
+        } catch {
+    // Ignore errors when localStorage is unavailable
+         }
 
         var match = document.cookie.match(
             new RegExp('(?:^|; )' + encodeURIComponent(key) + '=([^;]*)')

--- a/www/js/theme-init.js
+++ b/www/js/theme-init.js
@@ -1,49 +1,25 @@
-(function() {
-    // Immediately apply theme background to prevent flash
-    try {
-        var theme = localStorage.getItem('kiwixjs-appTheme');
-        console.log('Theme init: Retrieved theme =', theme); 
-        
-       
-        var bgColor = '#FBEAEA'; 
-        var isDark = false;
-        
-        if (theme && theme.includes('dark')) {
-            bgColor = '#300000';
-            isDark = true;
-            console.log('Theme init: Applying dark theme');
-        } else {
-            console.log('Theme init: Applying light theme');
-        }
-        
-      
-        var html = document.documentElement;
-        html.style.backgroundColor = bgColor;
-        
-        if (isDark) {
-            html.classList.add('dark');
-        }
-        
-       
-        var style = document.createElement('style');
-        style.textContent = 'html, body { background-color: ' + bgColor +';}';
-        document.head.appendChild(style);
-        
-       
-        if (document.body) {
-            document.body.style.backgroundColor = bgColor;
-            if (isDark) {
-                document.body.classList.add('dark');
+// Prevent white flash on reload by applying correct background
+(
+    function () {
+        var storedTheme = localStorage.getItem('kiwixjs-appTheme') || "light";
+        var htmlEl = document.documentElement;
+        if (localStorage.getItem('kiwixjs-appCache') === 'true') {
+            if (storedTheme.includes('dark')) {
+
+                htmlEl.classList.add('dark');
+
             }
-        } else {
-            document.addEventListener('DOMContentLoaded', function() {
-                document.body.style.backgroundColor = bgColor;
-                if (isDark) {
-                    document.body.classList.add('dark');
-                }
-            });
+            else {
+                if (htmlEl.classList.contains('dark')) {
+                    htmlEl.classList.remove('dark');
+                };
+            }
         }
-    } catch (e) {
-        console.error('Theme init error:', e);
+        else {
+            htmlEl.style.backgroundColor =
+                storedTheme.includes('dark')
+                    ? '#300000'
+                    : 'mistyrose';
+        }
     }
-})();
+)();

--- a/www/js/theme-init.js
+++ b/www/js/theme-init.js
@@ -8,9 +8,9 @@
         try {
             var val = localStorage.getItem(keyPrefix + key);
             if (val !== null) return val;
-        } catch {
-    // Ignore errors when localStorage is unavailable
-         }
+        } catch (e) {
+            // Ignore errors when localStorage is unavailable
+        }
 
         var match = document.cookie.match(
             new RegExp('(?:^|; )' + encodeURIComponent(key) + '=([^;]*)')
@@ -29,27 +29,23 @@
 
     var isDark = false;
 
-    if (storedTheme.includes('dark') ) {
+    if (storedTheme.indexOf('dark') !== -1) {
         isDark = true;
-    } else if (  storedTheme.includes('auto')  || storedTheme.includes('auto_wikimediaNative')  ) {
+    } else if (storedTheme.indexOf('auto') !== -1) {
         isDark = prefersDark();
     }
 
     var htmlEl = document.documentElement;
 
-    
-    if ( appCache === null || appCache === 'true') {
+    if (appCache === null || appCache === 'true') {
         if (isDark) {
             htmlEl.classList.add('dark');
         } else {
-            if(htmlEl.classList.contains('dark')){
-                 htmlEl.classList.remove('dark');
+            if (htmlEl.classList.contains('dark')) {
+                htmlEl.classList.remove('dark');
             }
         }
-    }
-
-   
-    else {
+    } else {
         htmlEl.style.backgroundColor =
             isDark ? '#300000' : 'mistyrose';
     }


### PR DESCRIPTION
### Description:
**Fixes:**#1125
This PR addresses the "white flash" issue that occurs when the app is launched or refreshed while a dark theme is active. By checking the user's theme preference and applying a .dark class immediately in the '<head>', we ensure the app paints with a dark background before the main CSS and JS files are fully loaded if the theme was already set to dark mode.
### Changes Made

- Modified www/index.html:
- Added an inline, blocking <script> at the very top of the '<head>'.
- Implemented a MutationObserver to watch for the creation of the '<body>' element.
- Added logic to read kiwixjs-appTheme from localStorage.
- Applies the .dark class to the <body> at the very moment it is created, preventing the browser's default white paint.   
### Rationale  
Currently, the application applies the dark theme via app.js. Since app.js is a large bundle loaded at the end of the document, the browser often performs a "first paint" with the default white background while the script is still downloading or parsing.

By placing a tiny, dependency-free script in the <head>:

- Eliminates Flicker: We beat the CSS/JS load time by targeting the DOM during the initial parse.  
- Performance: Using MutationObserver is more efficient than waiting for DOMContentLoaded because it triggers as soon as the <body> tag exists, rather than waiting for the entire HTML to be parsed.  
### Testing Done
Manual Verification: Tested in Chrome/Edge. Cleared cache, set theme to dark, and refreshed. The white flash is no longer visible.
**Unit Tests**: Ran npm run test-unit — 22 passing, 0 failing.
**Environment**: Verified the fix works even when the app is served via a local server (http-server).
<img width="355" height="142" alt="Screenshot 2026-01-25 185432" src="https://github.com/user-attachments/assets/f56ee8e6-63e4-4f3b-aeac-cf14193eacf3" />
