### PR TITLE
Fix navbar and footer overlapping with ZIM page content (Fixes #1432)

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -31,6 +31,7 @@
 [role=region] > header {
      margin-bottom: 12px;
      text-align: center;
+     background-color: #f8f9fa;
 }
 [role=region] > header > h1 {
     margin: 0;
@@ -41,7 +42,7 @@
     position: relative; /*Fixes #250 Random button display bug in W10M */
 }
 [role=region] > footer {
-    background: rgba(0,0,0,.2);
+    background: #e9ecef;
     right: 0;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
## Description

This PR fixes #1432 where the Kiwix navigation bar and bottom footer overlap with ZIM page content (e.g., cookie consent bars), making both the Kiwix UI and the underlying page unreadable.

### Problem

- The bottom navigation bar (footer) used a **semi-transparent background** (`rgba(0,0,0,.2)` — only 20% opaque), allowing ZIM page content to bleed through
- The top header container (`#top`) had **no explicit background**, so content could also show through the search bar area
- This caused **click-through confusion**: clicking Kiwix nav buttons could accidentally trigger ZIM page elements underneath (and vice versa)

### Solution

Made both the header and footer backgrounds **fully opaque** using standard Bootstrap 4 palette colours:

| Element | Before | After |
|---------|--------|-------|
| Footer (`[role=region] > footer`) | `rgba(0,0,0,.2)` | `#e9ecef` |
| Header (`[role=region] > header`) | *(no background)* | `#f8f9fa` |

- `#f8f9fa` matches Bootstrap's `bg-light` class already used on the `<nav>` element
- `#e9ecef` is a standard Bootstrap 4 light grey
- Dark mode is handled automatically — the existing CSS rule applies `filter: invert(1) hue-rotate(180deg)` to both header and footer, which correctly inverts these opaque colours

### Testing

- Tested source code with `npm run serve` in both **Firefox** and **Chromium (Edge)**
- Verified header and footer are fully opaque in both **light and dark modes**
- Verified **slide-away behaviour** still works correctly
- Confirmed no ZIM content is visible through the navigation bars
- Verified footer buttons (Home, Back, Forward, Top) remain clearly visible and clickable
- Tested in both **ServiceWorker** and **Restricted** modes
