### PR TITLE
Fix : Properly clear App Cache and IndexedDB on Resetfix reset btn to clear cache #1136

### DIFF
--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -25,7 +25,7 @@ var deprecatedKeys = [
 var keyPrefix = params.keyPrefix;
 
 // Tests for available Storage APIs (document.cookie or localStorage) and returns the best available of these
-function getBestAvailableStorageAPI () {
+function getBestAvailableStorageAPI() {
     // DEV: In FF extensions, cookies are blocked since at least FF 68.6 but possibly since FF 55 [kiwix-js #612]
     var type = 'none';
     // First test for localStorage API support
@@ -68,7 +68,98 @@ function getBestAvailableStorageAPI () {
  * Or, if a parameter is supplied, deletes or disables the object
  * @param {String} object Optional name of the object to disable or delete ('cookie', 'localStorage', 'indexedDB', 'cacheAPI')
  */
-function reset (object) {
+// function reset(object) {
+//     // 1. Clear any cookie entries
+//     if (!object || object === 'cookie') {
+//         var regexpCookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;
+//         var currentCookie = document.cookie;
+//         var foundCrumb = false;
+//         var cookieCrumb = regexpCookieKeys.exec(currentCookie);
+//         while (cookieCrumb !== null) {
+//             // DEV: Note that we don't use the keyPrefix in legacy cookie support
+//             foundCrumb = true;
+//             // This expiry date will cause the browser to delete the cookie crumb on next page refresh
+//             document.cookie = cookieCrumb[1] + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
+//             cookieCrumb = regexpCookieKeys.exec(currentCookie);
+//         }
+//         if (foundCrumb) console.debug('All cookie keys were expired...');
+//     }
+
+//     // 2. Clear any localStorage settings
+//     if (!object || object === 'localStorage') {
+//         if (params.storeType === 'local_storage') {
+//             localStorage.clear();
+//             console.debug('All Local Storage settings were deleted...');
+//         }
+//     }
+
+//     // 3. Clear any IndexedDB databases
+//     if (!object || object === 'indexedDB') {
+//         if (window.indexedDB) {
+//             // Attempt to delete all databases (only works in Chromium-based browsers)
+//             if (indexedDB.databases) {
+//                 var result = 0;
+//                 indexedDB.databases().then(function (dbs) {
+//                     dbs.forEach(function (db) {
+//                         result++;
+//                         indexedDB.deleteDatabase(db.name);
+//                         console.debug('Deleting ' + db.name + '...');
+//                     });
+//                 }).then(function () {
+//                     console.debug('Deleted ' + result + ' indexedDB databases...');
+//                 }).catch(function (err) {
+//                     console.error('Error deleting indexedDB databases', err);
+//                 });
+//             } else {
+//                 // For Firefox, we can only delete databases we know the names of
+//                 var dbNames = [params.cacheIDB, 'collDB'];
+//                 dbNames.forEach(function (dbName) {
+//                     var deleteRequest = indexedDB.deleteDatabase(dbName);
+//                     deleteRequest.onsuccess = function () {
+//                         console.debug('Deleted ' + dbName + '...');
+//                     }
+//                     deleteRequest.onerror = function (ev) {
+//                         console.error('Error deleting ' + dbName + '...', ev);
+//                     }
+//                 });
+//             }
+//         }
+//     }
+
+//     // 4. Clear any Cache API caches
+//     if (!object || object === 'cacheAPI') {
+//         if ('caches' in window) {
+//             // Get all cache names directly from Cache API
+//             caches.keys().then(function (cacheNames) {
+//                 if (cacheNames && cacheNames.length > 0) {
+//                     var deletePromises = cacheNames.map(function (cacheName) {
+//                         console.debug('Deleting cache: ' + cacheName);
+//                         return caches.delete(cacheName);
+//                     });
+
+//                     return Promise.all(deletePromises);
+//                 }
+//             }).then(function () {
+//                 console.debug('All Cache API caches were deleted...');
+//                 // Reload if user performed full reset or if appCache is needed
+//                 if (!object || params.appCache) _reloadApp();
+//             }).catch(function (err) {
+//                 console.error('Error deleting caches:', err);
+//                 // Still reload on error
+//                 if (!object || params.appCache) _reloadApp();
+//             });
+//         } else {
+//             console.debug('Cache API not available');
+//             if (!object || params.appCache) _reloadApp();
+//         }
+//     }
+// }
+function reset(object) {
+    // Helper function to handle reload after all operations
+    var shouldReload = function () {
+        return !object || params.appCache;
+    };
+
     // 1. Clear any cookie entries
     if (!object || object === 'cookie') {
         var regexpCookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;
@@ -76,9 +167,7 @@ function reset (object) {
         var foundCrumb = false;
         var cookieCrumb = regexpCookieKeys.exec(currentCookie);
         while (cookieCrumb !== null) {
-            // DEV: Note that we don't use the keyPrefix in legacy cookie support
             foundCrumb = true;
-            // This expiry date will cause the browser to delete the cookie crumb on next page refresh
             document.cookie = cookieCrumb[1] + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
             cookieCrumb = regexpCookieKeys.exec(currentCookie);
         }
@@ -94,66 +183,85 @@ function reset (object) {
     }
 
     // 3. Clear any IndexedDB databases
+    var indexedDBPromise = Promise.resolve();
     if (!object || object === 'indexedDB') {
         if (window.indexedDB) {
-            // Attempt to delete all databases (only works in Chromium-based browsers)
             if (indexedDB.databases) {
-                var result = 0;
-                indexedDB.databases().then(function (dbs) {
-                    dbs.forEach(function (db) {
-                        result++;
-                        indexedDB.deleteDatabase(db.name);
+                indexedDBPromise = indexedDB.databases().then(function (dbs) {
+                    var deletePromises = dbs.map(function (db) {
                         console.debug('Deleting ' + db.name + '...');
+                        return new Promise(function (resolve) {
+                            var req = indexedDB.deleteDatabase(db.name);
+                            req.onsuccess = resolve;
+                            req.onerror = resolve; // Resolve even on error
+                        });
                     });
+                    return Promise.all(deletePromises);
                 }).then(function () {
-                    console.debug('Deleted ' + result + ' indexedDB databases...');
+                    console.debug('Deleted all indexedDB databases...');
                 }).catch(function (err) {
                     console.error('Error deleting indexedDB databases', err);
                 });
             } else {
-                // For Firefox, we can only delete databases we know the names of
+                // For Firefox
                 var dbNames = [params.cacheIDB, 'collDB'];
-                dbNames.forEach(function (dbName) {
-                    var deleteRequest = indexedDB.deleteDatabase(dbName);
-                    deleteRequest.onsuccess = function () {
-                        console.debug('Deleted ' + dbName + '...');
-                    }
-                    deleteRequest.onerror = function (ev) {
-                        console.error('Error deleting ' + dbName + '...', ev);
-                    }
+                var deletePromises = dbNames.map(function (dbName) {
+                    return new Promise(function (resolve) {
+                        var deleteRequest = indexedDB.deleteDatabase(dbName);
+                        deleteRequest.onsuccess = function () {
+                            console.debug('Deleted ' + dbName + '...');
+                            resolve();
+                        };
+                        deleteRequest.onerror = function (ev) {
+                            console.error('Error deleting ' + dbName + '...', ev);
+                            resolve(); // Resolve even on error
+                        };
+                    });
                 });
+                indexedDBPromise = Promise.all(deletePromises);
             }
         }
     }
 
     // 4. Clear any Cache API caches
+    var cachePromise = Promise.resolve();
     if (!object || object === 'cacheAPI') {
-        getCacheNames(function (cacheNames) {
-            if (cacheNames && !cacheNames.error) {
-                var cnt = 0;
-                for (var cacheName in cacheNames) {
-                    cnt++;
-                    caches.delete(cacheNames[cacheName]).then(function () {
-                        cnt--;
-                        if (!cnt) {
-                            // All caches deleted
-                            console.debug('All Cache API caches were deleted...');
-                            // Reload if user performed full reset or if appCache is needed
-                            if (!object || params.appCache) _reloadApp();
-                        }
+        if ('caches' in window) {
+            cachePromise = caches.keys().then(function (cacheNames) {
+                if (cacheNames && cacheNames.length > 0) {
+                    var deletePromises = cacheNames.map(function (cacheName) {
+                        console.debug('Deleting cache: ' + cacheName);
+                        return caches.delete(cacheName);
                     });
+                    return Promise.all(deletePromises);
                 }
-            } else {
-                console.debug('No Cache API caches were in use (or we do not have access to the names).');
-                // All operations complete, reload if user performed full reset or if appCache is needed
-                if (!object || params.appCache) _reloadApp();
-            }
-        });
+            }).then(function () {
+                console.debug('All Cache API caches were deleted...');
+            }).catch(function (err) {
+                console.error('Error deleting caches:', err);
+            });
+        } else {
+            console.debug('Cache API not available');
+        }
     }
+
+    // Wait for all async operations to complete before reloading
+    Promise.all([indexedDBPromise, cachePromise]).then(function () {
+        if (shouldReload()) {
+            _reloadApp();
+        }
+    }).catch(function (err) {
+        console.error('Error during reset:', err);
+        if (shouldReload()) {
+            _reloadApp();
+        }
+    });
 }
 
+
+
 // Gets cache names from Service Worker, as we cannot rely on having them in params.cacheNames
-function getCacheNames (callback) {
+function getCacheNames(callback) {
     if (navigator.serviceWorker && navigator.serviceWorker.controller) {
         var channel = new MessageChannel();
         channel.port1.onmessage = function (event) {
@@ -169,7 +277,7 @@ function getCacheNames (callback) {
 }
 
 // Deregisters all Service Workers and reboots the app
-function _reloadApp () {
+function _reloadApp() {
     var reboot = function () {
         console.debug('Performing app reload...');
         setTimeout(function () {
@@ -234,15 +342,15 @@ var settingsStore = {
             var sExpires = '';
             if (vEnd) {
                 switch (vEnd.constructor) {
-                case Number:
-                    sExpires = vEnd === Infinity ? '; expires=Fri, 31 Dec 9999 23:59:59 GMT' : '; max-age=' + vEnd;
-                    break;
-                case String:
-                    sExpires = '; expires=' + vEnd;
-                    break;
-                case Date:
-                    sExpires = '; expires=' + vEnd.toUTCString();
-                    break;
+                    case Number:
+                        sExpires = vEnd === Infinity ? '; expires=Fri, 31 Dec 9999 23:59:59 GMT' : '; max-age=' + vEnd;
+                        break;
+                    case String:
+                        sExpires = '; expires=' + vEnd;
+                        break;
+                    case Date:
+                        sExpires = '; expires=' + vEnd.toUTCString();
+                        break;
                 }
             }
             document.cookie = encodeURIComponent(sKey) + '=' + encodeURIComponent(sValue) + sExpires + (sDomain ? '; domain=' + sDomain : '') + (sPath ? '; path=' + sPath : '') + (bSecure ? '; secure' : '');
@@ -284,7 +392,7 @@ var settingsStore = {
 };
 
 // One-off migration of storage settings from cookies to localStorage
-function _migrateStorageSettings () {
+function _migrateStorageSettings() {
     console.log('Migrating Settings Store from cookies to localStorage...');
     var cookieKeys = settingsStore._cookieKeys();
     // Note that because migration occurs before setting params.storeType, settingsStore.getItem() will get the item from

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -68,95 +68,10 @@ function getBestAvailableStorageAPI() {
  * Or, if a parameter is supplied, deletes or disables the object
  * @param {String} object Optional name of the object to disable or delete ('cookie', 'localStorage', 'indexedDB', 'cacheAPI')
  */
-// function reset(object) {
-//     // 1. Clear any cookie entries
-//     if (!object || object === 'cookie') {
-//         var regexpCookieKeys = /(?:^|;)\s*([^=]+)=([^;]*)/ig;
-//         var currentCookie = document.cookie;
-//         var foundCrumb = false;
-//         var cookieCrumb = regexpCookieKeys.exec(currentCookie);
-//         while (cookieCrumb !== null) {
-//             // DEV: Note that we don't use the keyPrefix in legacy cookie support
-//             foundCrumb = true;
-//             // This expiry date will cause the browser to delete the cookie crumb on next page refresh
-//             document.cookie = cookieCrumb[1] + '=;expires=Thu, 21 Sep 1979 00:00:01 UTC;';
-//             cookieCrumb = regexpCookieKeys.exec(currentCookie);
-//         }
-//         if (foundCrumb) console.debug('All cookie keys were expired...');
-//     }
 
-//     // 2. Clear any localStorage settings
-//     if (!object || object === 'localStorage') {
-//         if (params.storeType === 'local_storage') {
-//             localStorage.clear();
-//             console.debug('All Local Storage settings were deleted...');
-//         }
-//     }
-
-//     // 3. Clear any IndexedDB databases
-//     if (!object || object === 'indexedDB') {
-//         if (window.indexedDB) {
-//             // Attempt to delete all databases (only works in Chromium-based browsers)
-//             if (indexedDB.databases) {
-//                 var result = 0;
-//                 indexedDB.databases().then(function (dbs) {
-//                     dbs.forEach(function (db) {
-//                         result++;
-//                         indexedDB.deleteDatabase(db.name);
-//                         console.debug('Deleting ' + db.name + '...');
-//                     });
-//                 }).then(function () {
-//                     console.debug('Deleted ' + result + ' indexedDB databases...');
-//                 }).catch(function (err) {
-//                     console.error('Error deleting indexedDB databases', err);
-//                 });
-//             } else {
-//                 // For Firefox, we can only delete databases we know the names of
-//                 var dbNames = [params.cacheIDB, 'collDB'];
-//                 dbNames.forEach(function (dbName) {
-//                     var deleteRequest = indexedDB.deleteDatabase(dbName);
-//                     deleteRequest.onsuccess = function () {
-//                         console.debug('Deleted ' + dbName + '...');
-//                     }
-//                     deleteRequest.onerror = function (ev) {
-//                         console.error('Error deleting ' + dbName + '...', ev);
-//                     }
-//                 });
-//             }
-//         }
-//     }
-
-//     // 4. Clear any Cache API caches
-//     if (!object || object === 'cacheAPI') {
-//         if ('caches' in window) {
-//             // Get all cache names directly from Cache API
-//             caches.keys().then(function (cacheNames) {
-//                 if (cacheNames && cacheNames.length > 0) {
-//                     var deletePromises = cacheNames.map(function (cacheName) {
-//                         console.debug('Deleting cache: ' + cacheName);
-//                         return caches.delete(cacheName);
-//                     });
-
-//                     return Promise.all(deletePromises);
-//                 }
-//             }).then(function () {
-//                 console.debug('All Cache API caches were deleted...');
-//                 // Reload if user performed full reset or if appCache is needed
-//                 if (!object || params.appCache) _reloadApp();
-//             }).catch(function (err) {
-//                 console.error('Error deleting caches:', err);
-//                 // Still reload on error
-//                 if (!object || params.appCache) _reloadApp();
-//             });
-//         } else {
-//             console.debug('Cache API not available');
-//             if (!object || params.appCache) _reloadApp();
-//         }
-//     }
-// }
-function reset(object) {
+function reset (object) {
     // Helper function to handle reload after all operations
-    var shouldReload = function () {
+    var shouldReload = function() {
         return !object || params.appCache;
     };
 
@@ -188,16 +103,21 @@ function reset(object) {
         if (window.indexedDB) {
             if (indexedDB.databases) {
                 indexedDBPromise = indexedDB.databases().then(function (dbs) {
-                    var deletePromises = dbs.map(function (db) {
+                    var deletePromises = dbs.map(function(db) {
+                        if (!db.name) return Promise.resolve(); 
                         console.debug('Deleting ' + db.name + '...');
-                        return new Promise(function (resolve) {
+                        return new Promise(function(resolve) {
                             var req = indexedDB.deleteDatabase(db.name);
                             req.onsuccess = resolve;
-                            req.onerror = resolve; // Resolve even on error
+                            req.onerror = resolve;
+                            req.onblocked = function(ev) { 
+                                console.warn('IDB delete blocked: ' + db.name, ev);
+                                resolve();
+                            };
                         });
                     });
                     return Promise.all(deletePromises);
-                }).then(function () {
+                }).then(function() {
                     console.debug('Deleted all indexedDB databases...');
                 }).catch(function (err) {
                     console.error('Error deleting indexedDB databases', err);
@@ -205,8 +125,9 @@ function reset(object) {
             } else {
                 // For Firefox
                 var dbNames = [params.cacheIDB, 'collDB'];
-                var deletePromises = dbNames.map(function (dbName) {
-                    return new Promise(function (resolve) {
+                var deletePromises = dbNames.map(function(dbName) {
+                    if (!dbName) return Promise.resolve(); 
+                    return new Promise(function(resolve) {
                         var deleteRequest = indexedDB.deleteDatabase(dbName);
                         deleteRequest.onsuccess = function () {
                             console.debug('Deleted ' + dbName + '...');
@@ -214,7 +135,11 @@ function reset(object) {
                         };
                         deleteRequest.onerror = function (ev) {
                             console.error('Error deleting ' + dbName + '...', ev);
-                            resolve(); // Resolve even on error
+                            resolve();
+                        };
+                        deleteRequest.onblocked = function(ev) {
+                            console.warn('IDB delete blocked: ' + dbName, ev);
+                            resolve();
                         };
                     });
                 });
@@ -223,7 +148,7 @@ function reset(object) {
         }
     }
 
-    // 4. Clear any Cache API caches
+    // 4. Clear any Cache API caches - delete ALL caches (no filter)
     var cachePromise = Promise.resolve();
     if (!object || object === 'cacheAPI') {
         if ('caches' in window) {
@@ -246,19 +171,17 @@ function reset(object) {
     }
 
     // Wait for all async operations to complete before reloading
-    Promise.all([indexedDBPromise, cachePromise]).then(function () {
+    Promise.all([indexedDBPromise, cachePromise]).then(function() {
         if (shouldReload()) {
             _reloadApp();
         }
-    }).catch(function (err) {
+    }).catch(function(err) {
         console.error('Error during reset:', err);
         if (shouldReload()) {
             _reloadApp();
         }
     });
 }
-
-
 
 // Gets cache names from Service Worker, as we cannot rely on having them in params.cacheNames
 function getCacheNames(callback) {


### PR DESCRIPTION
## Problem
The reset function was not properly clearing the app cache and IndexedDB because:

1. **Cache deletion failed silently**: The code relied on `getCacheNames()` which queries the Service Worker. When no Service Worker controller was available, it returned `null` and skipped cache deletion entirely.

2. **Race condition**: The reset function triggered app reload before async cleanup operations (IndexedDB and Cache API deletions) completed, leaving data behind.

## Solution
- Changed cache deletion to use `caches.keys()` directly instead of querying the Service Worker, ensuring caches are always accessible
- Wrapped IndexedDB and Cache API deletions in Promises
- Used `Promise.all()` to wait for all async cleanup operations to complete before reloading the app
- This ensures both `kiwixjs-appCache` and `kiwixjs-assetsCache` are properly deleted, along with IndexedDB databases

## Testing
Verified that after clicking "Reset App":
- Cache storage drops from ~17MB to 0MB
- IndexedDB databases (`collDB`) are deleted
- App reloads only after all cleanup completes

Fixes #1136