### PR TITLE
Fix contentInjectionMode handling: trust gate in ServiceWorkerLocal mode, and value validation #1469

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Please note that this application has changed its name over time.
 It was first called "Evopedia" (and was using the file format of Evopedia).
 Then it was renamed to "Kiwix HTML5" (and used the ZIM file format). Finally it was renamed "Kiwix JS".
 
+## Interim update Kiwix JS v4.3.4
+
+* SECURITY: The security prompt regarding the source of an archive now appears consistently in ServiceWorkerLocal mode
+* FIX: The content injection mode is now checked against the modes the app actually supports, so an unrecognised value can no longer leave the app in an invalid state
+* FIX: Users who had already chosen ServiceWorkerLocal mode are no longer shown the mode-change alert they had answered before
+* DEV: Added unit tests covering the trust setting across the content injection modes, and the validation of the mode value itself
+
 ## Interim update Kiwix JS v4.3.3
 
 * SECURITY: Settings supplied in the app's URL are no longer saved permanently, apart from the few the app passes between its own windows, and source verification can now only be changed in Configuration

--- a/tests/unit/spec/init-overrideParams.test.js
+++ b/tests/unit/spec/init-overrideParams.test.js
@@ -68,14 +68,16 @@ function elementStub () {
  * Evaluates the real init.js in a JSDOM window created at the given URL, and reports what it did.
  * @param {String} baseUrl The URL the app is served from, which determines whether the context is trusted
  * @param {String} querystring The querystring to apply, including the leading '?'
+ * @param {Object} [seed] Settings already in the Store when the app launches, keyed as they are actually
+ *     held (with the kiwixjs- prefix) and given as strings, which is all the real localStorage can store
  * @returns {Object} An object with the resulting params, the keys written to storage, and any warnings
  */
-function loadInit (baseUrl, querystring) {
+function loadInit (baseUrl, querystring, seed) {
     // runScripts gives us window.eval, which is what runs init.js inside this window rather than in Node
     const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: baseUrl + querystring, runScripts: 'outside-only' });
     const win = dom.window;
     const warnings = [];
-    const stored = {};
+    const stored = Object.assign({}, seed);
     // JSDOM refuses localStorage on the opaque origins of moz-extension: and file:, so supply our own.
     // It stringifies values exactly as the real API does, which is what init.js reads back.
     Object.defineProperty(win, 'localStorage', {
@@ -142,6 +144,40 @@ describe('init.js querystring overrides', function () {
                 assert.strictEqual(result.params.sourceVerification, true, 'should be refused at: ' + url);
                 assertNotStored(result, 'sourceVerification');
             });
+        });
+    });
+
+    describe('the trust gate across content injection modes', function () {
+        // The querystring cannot reach sourceVerification at all, so what matters is that the value the
+        // user set in Configuration is read back on the next launch. It is only meaningful in the modes
+        // that serve ZIM content through a Service Worker, and there are two of those: 'serviceworker',
+        // and the 'serviceworkerlocal' mode that Chromium extensions use to run the Service Worker on the
+        // extension origin rather than jumping to the PWA. The stored mode string is the full one, so an
+        // exact comparison against 'serviceworker' leaves the gate off for every ServiceWorkerLocal launch
+        const SW = { 'kiwixjs-contentInjectionMode': 'serviceworker' };
+        const SW_LOCAL = { 'kiwixjs-contentInjectionMode': 'serviceworkerlocal' };
+        const RESTRICTED = { 'kiwixjs-contentInjectionMode': 'jquery' };
+
+        it('defaults to verifying when nothing has been stored', function () {
+            assert.strictEqual(loadInit(PROD_PWA, '', SW).params.sourceVerification, true);
+        });
+
+        it('verifies in ServiceWorkerLocal mode, where ZIM content is served on the extension origin', function () {
+            assert.strictEqual(loadInit(CHROME_EXT, '', SW_LOCAL).params.sourceVerification, true);
+        });
+
+        it('honours a stored opt-out in both Service Worker modes', function () {
+            [[PROD_PWA, SW], [CHROME_EXT, SW_LOCAL]].forEach(function (testCase) {
+                const seed = Object.assign({ 'kiwixjs-sourceVerification': 'false' }, testCase[1]);
+                assert.strictEqual(loadInit(testCase[0], '', seed).params.sourceVerification, false,
+                    'a deliberate opt-out should survive in mode: ' + testCase[1]['kiwixjs-contentInjectionMode']);
+            });
+        });
+
+        it('leaves verification off in Restricted mode, where it is redundant', function () {
+            // Restricted mode never runs script from the archive, so there is nothing to gate
+            const seed = Object.assign({ 'kiwixjs-sourceVerification': 'true' }, RESTRICTED);
+            assert.strictEqual(loadInit(PROD_PWA, '', seed).params.sourceVerification, false);
         });
     });
 

