### PR TITLE
Fix typo in URI param

### DIFF
--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -55,14 +55,8 @@ function getBestAvailableStorageAPI () {
     if (kiwixCookieTest && localStorageTest && regexpCookieKeysToMigrate.test(document.cookie)) _migrateStorageSettings();
     // Remove any deprecated keys
     deprecatedKeys.forEach(function (key) {
-        try{
         if (localStorageTest) localStorage.removeItem(keyPrefix + key);
         settingsStore.removeItem(key); // Because this runs before we have returned a store type, this will remove from cookie too
-        }
-        catch (e) {
-            console.warn('Failed to remove deprecated key: ' + key, e);
-        }
-        
     });
     // Note that if this function returns 'none', the cookie implementations below will run anyway. This is because storing a cookie
     // does not cause an exception even if cookies are blocked in some contexts, whereas accessing localStorage may cause an exception
@@ -298,15 +292,9 @@ function _migrateStorageSettings () {
     for (var i = 0; i < cookieKeys.length; i++) {
         if (regexpCookieKeysToMigrate.test(cookieKeys[i])) {
             var migratedKey = keyPrefix + cookieKeys[i];
-            try {
-            
             localStorage.setItem(migratedKey, settingsStore.getItem(cookieKeys[i]));
             settingsStore.removeItem(cookieKeys[i]);
             console.log('- ' + migratedKey);
-            }
-            catch( e ) {
-                console.warn('Failed to migrate key: ' + cookieKeys[i], e);
-            }
         }
     }
     console.log('Migration done.');

--- a/www/js/lib/settingsStore.js
+++ b/www/js/lib/settingsStore.js
@@ -55,8 +55,14 @@ function getBestAvailableStorageAPI () {
     if (kiwixCookieTest && localStorageTest && regexpCookieKeysToMigrate.test(document.cookie)) _migrateStorageSettings();
     // Remove any deprecated keys
     deprecatedKeys.forEach(function (key) {
+        try{
         if (localStorageTest) localStorage.removeItem(keyPrefix + key);
         settingsStore.removeItem(key); // Because this runs before we have returned a store type, this will remove from cookie too
+        }
+        catch (e) {
+            console.warn('Failed to remove deprecated key: ' + key, e);
+        }
+        
     });
     // Note that if this function returns 'none', the cookie implementations below will run anyway. This is because storing a cookie
     // does not cause an exception even if cookies are blocked in some contexts, whereas accessing localStorage may cause an exception
@@ -181,7 +187,7 @@ function _reloadApp () {
     if (~window.location.href.indexOf(params.PWAServer) && params.referrerExtensionURL) {
     // However, if we're in a PWA that was called from local code, then by definition we must remain in SW mode and we need to
     // ensure the user still has access to the referrerExtensionURL (so they can get back to local code from the UI)
-        uriParams = '?allowInternetAccess=truee&contentInjectionMode=serviceworker';
+        uriParams = '?allowInternetAccess=true&contentInjectionMode=serviceworker';
         uriParams += '&referrerExtensionURL=' + encodeURIComponent(params.referrerExtensionURL);
     }
     if (navigator && navigator.serviceWorker) {
@@ -292,9 +298,15 @@ function _migrateStorageSettings () {
     for (var i = 0; i < cookieKeys.length; i++) {
         if (regexpCookieKeysToMigrate.test(cookieKeys[i])) {
             var migratedKey = keyPrefix + cookieKeys[i];
+            try {
+            
             localStorage.setItem(migratedKey, settingsStore.getItem(cookieKeys[i]));
             settingsStore.removeItem(cookieKeys[i]);
             console.log('- ' + migratedKey);
+            }
+            catch( e ) {
+                console.warn('Failed to migrate key: ' + cookieKeys[i], e);
+            }
         }
     }
     console.log('Migration done.');


### PR DESCRIPTION
### **Problem**
The settings storage logic had a typo and lacked proper error handling during storage operations.

Typo in URI parameter: The allowInternetAccess parameter was incorrectly set to truee, which could prevent the flag from being recognized correctly by code expecting true.

Storage operations could fail silently: The removal of deprecated keys and the cookie → localStorage migration were performed without error handling. If a storage operation threw an exception (e.g., localStorage quota exceeded or browser storage restrictions), the script could stop executing and leave some keys unmigrated or undeleted.

Migration interruption: During _migrateStorageSettings(), a failure when writing a specific key to localStorage could stop the entire migration process, leaving remaining cookies unmigrated.
This ensures migration continues even if a specific key fails due to
storage quota limits, malformed cookie values, or browser storage restrictions.    
### **Solution**

- Fixed the typo in the URI parameter (truee → true) so the allowInternetAccess flag is interpreted correctly.
- Added try–catch blocks around deprecated key removal to prevent the script from stopping if a storage operation fails.
- Added try–catch handling during cookie → localStorage migration so that migration continues even if a specific key fails.
- Logged failures using console.warn to aid debugging while ensuring the rest of the cleanup and migration process continues.

Fixes #1419