### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/www/article.html
+++ b/www/article.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: file: blob: about: https://browser-extension.kiwix.org https://kiwix.github.io 'unsafe-inline' 'unsafe-eval';">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: file: blob: about: https://browser-extension.kiwix.org https://kiwix.github.io;">
         <meta name="description" content="Placeholder for injecting an article into the iframe or window">
     </head>
     <body></body>

--- a/www/library.html
+++ b/www/library.html
@@ -5,7 +5,7 @@
     <title>Placeholder for injecting an article into the iframe</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' data: * 'unsafe-inline' 'unsafe-eval'; frame-src 'self' moz-extension: chrome-extension: *; object-src 'none';"
+      content="default-src 'self' data:; frame-src 'self' moz-extension: chrome-extension:; object-src 'none';"
     />
   </head>
   <body>


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `www/library.html:L7`

www/library.html contains a CSP with '*' in default-src and 'unsafe-inline' 'unsafe-eval' which allows any external source and disables browser XSS protections. The wildcard '*' in default-src is particularly dangerous as it allows scripts from any origin.

## Solution

Replace '*' with specific allowed origins. Remove 'unsafe-inline' and 'unsafe-eval' if possible, or use nonces/hashes for inline scripts.

## Changes

- `www/library.html` (modified)
- `www/article.html` (modified)