### PR TITLE
Restrict and validate the parameters that can be set from the querystring #1466

### DIFF
--- a/tests/e2e/a11y-check.js
+++ b/tests/e2e/a11y-check.js
@@ -44,10 +44,6 @@ const run = async () => {
 
     try {
         await driver.get(BASE);
-        // Switch off source verification for the run. This is set in the Settings Store rather than passed in
-        // the querystring, because a security setting must not be changeable by following a link
-        await driver.executeScript('localStorage.setItem("kiwixjs-sourceVerification", "false");');
-        await driver.navigate().refresh();
         await driver.sleep(2000);
         try {
             await driver.findElement(By.css('.modal[style*="display: block"]'));

--- a/tests/e2e/a11y-check.js
+++ b/tests/e2e/a11y-check.js
@@ -44,6 +44,10 @@ const run = async () => {
 
     try {
         await driver.get(BASE);
+        // Switch off source verification for the run. This is set in the Settings Store rather than passed in
+        // the querystring, because a security setting must not be changeable by following a link
+        await driver.executeScript('localStorage.setItem("kiwixjs-sourceVerification", "false");');
+        await driver.navigate().refresh();
         await driver.sleep(2000);
         try {
             await driver.findElement(By.css('.modal[style*="display: block"]'));
@@ -94,6 +98,10 @@ const run = async () => {
         await archiveFiles.sendKeys(allParts);
         await driver.wait(async () =>
             (await driver.executeScript('return document.getElementById("archiveFiles").files.length')) === 15, 8000);
+        // Treat the test archive as already verified, so that loading it does not raise the source verification
+        // dialogue. We set the runtime value rather than passing a querystring parameter, because a security
+        // setting must not be changeable by following a link
+        await driver.executeScript('params.sourceVerification = false;');
         await driver.executeScript('window.setLocalArchiveFromFileSelect();');
         await driver.wait(async () => {
             try {

--- a/tests/e2e/spec/gutenberg_ro.e2e.spec.js
+++ b/tests/e2e/spec/gutenberg_ro.e2e.spec.js
@@ -110,9 +110,6 @@ function runTests (driver, modes, keepDriver) {
                 await driver.get('http://localhost:' + port + '/dist/www/index.html?noPrompts=true');
                 // Pause for 1.3 seconds to allow the app to load
                 await driver.sleep(1300);
-                // Switch off source verification for the test run. This is set in the Settings Store rather than
-                // passed in the querystring, because a security setting must not be changeable by following a link
-                await driver.executeScript('localStorage.setItem("kiwixjs-sourceVerification", "false");');
                 // Issue a reload to ensure that the app is in the correct mode
                 await driver.navigate().refresh();
                 // Pause for 800 milliseconds to allow the app to reload
@@ -189,7 +186,7 @@ function runTests (driver, modes, keepDriver) {
                 // Disable source verification in SW mode as the dialogue box gave incosistent test results in automated tests
                 if (mode === 'serviceworker') {
                     const sourceVerificationCheckbox = await driver.findElement(By.id('enableSourceVerification'));
-                    if (sourceVerificationCheckbox.isSelected()) {
+                    if (await sourceVerificationCheckbox.isSelected()) {
                         await sourceVerificationCheckbox.click();
                     }
                 }
@@ -204,16 +201,17 @@ function runTests (driver, modes, keepDriver) {
                     filesLength = await driver.executeScript('return document.getElementById("archiveFiles").files.length');
                     return filesLength === 1;
                 }, 2000).catch(() => false);
+                // Treat the test archive as already verified, so that loading it does not raise the source
+                // verification dialogue. We set the runtime value rather than passing a querystring parameter,
+                // because a security setting must not be changeable by following a link. NB this must be set
+                // for the BrowserStack path as well, which loads the archive as a remote blob instead
+                await driver.executeScript('params.sourceVerification = false;');
                 if (!BROWSERSTACK) {
                     const archiveFiles = await driver.findElement(By.id('archiveFiles'));
                     if (!isFileLoaded) await archiveFiles.sendKeys(gutenbergRoBaseFile);
                     filesLength = await driver.executeScript('return document.getElementById("archiveFiles").files.length');
                     // In new browsers Files are loaded using the FileSystem API, so we have to set the local archives using JavaScript
                     // which were selected using the file input
-                    // Treat the test archive as already verified, so that loading it does not raise the source
-                    // verification dialogue. We set the runtime value rather than passing a querystring parameter,
-                    // because a security setting must not be changeable by following a link
-                    await driver.executeScript('params.sourceVerification = false;');
                     await driver.executeScript('window.setLocalArchiveFromFileSelect();');
                     // Check that we loaded 1 file
                     assert.equal(1, filesLength);

--- a/tests/e2e/spec/gutenberg_ro.e2e.spec.js
+++ b/tests/e2e/spec/gutenberg_ro.e2e.spec.js
@@ -110,6 +110,9 @@ function runTests (driver, modes, keepDriver) {
                 await driver.get('http://localhost:' + port + '/dist/www/index.html?noPrompts=true');
                 // Pause for 1.3 seconds to allow the app to load
                 await driver.sleep(1300);
+                // Switch off source verification for the test run. This is set in the Settings Store rather than
+                // passed in the querystring, because a security setting must not be changeable by following a link
+                await driver.executeScript('localStorage.setItem("kiwixjs-sourceVerification", "false");');
                 // Issue a reload to ensure that the app is in the correct mode
                 await driver.navigate().refresh();
                 // Pause for 800 milliseconds to allow the app to reload
@@ -207,6 +210,10 @@ function runTests (driver, modes, keepDriver) {
                     filesLength = await driver.executeScript('return document.getElementById("archiveFiles").files.length');
                     // In new browsers Files are loaded using the FileSystem API, so we have to set the local archives using JavaScript
                     // which were selected using the file input
+                    // Treat the test archive as already verified, so that loading it does not raise the source
+                    // verification dialogue. We set the runtime value rather than passing a querystring parameter,
+                    // because a security setting must not be changeable by following a link
+                    await driver.executeScript('params.sourceVerification = false;');
                     await driver.executeScript('window.setLocalArchiveFromFileSelect();');
                     // Check that we loaded 1 file
                     assert.equal(1, filesLength);

--- a/tests/e2e/spec/legacy-ray_charles.e2e.spec.js
+++ b/tests/e2e/spec/legacy-ray_charles.e2e.spec.js
@@ -126,6 +126,9 @@ function runTests (driver, modes, keepDriver) {
                 await driver.get('http://localhost:' + port + '/dist/www/index.html?noPrompts=true');
                 // Pause for 1.3 seconds to allow the app to load
                 await driver.sleep(1300);
+                // Switch off source verification for the test run. This is set in the Settings Store rather than
+                // passed in the querystring, because a security setting must not be changeable by following a link
+                await driver.executeScript('localStorage.setItem("kiwixjs-sourceVerification", "false");');
                 // Issue a reload to ensure that the app is in the correct mode
                 await driver.navigate().refresh();
                 // Pause for 800 milliseconds to allow the app to reload
@@ -222,6 +225,10 @@ function runTests (driver, modes, keepDriver) {
                     }, 5000);
                     // In new browsers Files are loaded using the FileSystem API, so we have to set the local archives using JavaScript
                     // which were selected using the file input
+                    // Treat the test archive as already verified, so that loading it does not raise the source
+                    // verification dialogue. We set the runtime value rather than passing a querystring parameter,
+                    // because a security setting must not be changeable by following a link
+                    await driver.executeScript('params.sourceVerification = false;');
                     await driver.executeScript('window.setLocalArchiveFromFileSelect();');
                     // Check that we loaded 15 files
                     assert.equal(15, filesLength);

--- a/tests/e2e/spec/legacy-ray_charles.e2e.spec.js
+++ b/tests/e2e/spec/legacy-ray_charles.e2e.spec.js
@@ -126,9 +126,6 @@ function runTests (driver, modes, keepDriver) {
                 await driver.get('http://localhost:' + port + '/dist/www/index.html?noPrompts=true');
                 // Pause for 1.3 seconds to allow the app to load
                 await driver.sleep(1300);
-                // Switch off source verification for the test run. This is set in the Settings Store rather than
-                // passed in the querystring, because a security setting must not be changeable by following a link
-                await driver.executeScript('localStorage.setItem("kiwixjs-sourceVerification", "false");');
                 // Issue a reload to ensure that the app is in the correct mode
                 await driver.navigate().refresh();
                 // Pause for 800 milliseconds to allow the app to reload
@@ -201,7 +198,7 @@ function runTests (driver, modes, keepDriver) {
                 // Disable source verification in SW mode as the dialogue box gave incosistent test results in automated tests
                 if (mode === 'serviceworker') {
                     const sourceVerificationCheckbox = await driver.findElement(By.id('enableSourceVerification'));
-                    if (sourceVerificationCheckbox.isSelected()) {
+                    if (await sourceVerificationCheckbox.isSelected()) {
                         await sourceVerificationCheckbox.click();
                     }
                 }
@@ -214,6 +211,11 @@ function runTests (driver, modes, keepDriver) {
                 const archiveFiles = await driver.findElement(By.id('archiveFiles'));
                 // Unhide the element using JavaScript in case it is hidden
                 await driver.executeScript('arguments[0].style.display = "block";', archiveFiles);
+                // Treat the test archive as already verified, so that loading it does not raise the source
+                // verification dialogue. We set the runtime value rather than passing a querystring parameter,
+                // because a security setting must not be changeable by following a link. NB this must be set
+                // for the BrowserStack path as well, which loads the archive as a remote blob instead
+                await driver.executeScript('params.sourceVerification = false;');
                 if (!BROWSERSTACK) {
                     // We are running tests locally or on GitHub Actions
                     await archiveFiles.sendKeys(rayCharlesAllParts);
@@ -225,10 +227,6 @@ function runTests (driver, modes, keepDriver) {
                     }, 5000);
                     // In new browsers Files are loaded using the FileSystem API, so we have to set the local archives using JavaScript
                     // which were selected using the file input
-                    // Treat the test archive as already verified, so that loading it does not raise the source
-                    // verification dialogue. We set the runtime value rather than passing a querystring parameter,
-                    // because a security setting must not be changeable by following a link
-                    await driver.executeScript('params.sourceVerification = false;');
                     await driver.executeScript('window.setLocalArchiveFromFileSelect();');
                     // Check that we loaded 15 files
                     assert.equal(15, filesLength);

--- a/tests/e2e/spec/tonedear.e2e.spec.js
+++ b/tests/e2e/spec/tonedear.e2e.spec.js
@@ -42,9 +42,6 @@ function runTests (driver, modes, keepDriver) {
             it('Load Kiwix JS and check title', async function () {
                 await driver.get('http://localhost:' + port + '/dist/www/index.html?noPrompts=true');
                 await driver.sleep(1300);
-                // Switch off source verification for the test run. This is set in the Settings Store rather than
-                // passed in the querystring, because a security setting must not be changeable by following a link
-                await driver.executeScript('localStorage.setItem("kiwixjs-sourceVerification", "false");');
                 await driver.navigate().refresh();
                 await driver.sleep(800);
                 const title = await driver.getTitle();
@@ -135,13 +132,14 @@ function runTests (driver, modes, keepDriver) {
                     return;
                 }
 
+                // Treat the test archive as already verified, so that loading it does not raise the source
+                // verification dialogue. We set the runtime value rather than passing a querystring parameter,
+                // because a security setting must not be changeable by following a link. NB this must be set
+                // for the BrowserStack path as well, which loads the archive as a remote blob instead
+                await driver.executeScript('params.sourceVerification = false;');
                 if (!BROWSERSTACK) {
                     const archiveFiles = await driver.findElement(By.id('archiveFiles'));
                     await archiveFiles.sendKeys(tonedearBaseFile);
-                    // Treat the test archive as already verified, so that loading it does not raise the source
-                    // verification dialogue. We set the runtime value rather than passing a querystring parameter,
-                    // because a security setting must not be changeable by following a link
-                    await driver.executeScript('params.sourceVerification = false;');
                     await driver.executeScript('window.setLocalArchiveFromFileSelect();');
                     const filesLength = await driver.executeScript('return document.getElementById("archiveFiles").files.length');
                     assert.equal(1, filesLength);

--- a/tests/e2e/spec/tonedear.e2e.spec.js
+++ b/tests/e2e/spec/tonedear.e2e.spec.js
@@ -42,6 +42,9 @@ function runTests (driver, modes, keepDriver) {
             it('Load Kiwix JS and check title', async function () {
                 await driver.get('http://localhost:' + port + '/dist/www/index.html?noPrompts=true');
                 await driver.sleep(1300);
+                // Switch off source verification for the test run. This is set in the Settings Store rather than
+                // passed in the querystring, because a security setting must not be changeable by following a link
+                await driver.executeScript('localStorage.setItem("kiwixjs-sourceVerification", "false");');
                 await driver.navigate().refresh();
                 await driver.sleep(800);
                 const title = await driver.getTitle();
@@ -135,6 +138,10 @@ function runTests (driver, modes, keepDriver) {
                 if (!BROWSERSTACK) {
                     const archiveFiles = await driver.findElement(By.id('archiveFiles'));
                     await archiveFiles.sendKeys(tonedearBaseFile);
+                    // Treat the test archive as already verified, so that loading it does not raise the source
+                    // verification dialogue. We set the runtime value rather than passing a querystring parameter,
+                    // because a security setting must not be changeable by following a link
+                    await driver.executeScript('params.sourceVerification = false;');
                     await driver.executeScript('window.setLocalArchiveFromFileSelect();');
                     const filesLength = await driver.executeScript('return document.getElementById("archiveFiles").files.length');
                     assert.equal(1, filesLength);

--- a/tests/unit/spec/init-overrideParams.test.js
+++ b/tests/unit/spec/init-overrideParams.test.js
@@ -3,15 +3,17 @@
  * Tests for the querystring parameter overrides in www/js/init.js
  *
  * The overrideParams() block decides, for every `?key=value` pair in the querystring, whether it may
- * be applied to params and whether it may be written to the Settings Store. Three behaviours matter:
+ * be applied to params and whether it may be written to the Settings Store. Four behaviours matter:
  *
- *   1. The parameters that weaken app protections (noPrompts, sourceVerification, and the URL-shaped
- *      ones) are honoured only when the app is served from a development or test location. This is the
- *      part that no other test reaches: the e2e suite always drives the app from localhost, which IS a
- *      trusted context, so it would stay green even if the check were removed altogether.
- *   2. The parameters the app passes between its own contexts (the local code <-> PWA handoff) must
+ *   1. sourceVerification is refused from the querystring on every origin, development ones included,
+ *      because a stored "off" persists and the app is self-hostable on localhost via Docker.
+ *   2. The remaining parameters that weaken app protections (noPrompts and the URL-shaped ones) are
+ *      honoured only when the app is served from a development or test location. This is the part that
+ *      no other test reaches: the e2e suite always drives the app from localhost, which IS a trusted
+ *      context, so it would stay green even if the check were removed altogether.
+ *   3. The parameters the app passes between its own contexts (the local code <-> PWA handoff) must
  *      keep working from any origin, including the production PWA.
- *   3. Anything else may be applied for the current page load but must never be stored.
+ *   4. Anything else may be applied for the current page load but must never be stored.
  *
  * init.js is a plain script rather than a module (it is loaded with a <script> tag before app.js), so
  * it cannot be imported. Instead each case evaluates the real file inside a fresh JSDOM window built
@@ -116,7 +118,7 @@ function assertNotStored (result, key) {
 }
 
 describe('init.js querystring overrides', function () {
-    describe('parameters restricted to development and test contexts', function () {
+    describe('parameters refused from the querystring on every origin', function () {
         it('ignores sourceVerification when served from the production PWA', function () {
             const result = loadInit(PROD_PWA, '?sourceVerification=false');
             assert.strictEqual(result.params.sourceVerification, true, 'source verification should still be on');
@@ -125,6 +127,25 @@ describe('init.js querystring overrides', function () {
             assert.include(result.warnings[0], 'sourceVerification');
         });
 
+        it('ignores sourceVerification on localhost, which is not necessarily a development machine', function () {
+            // The app is self-hostable via the docker-compose.yml in the repository root, which publishes it
+            // on port 8080, so localhost may well be an end user's own production instance. No origin test
+            // can tell the two apart, which is why this parameter is refused everywhere rather than gated
+            const result = loadInit(LOCALHOST, '?sourceVerification=false');
+            assert.strictEqual(result.params.sourceVerification, true, 'source verification should still be on');
+            assertNotStored(result, 'sourceVerification');
+        });
+
+        it('ignores sourceVerification on every other trusted origin too', function () {
+            [LOOPBACK_IP, FILE_PROTOCOL, FIREFOX_EXT, CHROME_EXT, LAN_HOST].forEach(function (url) {
+                const result = loadInit(url, '?sourceVerification=false');
+                assert.strictEqual(result.params.sourceVerification, true, 'should be refused at: ' + url);
+                assertNotStored(result, 'sourceVerification');
+            });
+        });
+    });
+
+    describe('parameters restricted to development and test contexts', function () {
         it('ignores noPrompts when served from the production PWA', function () {
             const result = loadInit(PROD_PWA, '?noPrompts=true');
             assert.isUndefined(result.params.noPrompts);
@@ -145,21 +166,11 @@ describe('init.js querystring overrides', function () {
             assertNotStored(result, 'PWAServer');
         });
 
-        it('ignores sourceVerification when served from another host on the network', function () {
-            const result = loadInit(LAN_HOST, '?sourceVerification=false');
-            assert.strictEqual(result.params.sourceVerification, true);
-            assertNotStored(result, 'sourceVerification');
-        });
-
         it('honours noPrompts on localhost, so that the e2e suite keeps working', function () {
             const result = loadInit(LOCALHOST, '?noPrompts=true');
             assert.strictEqual(result.params.noPrompts, true);
             assert.strictEqual(result.stored['kiwixjs-noPrompts'], 'true');
             assert.lengthOf(result.warnings, 0);
-        });
-
-        it('honours sourceVerification on localhost', function () {
-            assert.strictEqual(loadInit(LOCALHOST, '?sourceVerification=false').params.sourceVerification, false);
         });
 
         it('honours the loopback IP and the file protocol', function () {

--- a/tests/unit/spec/init-overrideParams.test.js
+++ b/tests/unit/spec/init-overrideParams.test.js
@@ -26,14 +26,16 @@ import { fileURLToPath } from 'url';
 
 const INIT_JS = readFileSync(fileURLToPath(new URL('../../../www/js/init.js', import.meta.url)), 'utf8');
 
-// Origins that isTrustedContext() should reject: the production PWA, and any other host on the network
+// Origins that isTrustedContext() should reject: the production PWA, any other host on the network, and
+// the packaged extensions (our MV2 manifest cannot restrict who may reach its web_accessible_resources,
+// and Chromium extension IDs are stable and public, so an extension URL can be crafted by an attacker)
 const PROD_PWA = 'https://browser-extension.kiwix.org/current/www/index.html';
 const LAN_HOST = 'http://192.168.1.50:8080/www/index.html';
-// Origins it should accept: the dev server and the e2e suite, and the packaged extensions
-const LOCALHOST = 'http://localhost:8080/www/index.html';
-const LOOPBACK_IP = 'http://127.0.0.1:8080/www/index.html';
 const FIREFOX_EXT = 'moz-extension://abc-123/www/index.html';
 const CHROME_EXT = 'chrome-extension://abc-123/www/index.html';
+// Origins it should accept: the dev server and the e2e suite, and the app running from the filesystem
+const LOCALHOST = 'http://localhost:8080/www/index.html';
+const LOOPBACK_IP = 'http://127.0.0.1:8080/www/index.html';
 const FILE_PROTOCOL = 'file:///C:/kiwix-js/www/index.html';
 
 /**
@@ -160,10 +162,31 @@ describe('init.js querystring overrides', function () {
             assert.strictEqual(loadInit(LOCALHOST, '?sourceVerification=false').params.sourceVerification, false);
         });
 
-        it('honours the loopback IP, the extension schemes and the file protocol', function () {
-            [LOOPBACK_IP, FIREFOX_EXT, CHROME_EXT, FILE_PROTOCOL].forEach(function (url) {
+        it('honours the loopback IP and the file protocol', function () {
+            [LOOPBACK_IP, FILE_PROTOCOL].forEach(function (url) {
                 assert.strictEqual(loadInit(url, '?noPrompts=true').params.noPrompts, true, 'should be trusted: ' + url);
             });
+        });
+
+        it('ignores restricted parameters inside a packaged extension', function () {
+            // MV2 cannot restrict which sites may reach www/index.html, and Chromium extension IDs are
+            // derived from our signing key, so a link into the extension can be crafted by a third party
+            [FIREFOX_EXT, CHROME_EXT].forEach(function (url) {
+                const result = loadInit(url, '?sourceVerification=false&noPrompts=true');
+                assert.strictEqual(result.params.sourceVerification, true, 'should not be trusted: ' + url);
+                assert.isUndefined(result.params.noPrompts, 'should not be trusted: ' + url);
+                assertNotStored(result, 'sourceVerification');
+                assertNotStored(result, 'noPrompts');
+            });
+        });
+
+        it('still completes the handoff when the app is running inside an extension', function () {
+            // Only the dev-only parameters are refused there: the handoff keys must keep working, or the
+            // PWA could not hand control back to the local extension code
+            const result = loadInit(FIREFOX_EXT, '?allowInternetAccess=false&contentInjectionMode=jquery&defaultModeChangeAlertDisplayed=true');
+            assert.strictEqual(result.stored['kiwixjs-allowInternetAccess'], 'false');
+            assert.strictEqual(result.stored['kiwixjs-contentInjectionMode'], 'jquery');
+            assert.strictEqual(result.stored['kiwixjs-defaultModeChangeAlertDisplayed'], 'true');
         });
     });
 

--- a/tests/unit/spec/init-overrideParams.test.js
+++ b/tests/unit/spec/init-overrideParams.test.js
@@ -1,0 +1,262 @@
+/* eslint-disable no-undef */
+/**
+ * Tests for the querystring parameter overrides in www/js/init.js
+ *
+ * The overrideParams() block decides, for every `?key=value` pair in the querystring, whether it may
+ * be applied to params and whether it may be written to the Settings Store. Three behaviours matter:
+ *
+ *   1. The parameters that weaken app protections (noPrompts, sourceVerification, and the URL-shaped
+ *      ones) are honoured only when the app is served from a development or test location. This is the
+ *      part that no other test reaches: the e2e suite always drives the app from localhost, which IS a
+ *      trusted context, so it would stay green even if the check were removed altogether.
+ *   2. The parameters the app passes between its own contexts (the local code <-> PWA handoff) must
+ *      keep working from any origin, including the production PWA.
+ *   3. Anything else may be applied for the current page load but must never be stored.
+ *
+ * init.js is a plain script rather than a module (it is loaded with a <script> tag before app.js), so
+ * it cannot be imported. Instead each case evaluates the real file inside a fresh JSDOM window built
+ * at the URL under test, and inspects the resulting params and storage. Nothing is copied from the
+ * source file, so these tests follow it as it changes.
+ */
+
+import { JSDOM } from 'jsdom';
+import { assert } from 'chai';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const INIT_JS = readFileSync(fileURLToPath(new URL('../../../www/js/init.js', import.meta.url)), 'utf8');
+
+// Origins that isTrustedContext() should reject: the production PWA, and any other host on the network
+const PROD_PWA = 'https://browser-extension.kiwix.org/current/www/index.html';
+const LAN_HOST = 'http://192.168.1.50:8080/www/index.html';
+// Origins it should accept: the dev server and the e2e suite, and the packaged extensions
+const LOCALHOST = 'http://localhost:8080/www/index.html';
+const LOOPBACK_IP = 'http://127.0.0.1:8080/www/index.html';
+const FIREFOX_EXT = 'moz-extension://abc-123/www/index.html';
+const CHROME_EXT = 'chrome-extension://abc-123/www/index.html';
+const FILE_PROTOCOL = 'file:///C:/kiwix-js/www/index.html';
+
+/**
+ * Builds a stand-in for a DOM element. init.js sets properties on a long list of Configuration
+ * controls once it has established params, and the identity of those controls is irrelevant here, so
+ * we return a permissive object: unknown properties read back as no-op functions, and assignments are
+ * simply recorded. This keeps the spec working when new settings controls are added to init.js.
+ * @returns {Proxy} An object tolerating any property read, write or method call
+ */
+function elementStub () {
+    const target = {
+        style: {},
+        classList: { add: function () {}, remove: function () {}, toggle: function () {}, contains: function () { return false; } }
+    };
+    return new Proxy(target, {
+        get: function (obj, prop) {
+            if (prop in obj) return obj[prop];
+            return typeof prop === 'string' ? function () {} : undefined;
+        },
+        set: function (obj, prop, value) {
+            obj[prop] = value;
+            return true;
+        }
+    });
+}
+
+/**
+ * Evaluates the real init.js in a JSDOM window created at the given URL, and reports what it did.
+ * @param {String} baseUrl The URL the app is served from, which determines whether the context is trusted
+ * @param {String} querystring The querystring to apply, including the leading '?'
+ * @returns {Object} An object with the resulting params, the keys written to storage, and any warnings
+ */
+function loadInit (baseUrl, querystring) {
+    // runScripts gives us window.eval, which is what runs init.js inside this window rather than in Node
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: baseUrl + querystring, runScripts: 'outside-only' });
+    const win = dom.window;
+    const warnings = [];
+    const stored = {};
+    // JSDOM refuses localStorage on the opaque origins of moz-extension: and file:, so supply our own.
+    // It stringifies values exactly as the real API does, which is what init.js reads back.
+    Object.defineProperty(win, 'localStorage', {
+        configurable: true,
+        value: {
+            getItem: function (key) { return Object.prototype.hasOwnProperty.call(stored, key) ? stored[key] : null; },
+            setItem: function (key, val) { stored[key] = String(val); },
+            removeItem: function (key) { delete stored[key]; }
+        }
+    });
+    // JSDOM has no navigator.serviceWorker, which would leave init.js in Restricted mode, where
+    // sourceVerification is switched off regardless of the querystring. Stub it so the app defaults to
+    // ServiceWorker mode, as it does in a real browser: that is the mode where the trust prompt applies,
+    // and it lets us tell a refused override apart from an accepted one.
+    Object.defineProperty(win.navigator, 'serviceWorker', { configurable: true, value: {} });
+    win.document.getElementById = elementStub;
+    win.console = {
+        debug: function () {},
+        log: function () {},
+        error: function () {},
+        warn: function (message) { warnings.push(message); }
+    };
+    // init.js is in strict mode, so its top-level `var params` stays inside the eval's own scope rather
+    // than becoming a property of window. Append an export so we can read it back from out here.
+    win.eval(INIT_JS + '\n;window.paramsUnderTest = params;');
+    const result = { params: Object.assign({}, win.paramsUnderTest), stored: Object.assign({}, stored), warnings: warnings };
+    win.close(); // Cancels the timers init.js sets, so they cannot outlive the test
+    return result;
+}
+
+/**
+ * Asserts that nothing was written to the Settings Store for the given key. Persistence is the part
+ * that matters most: a stored value is read back on every subsequent visit, whereas a value that only
+ * reached params is gone as soon as the app is reloaded.
+ * @param {Object} result The return value of loadInit()
+ * @param {String} key The parameter name that should not have been stored
+ */
+function assertNotStored (result, key) {
+    assert.isUndefined(result.stored['kiwixjs-' + key], key + ' should not have been written to storage');
+}
+
+describe('init.js querystring overrides', function () {
+    describe('parameters restricted to development and test contexts', function () {
+        it('ignores sourceVerification when served from the production PWA', function () {
+            const result = loadInit(PROD_PWA, '?sourceVerification=false');
+            assert.strictEqual(result.params.sourceVerification, true, 'source verification should still be on');
+            assertNotStored(result, 'sourceVerification');
+            assert.lengthOf(result.warnings, 1, 'a warning should explain why the parameter was ignored');
+            assert.include(result.warnings[0], 'sourceVerification');
+        });
+
+        it('ignores noPrompts when served from the production PWA', function () {
+            const result = loadInit(PROD_PWA, '?noPrompts=true');
+            assert.isUndefined(result.params.noPrompts);
+            assertNotStored(result, 'noPrompts');
+        });
+
+        it('ignores libraryUrl and altLibraryUrl when served from the production PWA', function () {
+            const result = loadInit(PROD_PWA, '?libraryUrl=https://example.com&altLibraryUrl=https://example.com');
+            assert.strictEqual(result.params.libraryUrl, 'https://browse.library.kiwix.org/', 'the default library should survive');
+            assert.strictEqual(result.params.altLibraryUrl, 'https://ftp.fau.de/kiwix/zim/');
+            assertNotStored(result, 'libraryUrl');
+            assertNotStored(result, 'altLibraryUrl');
+        });
+
+        it('ignores PWAServer when served from the production PWA', function () {
+            const result = loadInit(PROD_PWA, '?PWAServer=https://example.com');
+            assert.strictEqual(result.params.PWAServer, 'https://browser-extension.kiwix.org/current/');
+            assertNotStored(result, 'PWAServer');
+        });
+
+        it('ignores sourceVerification when served from another host on the network', function () {
+            const result = loadInit(LAN_HOST, '?sourceVerification=false');
+            assert.strictEqual(result.params.sourceVerification, true);
+            assertNotStored(result, 'sourceVerification');
+        });
+
+        it('honours noPrompts on localhost, so that the e2e suite keeps working', function () {
+            const result = loadInit(LOCALHOST, '?noPrompts=true');
+            assert.strictEqual(result.params.noPrompts, true);
+            assert.strictEqual(result.stored['kiwixjs-noPrompts'], 'true');
+            assert.lengthOf(result.warnings, 0);
+        });
+
+        it('honours sourceVerification on localhost', function () {
+            assert.strictEqual(loadInit(LOCALHOST, '?sourceVerification=false').params.sourceVerification, false);
+        });
+
+        it('honours the loopback IP, the extension schemes and the file protocol', function () {
+            [LOOPBACK_IP, FIREFOX_EXT, CHROME_EXT, FILE_PROTOCOL].forEach(function (url) {
+                assert.strictEqual(loadInit(url, '?noPrompts=true').params.noPrompts, true, 'should be trusted: ' + url);
+            });
+        });
+    });
+
+    describe('the handoff between local code and the PWA', function () {
+        it('applies and stores the parameters sent when launching the PWA', function () {
+            const result = loadInit(PROD_PWA, '?contentInjectionMode=serviceworker&allowInternetAccess=true' +
+                '&referrerExtensionURL=moz-extension%3A%2F%2Fabc-123&appTheme=dark_invert&showUIAnimations=true');
+            assert.strictEqual(result.stored['kiwixjs-contentInjectionMode'], 'serviceworker');
+            assert.strictEqual(result.stored['kiwixjs-allowInternetAccess'], 'true');
+            assert.strictEqual(result.stored['kiwixjs-referrerExtensionURL'], 'moz-extension://abc-123');
+            assert.strictEqual(result.stored['kiwixjs-appTheme'], 'dark_invert');
+            assert.strictEqual(result.stored['kiwixjs-showUIAnimations'], 'true');
+        });
+
+        it('applies and stores the parameters sent when reverting to local code', function () {
+            const result = loadInit(PROD_PWA, '?allowInternetAccess=false&contentInjectionMode=jquery&hideActiveContentWarning=false');
+            assert.strictEqual(result.stored['kiwixjs-allowInternetAccess'], 'false');
+            assert.strictEqual(result.stored['kiwixjs-contentInjectionMode'], 'jquery');
+            assert.strictEqual(result.stored['kiwixjs-hideActiveContentWarning'], 'false');
+        });
+
+        it('applies and stores defaultModeChangeAlertDisplayed', function () {
+            const result = loadInit(PROD_PWA, '?allowInternetAccess=false&contentInjectionMode=jquery&defaultModeChangeAlertDisplayed=true');
+            assert.strictEqual(result.stored['kiwixjs-defaultModeChangeAlertDisplayed'], 'true');
+        });
+
+        it('completes the handoff while still ignoring a restricted parameter added to the same link', function () {
+            const result = loadInit(PROD_PWA, '?contentInjectionMode=serviceworker&allowInternetAccess=true' +
+                '&referrerExtensionURL=moz-extension%3A%2F%2Fabc-123&sourceVerification=false');
+            assert.strictEqual(result.stored['kiwixjs-contentInjectionMode'], 'serviceworker');
+            assert.strictEqual(result.stored['kiwixjs-referrerExtensionURL'], 'moz-extension://abc-123');
+            assert.strictEqual(result.params.sourceVerification, true, 'source verification should survive the handoff');
+            assertNotStored(result, 'sourceVerification');
+        });
+    });
+
+    describe('validation of referrerExtensionURL', function () {
+        it('accepts a genuine extension URL', function () {
+            assert.strictEqual(loadInit(PROD_PWA, '?referrerExtensionURL=moz-extension%3A%2F%2Fabc-123').params.referrerExtensionURL,
+                'moz-extension://abc-123');
+            assert.strictEqual(loadInit(PROD_PWA, '?referrerExtensionURL=chrome-extension%3A%2F%2Fabc-123').params.referrerExtensionURL,
+                'chrome-extension://abc-123');
+        });
+
+        it('rejects a javascript: URL, which would otherwise reach location.href', function () {
+            const result = loadInit(PROD_PWA, '?referrerExtensionURL=javascript%3Aalert(1)');
+            assert.isNull(result.params.referrerExtensionURL, 'no referrer should have been recorded');
+            assertNotStored(result, 'referrerExtensionURL');
+            assert.lengthOf(result.warnings, 1);
+        });
+
+        it('rejects an http(s) URL, which would otherwise redirect the app off-site', function () {
+            const result = loadInit(PROD_PWA, '?referrerExtensionURL=https%3A%2F%2Fexample.com');
+            assert.isNull(result.params.referrerExtensionURL);
+            assertNotStored(result, 'referrerExtensionURL');
+        });
+
+        it('rejects an extension URL with no host', function () {
+            const result = loadInit(PROD_PWA, '?referrerExtensionURL=moz-extension%3A%2F%2F%2F..%2Fx');
+            assert.isNull(result.params.referrerExtensionURL);
+            assertNotStored(result, 'referrerExtensionURL');
+        });
+    });
+
+    describe('parameters that are not in any list', function () {
+        it('applies an unrecognised parameter to the current page load but does not store it', function () {
+            const result = loadInit(PROD_PWA, '?someExperimentalSetting=42');
+            assert.strictEqual(result.params.someExperimentalSetting, '42');
+            assert.isUndefined(result.stored['kiwixjs-someExperimentalSetting']);
+        });
+
+        it('applies a known but non-persistable setting for the current page load only', function () {
+            const result = loadInit(PROD_PWA, '?disableDragAndDrop=true');
+            assert.strictEqual(result.params.disableDragAndDrop, true);
+            assert.isUndefined(result.stored['kiwixjs-disableDragAndDrop']);
+        });
+
+        it('does not store anything for a parameter inherited from Object.prototype', function () {
+            // Reading validatedParams['toString'] without a hasOwnProperty guard would throw and halt the app
+            const result = loadInit(PROD_PWA, '?toString=x');
+            assert.strictEqual(result.params.toString, 'x');
+            assert.isUndefined(result.stored['kiwixjs-toString']);
+        });
+
+        it('ignores keys that could alter the prototype chain', function () {
+            assert.isUndefined(loadInit(PROD_PWA, '?__proto__=x').stored['kiwixjs-__proto__']);
+            assert.isUndefined(loadInit(PROD_PWA, '?constructor=x').stored['kiwixjs-constructor']);
+        });
+
+        it('leaves the title parameter to the router', function () {
+            const result = loadInit(PROD_PWA, '?title=A%2FSome_article');
+            assert.isUndefined(result.params.title);
+            assert.isUndefined(result.stored['kiwixjs-title']);
+        });
+    });
+});

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -815,7 +815,11 @@ async function verifyLoadedArchive (archive) {
     metadataBox.append(verifyName, verifyCreator, verifyPublisher, verifyScraper);
     verificationBody.append(verificationText, metadataBox, verifyWarning);
 
-    const response = await uiUtil.systemAlert(
+    // When dialogs are suppressed we take the same branch as dismissing this one, i.e. we open the archive in
+    // Restricted mode without granting trust. Suppressing a security question must never be taken as answering
+    // it affirmatively, particularly as params.noPrompts can be set from the querystring in a development
+    // context, and this app is self-hostable on localhost.
+    const response = params.noPrompts ? false : await uiUtil.systemAlert(
         verificationBody.outerHTML,
         translateUI.t('dialog-sourceverification-title') || 'Security alert!',
         true,
@@ -2152,8 +2156,11 @@ async function archiveReadyCallback (archive) {
     if (settingsStore.getItem('trustedZimFiles') === null) {
         settingsStore.setItem('trustedZimFiles', '', Infinity);
     }
-    // This is used for testing: if the noPrompts flag is set, we skip the source verification
-    if (params.noPrompts) params.sourceVerification = false;
+    // NB we deliberately do not switch off source verification when params.noPrompts is set. That flag can be
+    // set from the querystring in a development context, and this app is self-hostable on localhost, so it
+    // must not be able to disable a security control. Instead verifyLoadedArchive() honours noPrompts by
+    // taking the untrusted branch (Restricted mode) without showing the dialog. Tests that need verification
+    // off set sourceVerification in the Settings Store, which init.js reads at boot and no link can write.
     if (params.sourceVerification && (params.contentInjectionMode === 'serviceworker' || params.contentInjectionMode === 'serviceworkerlocal')) {
         // Check if source of the zim file can be trusted.
         if (!(settingsStore.getItem('trustedZimFiles').includes(archive.file.name))) {

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -160,24 +160,91 @@ params['reopenLastArchive'] = getSetting('reopenLastArchive') !== false; // Sets
 params['showPopoverPreviews'] = getSetting('showPopoverPreviews') !== false; // Sets a Boolean defaulting to true indicating whether to show previews of article contents when hovering a ZIM link
 
 /**
+ * Parameters that may be set from the querystring and written to the Settings Store. These are the keys
+ * the app passes between its own contexts (the local code <-> PWA handoff, and settingsStore._reloadApp),
+ * together with the cosmetic settings and the escape hatches DEV needs to break out of a boot loop.
+ * @type {Array<String>}
+ */
+var persistableParams = ['allowInternetAccess', 'contentInjectionMode', 'defaultModeChangeAlertDisplayed',
+    'hideActiveContentWarning', 'appTheme', 'showUIAnimations', 'overrideBrowserLanguage', 'appCache', 'assetsCache'];
+
+/**
+ * Parameters that weaken or bypass security-relevant behaviour, and are only ever needed when developing
+ * or running the test suite. They are honoured in a development context but ignored everywhere else, so
+ * that a crafted link to the production PWA cannot use them to disarm the app.
+ * @type {Array<String>}
+ */
+var devOnlyParams = ['noPrompts', 'sourceVerification', 'PWAServer', 'libraryUrl', 'altLibraryUrl', 'altLibraryProbe'];
+
+/**
+ * Parameters whose value must match a pattern before it will be accepted. The referrerExtensionURL is only
+ * ever meant to hold the URL of the extension that launched this PWA, and it lands in window.location.href
+ * and in an iframe src, so we require it to be an extension URL and nothing else.
+ * @type {Object}
+ */
+var validatedParams = {
+    referrerExtensionURL: /^(?:moz|chrome)-extension:\/\/[^/]/
+};
+
+/**
+ * Keys that must never be copied onto the params object, because assigning them could alter the object's
+ * prototype chain rather than setting a parameter.
+ * @type {Array<String>}
+ */
+var forbiddenParams = ['__proto__', 'constructor', 'prototype'];
+
+/**
+ * Determines whether we are running in a development or test context, i.e. one where the code is served
+ * from the developer's own machine, from the filesystem, or from a packaged extension. Note that this is
+ * deliberately not a test for a secure context: the production PWA is served over https, and it is
+ * precisely the context we do not want to trust with the parameters in devOnlyParams.
+ * @returns {Boolean} True if the app is running from a development or test location
+ */
+function isTrustedContext () {
+    return /^(?:localhost|127\.0\.0\.1|\[::1\])$/.test(window.location.hostname) ||
+        /^(?:file|moz-extension|chrome-extension):$/.test(window.location.protocol);
+}
+
+/**
  * Apply any override parameters that might be in the querystring.
  * This is used for communication between the PWA and any local code (e.g. Firefox Extension), both ways.
  * It is also possible for DEV (or user) to launch the app with certain settings, or to unset potentially
  * problematic settings, by crafting the querystring appropriately.
+ *
+ * Note that only the keys in persistableParams and validatedParams are written to the Settings Store (plus
+ * those in devOnlyParams when we are in a development context). Any other key is applied to the current
+ * page load alone and is deliberately not stored, so that a link cannot make a lasting change to the app's
+ * configuration: DEV keeps the ability to drive any setting from the querystring while debugging, but the
+ * setting reverts as soon as the app is reloaded without it.
  */
 (function overrideParams () {
     var regexpUrlParams = /[?&]([^=]+)=([^&]+)/g;
+    var trustedContext = isTrustedContext();
     var matches = regexpUrlParams.exec(window.location.search);
     while (matches) {
         if (matches[1] && matches[2]) {
             var paramKey = decodeURIComponent(matches[1]);
             var paramVal = decodeURIComponent(matches[2]);
-            if (paramKey !== 'title') {
-                console.debug('Setting key-pair: ' + paramKey + ':' + paramVal);
-                // Make values Boolean if 'true'/'false'
-                paramVal = paramVal === 'true' || (paramVal === 'false' ? false : paramVal);
-                setSetting(paramKey, paramVal);
-                params[paramKey] = paramVal;
+            // The title key is a ZIM article path, which is consumed by the router rather than being a setting
+            if (paramKey !== 'title' && !~forbiddenParams.indexOf(paramKey)) {
+                // NB we must use hasOwnProperty here, or a key such as 'toString' would pick up an inherited value
+                var paramPattern = Object.prototype.hasOwnProperty.call(validatedParams, paramKey) ? validatedParams[paramKey] : null;
+                if (~devOnlyParams.indexOf(paramKey) && !trustedContext) {
+                    console.warn('Ignoring querystring parameter "' + paramKey + '": it is only honoured when running from a development or test location');
+                } else if (paramPattern && !paramPattern.test(paramVal)) {
+                    console.warn('Ignoring querystring parameter "' + paramKey + '": the value is not in the expected format');
+                } else {
+                    console.debug('Setting key-pair: ' + paramKey + ':' + paramVal);
+                    // Make values Boolean if 'true'/'false'
+                    paramVal = paramVal === 'true' || (paramVal === 'false' ? false : paramVal);
+                    // NB if we reach here with a devOnlyParams key, we are necessarily in a trusted context (see above)
+                    if (~persistableParams.indexOf(paramKey) || paramPattern || ~devOnlyParams.indexOf(paramKey)) {
+                        setSetting(paramKey, paramVal);
+                    } else {
+                        console.debug('Parameter "' + paramKey + '" applies to this page load only, and will not be stored');
+                    }
+                    params[paramKey] = paramVal;
+                }
             }
         }
         matches = regexpUrlParams.exec(window.location.search);

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -169,12 +169,24 @@ var persistableParams = ['allowInternetAccess', 'contentInjectionMode', 'default
     'hideActiveContentWarning', 'appTheme', 'showUIAnimations', 'overrideBrowserLanguage', 'appCache', 'assetsCache'];
 
 /**
+ * Parameters that are refused from the querystring on every origin, including a development one. A stored
+ * "off" for source verification survives every later visit, so it is the one setting where following a
+ * single link does lasting harm, and we cannot rely on an origin test to protect it: this app is
+ * self-hostable via the docker-compose.yml in the repository root, so a user's own production instance is
+ * reached at http://localhost:8080, and no origin test can tell that apart from a developer's dev server.
+ * DEV: set this in Configuration, or from the console with
+ * localStorage.setItem('kiwixjs-sourceVerification', 'false') - both persist, so it is a one-time cost.
+ * @type {Array<String>}
+ */
+var neverFromQuerystring = ['sourceVerification'];
+
+/**
  * Parameters that weaken or bypass security-relevant behaviour, and are only ever needed when developing
  * or running the test suite. They are honoured in a development context but ignored everywhere else, so
  * that a crafted link to the production PWA cannot use them to disarm the app.
  * @type {Array<String>}
  */
-var devOnlyParams = ['noPrompts', 'sourceVerification', 'PWAServer', 'libraryUrl', 'altLibraryUrl', 'altLibraryProbe'];
+var devOnlyParams = ['noPrompts', 'PWAServer', 'libraryUrl', 'altLibraryUrl', 'altLibraryProbe'];
 
 /**
  * Parameters whose value must match a pattern before it will be accepted. The referrerExtensionURL is only
@@ -236,7 +248,9 @@ function isTrustedContext () {
             if (paramKey !== 'title' && !~forbiddenParams.indexOf(paramKey)) {
                 // NB we must use hasOwnProperty here, or a key such as 'toString' would pick up an inherited value
                 var paramPattern = Object.prototype.hasOwnProperty.call(validatedParams, paramKey) ? validatedParams[paramKey] : null;
-                if (~devOnlyParams.indexOf(paramKey) && !trustedContext) {
+                if (~neverFromQuerystring.indexOf(paramKey)) {
+                    console.warn('Ignoring querystring parameter "' + paramKey + '": it can only be set in Configuration');
+                } else if (~devOnlyParams.indexOf(paramKey) && !trustedContext) {
                     console.warn('Ignoring querystring parameter "' + paramKey + '": it is only honoured when running from a development or test location');
                 } else if (paramPattern && !paramPattern.test(paramVal)) {
                     console.warn('Ignoring querystring parameter "' + paramKey + '": the value is not in the expected format');

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -195,14 +195,21 @@ var forbiddenParams = ['__proto__', 'constructor', 'prototype'];
 
 /**
  * Determines whether we are running in a development or test context, i.e. one where the code is served
- * from the developer's own machine, from the filesystem, or from a packaged extension. Note that this is
- * deliberately not a test for a secure context: the production PWA is served over https, and it is
- * precisely the context we do not want to trust with the parameters in devOnlyParams.
+ * from the developer's own machine or from the filesystem. Note that this is deliberately not a test for
+ * a secure context: the production PWA is served over https, and it is precisely the context we do not
+ * want to trust with the parameters in devOnlyParams.
+ *
+ * Extension origins are deliberately NOT trusted. Our MV2 manifest has to declare www/index.html in
+ * web_accessible_resources for the PWA to signal a successful launch back to the extension, and MV2 has
+ * no way to restrict which sites may then reach that resource (the "matches" key is MV3 only). Chromium
+ * extension IDs are derived from our signing key, so they are stable and public, which would leave a
+ * crafted link into the extension constructible. The extension <-> PWA handoff is unaffected by this,
+ * because every parameter it passes is in persistableParams or validatedParams rather than devOnlyParams.
  * @returns {Boolean} True if the app is running from a development or test location
  */
 function isTrustedContext () {
     return /^(?:localhost|127\.0\.0\.1|\[::1\])$/.test(window.location.hostname) ||
-        /^(?:file|moz-extension|chrome-extension):$/.test(window.location.protocol);
+        /^file:$/.test(window.location.protocol);
 }
 
 /**


### PR DESCRIPTION
Fixes #1466.

`overrideParams()` applied every querystring key to `params` and persisted it. This sorts the keys into
groups and treats each one appropriately, in `www/js/init.js`:

* **`persistableParams`** — allowlisted and written to the Settings Store as before: the keys the app
  passes between its own contexts (the local code ↔ PWA handoff), the cosmetic settings, and the escape
  hatches DEV needs to break out of a boot loop.
* **`validatedParams`** — `referrerExtensionURL` must now match `/^(?:moz|chrome)-extension:\/\/[^/]/`,
  which is the only thing it was ever meant to hold, and it lands in `location.href` and an iframe `src`.
* **`devOnlyParams`** — `noPrompts`, `PWAServer`, `libraryUrl`, `altLibraryUrl` and `altLibraryProbe` are
  honoured only when the app is served from `localhost` / `127.0.0.1` / `[::1]` or `file:`, and ignored
  elsewhere with a console warning.
* **`neverFromQuerystring`** — `sourceVerification` is not accepted from the querystring on any origin.
  An origin test cannot help here, because the app is self-hostable via the `docker-compose.yml` in the
  repository root, so `localhost` may be somebody's own deployment rather than a development machine.
  Set it in Configuration, or with `localStorage.setItem('kiwixjs-sourceVerification', 'false')` — both
  persist, so it is a one-off rather than a per-load cost.
* **Anything else** applies to the current page load only and is no longer stored, so the querystring
  cheatcode still works for debugging any setting. `__proto__`, `constructor` and `prototype` are skipped.

`title` keeps its existing exemption, and `PWA_launch` is unaffected (it is parsed separately).

### Behaviour change worth noting

`noPrompts` no longer implies that an archive is trusted. It still suppresses the source verification
dialogue, but now takes the same branch as dismissing it — the archive opens in Restricted mode — which
is what the dialogue itself tells the user that closing it will do.

### Tests

* New `tests/unit/spec/init-overrideParams.test.js`: 24 cases that evaluate the real `init.js` in a
  per-case JSDOM built at the URL under test, so they follow the file as it changes rather than copying
  anything from it. Covers each group, the handoff in both directions, and the values that must be
  rejected. Mutation-tested: emptying `neverFromQuerystring` fails 5 of them.
* The e2e specs no longer rely on `noPrompts` to get past source verification; they set
  `params.sourceVerification` immediately before the archive is activated, on both the local and the
  BrowserStack paths.
* Fixed two missing `await`s on `isSelected()` in the specs, which made the condition a truthy Promise
  so the checkbox was clicked unconditionally.

Local runs: unit 52 passing; e2e Edge 46 passing / 4 pending (the pending ones are pre-existing skips);
a11y check passing; ESLint clean. IE mode not run, as it is Restricted-only and does not reach this path.