--- a/tests/unit/spec/init-overrideParams.test.js
+++ b/tests/unit/spec/init-overrideParams.test.js
@@ -298,6 +298,48 @@ describe('init.js querystring overrides', function () {
         });
     });
 
+    describe('validation of contentInjectionMode', function () {
+        // The parameter is persistable, so before it was validated any string at all could be stored and
+        // then read back on every later launch. setContentInjectionMode() branches on the three radio
+        // values alone, so anything else leaves the app in a state its own UI cannot show: no radio lit,
+        // and the mode matching none of the branches that switch on it
+        it('accepts each of the three modes the app can represent', function () {
+            ['jquery', 'serviceworker', 'serviceworkerlocal'].forEach(function (mode) {
+                const result = loadInit(PROD_PWA, '?contentInjectionMode=' + mode);
+                assert.strictEqual(result.params.contentInjectionMode, mode);
+                assert.strictEqual(result.stored['kiwixjs-contentInjectionMode'], mode);
+            });
+        });
+
+        it('refuses a mode the app has no branch for, rather than storing it', function () {
+            const result = loadInit(PROD_PWA, '?contentInjectionMode=bogus');
+            assert.strictEqual(result.params.contentInjectionMode, 'serviceworker', 'the default should survive');
+            assertNotStored(result, 'contentInjectionMode');
+            assert.lengthOf(result.warnings, 1);
+            assert.include(result.warnings[0], 'contentInjectionMode');
+        });
+
+        it('refuses a value that merely starts with a real mode', function () {
+            // Without this, 'serviceworkerX' would read back as a trusting mode at the sourceVerification
+            // line, which tests the prefix rather than the whole string
+            const result = loadInit(PROD_PWA, '?contentInjectionMode=serviceworkerX');
+            assert.strictEqual(result.params.contentInjectionMode, 'serviceworker');
+            assertNotStored(result, 'contentInjectionMode');
+        });
+
+        it('heals an unrecognised mode stored before this validation existed', function () {
+            const result = loadInit(PROD_PWA, '', { 'kiwixjs-contentInjectionMode': 'bogus' });
+            assert.strictEqual(result.params.contentInjectionMode, 'serviceworker');
+        });
+
+        it('still reads back a stored mode the app can represent', function () {
+            ['jquery', 'serviceworker', 'serviceworkerlocal'].forEach(function (mode) {
+                const result = loadInit(PROD_PWA, '', { 'kiwixjs-contentInjectionMode': mode });
+                assert.strictEqual(result.params.contentInjectionMode, mode);
+            });
+        });
+    });
+
     describe('parameters that are not in any list', function () {
         it('applies an unrecognised parameter to the current page load but does not store it', function () {
             const result = loadInit(PROD_PWA, '?someExperimentalSetting=42');

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -88,8 +88,8 @@ if ((isServiceWorkerAvailable() || isMessageChannelAvailable() && /^(moz|chrome)
     params.contentInjectionMode === 'jquery' && !params.defaultModeChangeAlertDisplayed) {
     // Attempt to upgrade user to ServiceWorker mode
     params.contentInjectionMode = 'serviceworker';
-} else if (params.contentInjectionMode === 'serviceworker') {
-    // User is already in SW mode, so we will never need to display the upgrade alert
+} else if (/^serviceworker/.test(params.contentInjectionMode)) {
+    // User is already in SW mode (or ServiceWorkerLocal mode), so we will never need to display the upgrade alert
     params.defaultModeChangeAlertDisplayed = true;
     settingsStore.setItem('defaultModeChangeAlertDisplayed', true, Infinity);
 }

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -151,7 +151,11 @@ params['cacheAPI'] = 'kiwix-js'; // Sets name of the prefix used to identify the
 params['cacheIDB'] = 'kiwix-zim'; // Sets name of the Indexed DB database
 params['isFileSystemApiSupported'] = typeof window.showOpenFilePicker === 'function'; // Sets a boolean indicating whether the FileSystem API is supported
 params['isWebkitDirApiSupported'] = 'webkitdirectory' in document.createElement('input'); // Sets a Boolean indicating whether the Webkit Directory API is supported
-params['sourceVerification'] = params.contentInjectionMode === 'serviceworker' ? (getSetting('sourceVerification') === null ? true : getSetting('sourceVerification')) : false; // Sets a boolean indicating weather a user trusts the source of zim files
+// Sets a boolean indicating whether a user trusts the source of zim files. NB the stored mode may be
+// 'serviceworkerlocal' (Chromium extensions run the Service Worker on the extension origin instead of
+// jumping to the PWA), and the trust gate applies in that mode too, so we must not test for an exact
+// match with 'serviceworker' here or the gate would be silently off on every launch in that mode
+params['sourceVerification'] = /^serviceworker/.test(params.contentInjectionMode) ? (getSetting('sourceVerification') === null ? true : getSetting('sourceVerification')) : false;
 params['libzimMode'] = getSetting('libzimMode') || 'wasm'; // Sets a value indicating which libzim mode is selected
 params['useLibzim'] = !!getSetting('useLibzim'); // Sets a value indicating which libzim mode is selected
 params['libzimSearchType'] = getSetting('libzimSearchType') || 'searchWithSnippets'; // Sets a value indicating the type of search to use with libzim (currently 'search' or 'searchWithSnippets')

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -125,10 +125,16 @@ params['disableDragAndDrop'] = getSetting('disableDragAndDrop') === true;
 params['referrerExtensionURL'] = getSetting('referrerExtensionURL');
 // A parameter to keep track of the fact that the user has been informed of the switch to SW mode by default
 params['defaultModeChangeAlertDisplayed'] = getSetting('defaultModeChangeAlertDisplayed');
-// A parameter to set the content injection mode ('jquery' or 'serviceworker') used by this app
-params['contentInjectionMode'] = getSetting('contentInjectionMode') ||
+// The content injection modes the app can actually represent, which are exactly the three radio values in
+// index.html. Used both to validate the querystring parameter below and to sanitize the stored value: any
+// other string leaves the app in a state its own UI cannot show, with no radio lit and the mode matching
+// none of the branches in setContentInjectionMode()
+var contentInjectionModes = /^(?:jquery|serviceworker|serviceworkerlocal)$/;
+// A parameter to set the content injection mode ('jquery', 'serviceworker' or 'serviceworkerlocal') used by this app
+// NB testing the stored value heals anything unrecognized that was written before this validation existed
+params['contentInjectionMode'] = contentInjectionModes.test(getSetting('contentInjectionMode')) ? getSetting('contentInjectionMode')
     // Defaults to serviceworker mode when the API is available
-    (('serviceWorker' in navigator) ? 'serviceworker' : 'jquery');
+    : (('serviceWorker' in navigator) ? 'serviceworker' : 'jquery');
 // A parameter to circumvent anti-fingerprinting technology in browsers that do not support WebP natively by substituting images
 // directly with the canvas elements produced by the WebP polyfill [kiwix-js #835]. NB This is only currently used in jQuery mode.
 params['useCanvasElementsForWebpTranscoding'] = null; // Value is determined in uiUtil.determineCanvasElementsWorkaround(), called when setting the content injection mode
@@ -195,11 +201,14 @@ var devOnlyParams = ['noPrompts', 'PWAServer', 'libraryUrl', 'altLibraryUrl', 'a
 /**
  * Parameters whose value must match a pattern before it will be accepted. The referrerExtensionURL is only
  * ever meant to hold the URL of the extension that launched this PWA, and it lands in window.location.href
- * and in an iframe src, so we require it to be an extension URL and nothing else.
+ * and in an iframe src, so we require it to be an extension URL and nothing else. The contentInjectionMode
+ * is persistable, so an unrecognized value would otherwise be stored and read back on every later launch.
+ * Every querystring the app sends itself uses 'jquery' or 'serviceworker', so the handoff is unaffected.
  * @type {Object}
  */
 var validatedParams = {
-    referrerExtensionURL: /^(?:moz|chrome)-extension:\/\/[^/]/
+    referrerExtensionURL: /^(?:moz|chrome)-extension:\/\/[^/]/,
+    contentInjectionMode: contentInjectionModes
 };
 
 /**


### PR DESCRIPTION
Fixes #1469.

Two related defects in how `contentInjectionMode` is handled, one per commit.

## 1. The trust gate was off in ServiceWorkerLocal mode

In ServiceWorkerLocal mode the ZIM source-verification prompt stopped appearing after the first session, so an archive that had never been trusted was opened without the user being asked.

## Cause

The content injection mode is persisted as the full string, so selecting ServiceWorkerLocal mode stores `'serviceworkerlocal'` (`app.js:1360`). `init.js:154` tested the stored mode for exact equality with `'serviceworker'` when deciding whether to read `sourceVerification` back from the Settings Store, so on every launch in that mode the trust value was forced to `false` and the gate at `app.js:2164` — which correctly tests for both mode strings — never fired.

It looked like it worked because `params.sourceVerification` is assigned in only two places: `init.js` at boot, and the `enableSourceVerification` change handler. Selecting the mode mid-session leaves the value from a boot in a different mode, so the prompt shows that once and never again.

## Why the gate matters in this mode

ServiceWorkerLocal serves ZIM content from the extension origin under the extension CSP (`script-src 'self' 'wasm-unsafe-eval'`). That blocks *inline* script — which is why dynamic ZIMs break in this mode — but it allows same-origin script *files*, so an archive built for the purpose is not constrained by the restriction that constrains ordinary ZIMs. The trust prompt is the control that applies, and `app.js` already treated it as applying here.

## Changes

- `www/js/init.js` — test the mode with `/^serviceworker/` rather than an exact match. This is the idiom `kiwix-js-pwa` already uses at its equivalent gate, so the two codebases now read the same way.
- `www/js/app.js` — the same exact-match assumption at the top of the file meant neither branch matched `'serviceworkerlocal'`, so `defaultModeChangeAlertDisplayed` was never set and those users could be shown the mode-change alert again.
- `tests/unit/spec/init-overrideParams.test.js` — `loadInit()` gains an optional `seed` argument so a case can start with settings already in the Store, plus four cases covering the trust value across the modes.

## 2. The mode value itself was never validated

Raised while porting the above to `kiwix-js-pwa`, and fixed there in [kiwix-js-pwa#925](https://github.com/kiwix/kiwix-js-pwa/pull/925).

`contentInjectionMode` is in `persistableParams`, so it was accepted from the querystring and written to the Settings Store **with no check on its value**. `setContentInjectionMode()` branches on the three radio values alone, so any other string left the app in a state its own UI cannot show — no radio lit, and the mode matching none of the branches that switch on it. Because the value persists, it was then read back on every later launch.

- `www/js/init.js` — the mode joins `validatedParams`, so an unrecognised value is refused rather than stored. All three radio values are allowed (`index.html:672`, `:679`, `:686`); every querystring the app sends itself uses `jquery` or `serviceworker` (`app.js:1213`, `:1264`, `:1420`, `lib/settingsStore.js:215`), so the extension ↔ PWA handoff is unaffected.
- `www/js/init.js` — the stored value is tested on read-back too, which heals anything written before this validation existed. Without that, a poisoned value would persist untouched.

A side benefit: `serviceworkerX` can no longer read back as a trusting mode at the `sourceVerification` line, which tests the prefix rather than the whole string.

This is a robustness bug rather than a security one — `overrideParams()` runs *after* the `sourceVerification` line, so the trust prompt still fires in the session where a junk mode arrives, and `verifyLoadedArchive()` writes a real mode back on either answer. The heal is not guaranteed, though: it needs the user to open an archive in that session, which is the argument for validating the value.

## Testing

`npm test` passes (61 tests). Both fixes were checked against the unpatched file rather than assumed: stashing only the `init.js` changes makes *"verifies in ServiceWorkerLocal mode"*, *"refuses a mode the app has no branch for"*, *"refuses a value that merely starts with a real mode"* and *"heals an unrecognised mode stored before this validation existed"* fail, and all pass with the fixes restored. The remaining new cases pass either way by design — they guard against over-restricting. ServiceWorkerLocal behaviour was also confirmed by hand in the Chromium extension, before and after.

## Downstream

`kiwix/kiwix-js-pwa` has the identical line at its `init.js:160` and needs the same fix. It additionally has, at `app.js:2219`:

```js
params.contentInjectionMode === ('serviceworker' || 'serviceworkerlocal')
```

where the parenthesised expression short-circuits to `'serviceworker'`, so the source-verification checkbox is hidden in ServiceWorkerLocal mode. Both are covered by [kiwix-js-pwa#925](https://github.com/kiwix/kiwix-js-pwa/pull/925), along with the value validation in part 2. Note that repo has only two modes, so its allowlist is `/^(?:jquery|serviceworker)$/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
