### PR TITLE
Update release/nightly uploads for new destination

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -51,7 +51,7 @@ jobs:
       # Set up secret files from encrypted secrets
       - name: Set up secret files and copy needed scripts to dist
         env:
-          KIWIX_FILE_UPLOAD_SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
+          KIWIX_FILE_UPLOAD_SSH_KEY: ${{ secrets.KIWIXJS_FILE_UPLOAD_KEY }}
           CHROME_EXTENSION_KEY: ${{ secrets.CHROME_EXTENSION_KEY }}
         shell: bash
         run: |

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -141,8 +141,8 @@ fi
 if [ -z "${DRYRUN}" ]; then
     # Upload the files on master.download.kiwix.org
     echo -e "\nUploading the files to https://download.kiwix.org/nightly/$CURRENT_DATE/"
-    echo "mkdir /data/download/nightly/$CURRENT_DATE" | sftp -P 30022 -o StrictHostKeyChecking=no -i ./scripts/ssh_key ci@master.download.kiwix.org
-    scp -P 30022 -r -p -o StrictHostKeyChecking=no -i ./scripts/ssh_key build/* ci@master.download.kiwix.org:/data/download/nightly/$CURRENT_DATE
+    echo "mkdir /data/download/nightly/$CURRENT_DATE" | sftp -P 30322 -o StrictHostKeyChecking=no -i ./scripts/ssh_key kiwix-js@master.download.kiwix.org
+    scp -P 30322 -r -p -o StrictHostKeyChecking=no -i ./scripts/ssh_key build/* kiwix-js@master.download.kiwix.org:/data/download/nightly/$CURRENT_DATE
 else
     echo -e "\n[DRYRUN] Would have uploaded these files to https://download.kiwix.org/nightly/$CURRENT_DATE/ :\n"
     ls -l build/*
@@ -151,10 +151,10 @@ fi
 if [ -n "$TAG" ]; then
     if [ -z "${DRYRUN}" ]; then
         echo -e "\nUploading the files to https://download.kiwix.org/release/"
-        scp -P 30022 -r -p -o StrictHostKeyChecking=no -i ./scripts/ssh_key build/kiwix-firefoxos* ci@master.download.kiwix.org:/data/download/release/firefox-os
-        scp -P 30022 -r -p -o StrictHostKeyChecking=no -i ./scripts/ssh_key build/kiwix-ubuntu-touch* ci@master.download.kiwix.org:/data/download/release/ubuntu-touch
-        scp -P 30022 -r -p -o StrictHostKeyChecking=no -i ./scripts/ssh_key build/kiwix-chrome-signed*mv2*.zip ci@master.download.kiwix.org:/data/download/release/browsers/chrome/kiwix-chrome-mv2_$VERSION.zip
-        scp -P 30022 -r -p -o StrictHostKeyChecking=no -i ./scripts/ssh_key build/kiwix-chrome-signed*mv2*.zip ci@master.download.kiwix.org:/data/download/release/browsers/edge/kiwix-edge-mv2_$VERSION.zip
+        scp -P 30322 -r -p -o StrictHostKeyChecking=no -i ./scripts/ssh_key build/kiwix-firefoxos* kiwix-js@master.download.kiwix.org:/data/download/release/firefox-os
+        scp -P 30322 -r -p -o StrictHostKeyChecking=no -i ./scripts/ssh_key build/kiwix-ubuntu-touch* kiwix-js@master.download.kiwix.org:/data/download/release/ubuntu-touch
+        scp -P 30322 -r -p -o StrictHostKeyChecking=no -i ./scripts/ssh_key build/kiwix-chrome-signed*mv2*.zip kiwix-js@master.download.kiwix.org:/data/download/release/browsers/chrome/kiwix-chrome-mv2_$VERSION.zip
+        scp -P 30322 -r -p -o StrictHostKeyChecking=no -i ./scripts/ssh_key build/kiwix-chrome-signed*mv2*.zip kiwix-js@master.download.kiwix.org:/data/download/release/browsers/edge/kiwix-edge-mv2_$VERSION.zip
     else
         echo -e "\n[DRRUN] Would have uploaded these files to https://download.kiwix.org/release/ :\n"
         ls -l build/kiwix-firefoxos*

--- a/scripts/package_firefox_extension.sh
+++ b/scripts/package_firefox_extension.sh
@@ -51,13 +51,13 @@ if [ "${TAG}zz" == "zz" ]; then
             # echo "It might be because this commit id has already been signed : let's look for it in a previous nightly build"
             # FOUND=0
             # FNAME="kiwix-firefox-signed-extension-${VERSION}.xpi"
-            # REMOTE="ci@master.download.kiwix.org:/data/download/nightly/"
-            # for DATE in $(echo "ls -1" | sftp -P 30022 -i ../scripts/ssh_key -o 'StrictHostKeyChecking=no' $REMOTE |grep -E "^\d{4}-\d{2}-\d{2}$"); do
+            # REMOTE="kiwix-js@master.download.kiwix.org:/data/download/nightly/"
+            # for DATE in $(echo "ls -1" | sftp -P 30322 -i ../scripts/ssh_key -o 'StrictHostKeyChecking=no' $REMOTE |grep -E "^\d{4}-\d{2}-\d{2}$"); do
             #     echo "Checking ${DATE}..."
-            #     REMOTEPATH="ci@master.download.kiwix.org:/data/download/nightly/${DATE}"
-            #     FILE=$(echo "ls ${FNAME}" | sftp -P 30022 -i ../scripts/ssh_key -o 'StrictHostKeyChecking=no' $REMOTEPATH 2> /dev/null |grep $FNAME |grep -vE "^sftp")
+            #     REMOTEPATH="kiwix-js@master.download.kiwix.org:/data/download/nightly/${DATE}"
+            #     FILE=$(echo "ls ${FNAME}" | sftp -P 30322 -i ../scripts/ssh_key -o 'StrictHostKeyChecking=no' $REMOTEPATH 2> /dev/null |grep $FNAME |grep -vE "^sftp")
             #     if [ ! -z "$FILE" ]; then
-            #         scp -P 30022 -o StrictHostKeyChecking=no -i ../scripts/ssh_key $REMOTEPATH/$FILE ./
+            #         scp -P 30322 -o StrictHostKeyChecking=no -i ../scripts/ssh_key $REMOTEPATH/$FILE ./
             #         FOUND=1
             #         # We only need the first matching file
             #         break


### PR DESCRIPTION
As part of a server/infra change, the upload of nightly and release builds is done to a new destination.

The receiving service now uses per-project (well per-repo) users with independent SSH Keys. Each users now only has access to the folders in which it is expected to upload files.

- Host remains the same: `master.download.kiwix.org`
- Username changes from `ci` to `kiwix-js`
- Port changes from `30022` to `30322`
- Paths remains the same

⚠️ DO NOT MERGE ATM