### PR TITLE
Fix ServiceWorker-unavailable boot loop, and unblock "Bypass AppCache" in Restricted mode #1465

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Then it was renamed to "Kiwix HTML5" (and used the ZIM file format). Finally it 
 * FIX: The content injection mode is now checked against the modes the app actually supports, so an unrecognised value can no longer leave the app in an invalid state
 * FIX: Users who had already chosen ServiceWorkerLocal mode are no longer shown the mode-change alert they had answered before
 * FIX: In browsers without the ServiceWorker API (e.g. IE11), the "ServiceWorker API not available" dialogue no longer reappears indefinitely when the app starts in ServiceWorker mode: the app now warns once and drops back to Restricted mode
+* FIX: The "Bypass AppCache" setting no longer blocks a switch to Restricted mode, and can now be turned off from Restricted mode: the Service Worker still serves the app's own code in that mode, so the setting applies there too
 * DEV: Added unit tests covering the trust setting across the content injection modes, and the validation of the mode value itself
 * DEV: Added e2e tests, run in IE Mode, covering the app's recovery from ServiceWorker mode in a browser that cannot support it
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Then it was renamed to "Kiwix HTML5" (and used the ZIM file format). Finally it 
 * FIX: Users who had already chosen ServiceWorkerLocal mode are no longer shown the mode-change alert they had answered before
 * FIX: In browsers without the ServiceWorker API (e.g. IE11), the "ServiceWorker API not available" dialogue no longer reappears indefinitely when the app starts in ServiceWorker mode: the app now warns once and drops back to Restricted mode
 * FIX: The "Bypass AppCache" setting no longer blocks a switch to Restricted mode, and can now be turned off from Restricted mode: the Service Worker still serves the app's own code in that mode, so the setting applies there too
+* FIX: The "Bypass AppCache" setting is now shown in every mode in which it does something, including Restricted mode and ServiceWorkerLocal mode, and is hidden only in browsers with no ServiceWorker API, where it has no effect
 * DEV: Added unit tests covering the trust setting across the content injection modes, and the validation of the mode value itself
 * DEV: Added e2e tests, run in IE Mode, covering the app's recovery from ServiceWorker mode in a browser that cannot support it
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Then it was renamed to "Kiwix HTML5" (and used the ZIM file format). Finally it 
 * SECURITY: The security prompt regarding the source of an archive now appears consistently in ServiceWorkerLocal mode
 * FIX: The content injection mode is now checked against the modes the app actually supports, so an unrecognised value can no longer leave the app in an invalid state
 * FIX: Users who had already chosen ServiceWorkerLocal mode are no longer shown the mode-change alert they had answered before
+* FIX: In browsers without the ServiceWorker API (e.g. IE11), the "ServiceWorker API not available" dialogue no longer reappears indefinitely when the app starts in ServiceWorker mode: the app now warns once and drops back to Restricted mode
 * DEV: Added unit tests covering the trust setting across the content injection modes, and the validation of the mode value itself
+* DEV: Added e2e tests, run in IE Mode, covering the app's recovery from ServiceWorker mode in a browser that cannot support it
 
 ## Interim update Kiwix JS v4.3.3
 

--- a/tests/e2e/runners/edge/ieMode.e2e.runner.js
+++ b/tests/e2e/runners/edge/ieMode.e2e.runner.js
@@ -3,6 +3,7 @@ import { Options } from 'selenium-webdriver/ie.js';
 import legacyRayCharles from '../../spec/legacy-ray_charles.e2e.spec.js';
 // import gutenbergRo from '../../spec/gutenberg_ro.e2e.spec.js';
 import tonedear from '../../spec/tonedear.e2e.spec.js';
+import serviceWorkerUnavailable from '../../spec/serviceworker-unavailable.e2e.spec.js';
 
 async function loadIEModeDriver () {
     const ieOptions = new Options();
@@ -22,3 +23,5 @@ console.log(' ');
 await legacyRayCharles.runTests(await loadIEModeDriver(), ['jquery']);
 // await gutenbergRo.runTests(await loadIEModeDriver(), ['jquery']);
 await tonedear.runTests(await loadIEModeDriver(), ['jquery']);
+// This one runs last because it clears the Settings Store, which the browser profile shares with the specs above
+await serviceWorkerUnavailable.runTests(await loadIEModeDriver());

--- a/tests/e2e/runners/edge/microsoftEdge.e2e.runner.js
+++ b/tests/e2e/runners/edge/microsoftEdge.e2e.runner.js
@@ -3,6 +3,7 @@ import { Options } from 'selenium-webdriver/edge.js';
 import legacyRayCharles from '../../spec/legacy-ray_charles.e2e.spec.js';
 import gutenbergRo from '../../spec/gutenberg_ro.e2e.spec.js';
 import tonedearTests from '../../spec/tonedear.e2e.spec.js';
+import appCacheRestrictedMode from '../../spec/appcache-restricted-mode.e2e.spec.js';
 
 /* global process */
 
@@ -53,6 +54,7 @@ async function loadMSEdgeDriver () {
 
 // Preserve the order of loading, because when a user runs these on local machine, the third driver will be on top of and cover the first one
 // so we need to use the third one first
+const driver_for_appcache = await loadMSEdgeDriver();
 const driver_for_tonedear = await loadMSEdgeDriver();
 const driver_for_gutenberg = await loadMSEdgeDriver();
 const driver_for_ray_charles = await loadMSEdgeDriver();
@@ -60,3 +62,4 @@ const driver_for_ray_charles = await loadMSEdgeDriver();
 await legacyRayCharles.runTests(driver_for_ray_charles);
 await gutenbergRo.runTests(driver_for_gutenberg);
 await tonedearTests.runTests(driver_for_tonedear);
+await appCacheRestrictedMode.runTests(driver_for_appcache);

--- a/tests/e2e/spec/appcache-restricted-mode.e2e.spec.js
+++ b/tests/e2e/spec/appcache-restricted-mode.e2e.spec.js
@@ -40,7 +40,8 @@ const appUrl = 'http://localhost:' + port + '/dist/www/index.html';
 /**
  * Reports the state of the settings this spec manipulates
  * @param {WebDriver} driver Selenium WebDriver object
- * @returns {Promise<Object>} Any visible dialogue, the stored mode and AppCache settings, and the checkbox state
+ * @returns {Promise<Object>} Any visible dialogue, the stored mode and AppCache settings, the checkbox
+ *      state, and whether the setting is offered in the UI at all
  */
 function getAppState (driver) {
     return driver.executeScript(
@@ -49,7 +50,8 @@ function getAppState (driver) {
         '    dialogue: modal && modal.style.display === "block" ? document.getElementById("modalLabel").innerHTML : null,' +
         '    storedMode: localStorage.getItem("kiwixjs-contentInjectionMode"),' +
         '    storedAppCache: localStorage.getItem("kiwixjs-appCache"),' +
-        '    bypassChecked: document.getElementById("bypassAppCacheCheck").checked' +
+        '    bypassChecked: document.getElementById("bypassAppCacheCheck").checked,' +
+        '    bypassOffered: document.getElementById("bypassAppCacheDiv").style.display !== "none"' +
         '};'
     );
 }
@@ -109,6 +111,8 @@ function runTests (driver, keepDriver) {
             assert.strictEqual(afterSwitch.dialogue, null, 'No dialogue should refuse the switch to Restricted mode');
             assert.strictEqual(afterSwitch.storedMode, 'jquery', 'The app should have switched to Restricted mode');
             assert.ok(afterSwitch.bypassChecked, 'The bypass should have been left as the user set it');
+            // The setting used to be hidden outside ServiceWorker mode, which would leave it set but unreachable
+            assert.ok(afterSwitch.bypassOffered, 'The bypass setting should still be offered in Restricted mode');
         });
 
         // Turning the bypass off reloads the app (settingsStore.reset), which also proves the setting persisted

--- a/tests/e2e/spec/appcache-restricted-mode.e2e.spec.js
+++ b/tests/e2e/spec/appcache-restricted-mode.e2e.spec.js
@@ -1,0 +1,153 @@
+/**
+ * appcache-restricted-mode.e2e.spec.js : Tests that the AppCache bypass is usable in Restricted mode
+ *
+ * The app used to refuse to switch to Restricted mode while "Bypass AppCache" was set, bouncing the user
+ * back to ServiceWorker mode, and the setting could not be turned off from Restricted mode either. That
+ * block was removed in kiwix-js #1465: Restricted mode does not stop the Service Worker running, it only
+ * stops it intercepting requests for ZIM assets, so the app's own code is still served from APP_CACHE,
+ * which is exactly what this setting bypasses.
+ *
+ * These tests therefore need a browser that HAS the ServiceWorker API, and skip themselves otherwise
+ * (the companion spec serviceworker-unavailable.e2e.spec.js covers the browsers that do not).
+ *
+ * Copyright 2026 Jaifroid and contributors
+ * Licence GPL v3:
+ *
+ * This file is part of Kiwix.
+ *
+ * Kiwix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kiwix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
+ */
+
+import assert from 'assert';
+
+/* global describe, it, before, after, process */
+
+const BROWSERSTACK = !!process.env.BROWSERSTACK_LOCAL_IDENTIFIER;
+const port = BROWSERSTACK ? '8099' : '8080';
+const appUrl = 'http://localhost:' + port + '/dist/www/index.html';
+
+/**
+ * Reports the state of the settings this spec manipulates
+ * @param {WebDriver} driver Selenium WebDriver object
+ * @returns {Promise<Object>} Any visible dialogue, the stored mode and AppCache settings, and the checkbox state
+ */
+function getAppState (driver) {
+    return driver.executeScript(
+        'var modal = document.getElementById("alertModal");' +
+        'return {' +
+        '    dialogue: modal && modal.style.display === "block" ? document.getElementById("modalLabel").innerHTML : null,' +
+        '    storedMode: localStorage.getItem("kiwixjs-contentInjectionMode"),' +
+        '    storedAppCache: localStorage.getItem("kiwixjs-appCache"),' +
+        '    bypassChecked: document.getElementById("bypassAppCacheCheck").checked' +
+        '};'
+    );
+}
+
+/**
+ * Clicks an element with JavaScript. DEV: the expert settings live in a collapsed section of the
+ * Configuration page, so a WebDriver click can find the element not interactable
+ * @param {WebDriver} driver Selenium WebDriver object
+ * @param {String} id The id of the element to click
+ * @param {Number} pause Milliseconds to wait for the app to settle afterwards
+ * @returns {Promise<void>} A Promise for the completion of the click
+ */
+async function clickAndSettle (driver, id, pause) {
+    await driver.executeScript('document.getElementById("' + id + '").click();');
+    await driver.sleep(pause);
+}
+
+/**
+ * Run the tests
+ * @param {WebDriver} driver Selenium WebDriver object
+ * @param {boolean} keepDriver Whether to keep the driver open after the tests have run
+ * @returns {Promise<void>} A Promise for the completion of the tests
+ */
+function runTests (driver, keepDriver) {
+    driver.getCapabilities().then(function (caps) {
+        console.log('\nRunning AppCache-in-Restricted-mode tests on: ' + caps.get('browserName') + ' ' + caps.get('browserVersion'));
+    });
+
+    driver.manage().setTimeouts({ implicit: 3000 });
+
+    describe('AppCache bypass in Restricted mode [kiwix-js #1465]', function () {
+        this.timeout(60000);
+        this.slow(10000);
+
+        before(async function () {
+            await driver.get(appUrl + '?contentInjectionMode=jquery');
+            await driver.sleep(1300);
+            const serviceWorkerAPI = await driver.executeScript('return "serviceWorker" in navigator;');
+            if (!serviceWorkerAPI) {
+                console.log('    (skipped: this browser has no ServiceWorker API)');
+                this.skip();
+            }
+            // Start from a clean Store, in ServiceWorker mode with the bypass already set. The mode-change
+            // alert is marked as answered so that only dialogues raised by these settings can appear
+            await driver.executeScript('localStorage.clear();');
+            await driver.get(appUrl + '?contentInjectionMode=serviceworker&appCache=false&defaultModeChangeAlertDisplayed=true');
+            await driver.sleep(2500);
+        });
+
+        // The app used to refuse this switch and send the user back to ServiceWorker mode
+        it('Switches to Restricted mode while the AppCache bypass is set', async function () {
+            const onLaunch = await getAppState(driver);
+            assert.strictEqual(onLaunch.storedAppCache, 'false', 'The launch should have set the AppCache bypass');
+            assert.ok(onLaunch.bypassChecked, 'The bypass checkbox should be ticked');
+            await clickAndSettle(driver, 'jqueryModeRadio', 2500);
+            const afterSwitch = await getAppState(driver);
+            assert.strictEqual(afterSwitch.dialogue, null, 'No dialogue should refuse the switch to Restricted mode');
+            assert.strictEqual(afterSwitch.storedMode, 'jquery', 'The app should have switched to Restricted mode');
+            assert.ok(afterSwitch.bypassChecked, 'The bypass should have been left as the user set it');
+        });
+
+        // Turning the bypass off reloads the app (settingsStore.reset), which also proves the setting persisted
+        it('Turns the AppCache bypass off from Restricted mode', async function () {
+            await clickAndSettle(driver, 'bypassAppCacheCheck', 4000);
+            const state = await getAppState(driver);
+            assert.strictEqual(state.dialogue, null, 'No dialogue should refuse the change');
+            assert.strictEqual(state.storedAppCache, 'true', 'Turning the bypass off should have been saved');
+            assert.ok(!state.bypassChecked, 'The bypass checkbox should be unticked');
+            assert.strictEqual(state.storedMode, 'jquery', 'The app should still be in Restricted mode');
+        });
+
+        it('Turns the AppCache bypass back on from Restricted mode', async function () {
+            await clickAndSettle(driver, 'bypassAppCacheCheck', 2500);
+            const state = await getAppState(driver);
+            assert.strictEqual(state.dialogue, null, 'No dialogue should refuse the change');
+            assert.strictEqual(state.storedAppCache, 'false', 'Turning the bypass on should have been saved');
+            assert.ok(state.bypassChecked, 'The bypass checkbox should be ticked');
+            assert.strictEqual(state.storedMode, 'jquery', 'The app should still be in Restricted mode');
+        });
+
+        // init.js used to force the bypass off at launch whenever the app was in Restricted mode, to break
+        // the loop the old block caused. With the block gone, a deliberate setting must now survive
+        it('Keeps the AppCache bypass set across a relaunch in Restricted mode', async function () {
+            await driver.get(appUrl);
+            await driver.sleep(2500);
+            const state = await getAppState(driver);
+            assert.strictEqual(state.storedMode, 'jquery', 'The app should relaunch in Restricted mode');
+            assert.strictEqual(state.storedAppCache, 'false', 'The stored bypass setting should be untouched');
+            assert.ok(state.bypassChecked, 'The bypass checkbox should still be ticked');
+        });
+
+        after(async function () {
+            await driver.executeScript('localStorage.clear();');
+            if (!keepDriver) await driver.quit();
+        });
+    });
+}
+
+export default {
+    runTests: runTests
+};

--- a/tests/e2e/spec/serviceworker-unavailable.e2e.spec.js
+++ b/tests/e2e/spec/serviceworker-unavailable.e2e.spec.js
@@ -1,0 +1,163 @@
+/**
+ * serviceworker-unavailable.e2e.spec.js : Regression tests for kiwix-js #1465
+ *
+ * In a browser with no ServiceWorker API, launching the app with ServiceWorker mode already selected used
+ * to show the "ServiceWorker API not available" dialogue in an unbreakable loop: dismissing it restored
+ * the mode the app had just rejected, which brought the dialogue straight back, so the app could not be
+ * used at all. These tests launch the app in exactly that state and check that it warns the user once,
+ * then settles in Restricted mode and stays there.
+ *
+ * There is nothing to test in a browser that has the ServiceWorker API, so the suite skips itself unless
+ * the API is missing. In CI that means it runs in IE Mode, and is skipped everywhere else.
+ *
+ * Copyright 2026 Jaifroid and contributors
+ * Licence GPL v3:
+ *
+ * This file is part of Kiwix.
+ *
+ * Kiwix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kiwix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kiwix (file LICENSE-GPLv3.txt).  If not, see <http://www.gnu.org/licenses/>
+ */
+
+import assert from 'assert';
+
+/* global describe, it, before, after, process */
+
+const BROWSERSTACK = !!process.env.BROWSERSTACK_LOCAL_IDENTIFIER;
+const port = BROWSERSTACK ? '8099' : '8080';
+const appUrl = 'http://localhost:' + port + '/dist/www/index.html';
+
+/**
+ * Reports what the app is currently showing and which mode it has settled on
+ * @param {WebDriver} driver Selenium WebDriver object
+ * @returns {Promise<Object>} The title of any visible dialogue, the stored mode, and whether search is usable
+ */
+function getAppState (driver) {
+    return driver.executeScript(`
+        var modal = document.getElementById('alertModal');
+        var prefix = document.getElementById('prefix');
+        return {
+            dialogue: modal && modal.style.display === 'block' ? document.getElementById('modalLabel').innerHTML : null,
+            storedMode: localStorage.getItem('kiwixjs-contentInjectionMode'),
+            bypassAppCacheChecked: document.getElementById('bypassAppCacheCheck').checked,
+            searchUsable: !!prefix && !prefix.disabled
+        };
+    `);
+}
+
+/**
+ * Launches the app from a clean Settings Store with the given querystring
+ * @param {WebDriver} driver Selenium WebDriver object
+ * @param {String} querystring The querystring to launch with, including the leading '?'
+ * @returns {Promise<void>} A Promise for the completion of the launch
+ */
+async function launchWith (driver, querystring) {
+    // Restricted mode launches without any dialogue, which gives us a quiet page on which to clear the Store
+    await driver.get(appUrl + '?contentInjectionMode=jquery');
+    await driver.sleep(1300);
+    await driver.executeScript('localStorage.clear();');
+    await driver.get(appUrl + querystring);
+    await driver.sleep(2500);
+}
+
+/**
+ * Dismisses the dialogue with the given button. DEV: we click with JavaScript because in IE Mode a
+ * lingering modal backdrop can intercept a WebDriver click on the button beneath it
+ * @param {WebDriver} driver Selenium WebDriver object
+ * @param {String} buttonId The id of the button to click ('approveConfirm' or 'declineConfirm')
+ * @returns {Promise<void>} A Promise for the completion of the dismissal
+ */
+async function dismissDialogue (driver, buttonId) {
+    await driver.executeScript('document.getElementById("' + buttonId + '").click();');
+    await driver.sleep(2500);
+}
+
+/**
+ * Run the tests
+ * @param {WebDriver} driver Selenium WebDriver object
+ * @param {boolean} keepDriver Whether to keep the driver open after the tests have run
+ * @returns {Promise<void>} A Promise for the completion of the tests
+ */
+function runTests (driver, keepDriver) {
+    driver.getCapabilities().then(function (caps) {
+        console.log('\nRunning ServiceWorker-unavailable tests on: ' + caps.get('browserName') + ' ' + caps.get('browserVersion'));
+    });
+
+    driver.manage().setTimeouts({ implicit: 3000 });
+
+    describe('Recovery from ServiceWorker mode in a browser without the API [kiwix-js #1465]', function () {
+        this.timeout(60000);
+        this.slow(10000);
+
+        before(async function () {
+            await driver.get(appUrl + '?contentInjectionMode=jquery');
+            await driver.sleep(1300);
+            const serviceWorkerAPI = await driver.executeScript('return "serviceWorker" in navigator;');
+            if (serviceWorkerAPI) {
+                console.log('    (skipped: this browser supports the ServiceWorker API)');
+                this.skip();
+            }
+        });
+
+        // Both buttons of the dialogue used to lead to the same place: back into the mode just rejected
+        ['approveConfirm', 'declineConfirm'].forEach(function (buttonId) {
+            const buttonName = buttonId === 'approveConfirm' ? '"Use Restricted mode"' : '"Cancel"';
+            it('Falls back to Restricted mode when the dialogue is dismissed with ' + buttonName, async function () {
+                await launchWith(driver, '?contentInjectionMode=serviceworker');
+                const onLaunch = await getAppState(driver);
+                assert.match(onLaunch.dialogue || '', /ServiceWorker\sAPI\snot\savailable/i,
+                    'The app should warn that the ServiceWorker API is unavailable');
+                await dismissDialogue(driver, buttonId);
+                const afterDismissal = await getAppState(driver);
+                assert.strictEqual(afterDismissal.dialogue, null, 'The dialogue should not reappear once dismissed');
+                assert.strictEqual(afterDismissal.storedMode, 'jquery', 'The app should have settled in Restricted mode');
+                assert.ok(afterDismissal.searchUsable, 'The app should be usable');
+            });
+        });
+
+        // With prompts suppressed the fallback runs without user input, and used to recurse until the stack blew
+        it('Falls back to Restricted mode with no dialogue when prompts are suppressed', async function () {
+            await launchWith(driver, '?contentInjectionMode=serviceworker&noPrompts=true');
+            const state = await getAppState(driver);
+            assert.strictEqual(state.dialogue, null, 'No dialogue should be shown when prompts are suppressed');
+            assert.strictEqual(state.storedMode, 'jquery', 'The app should have settled in Restricted mode');
+            assert.ok(state.searchUsable, 'The app should be usable');
+        });
+
+        // Restricted mode refuses to start while "Bypass AppCache" is set, which gave a second loop between
+        // that dialogue and the one above. The bypass is meaningless without a Service Worker to bypass
+        it('Turns off "Bypass AppCache" rather than looping when it blocks the fallback', async function () {
+            await launchWith(driver, '?contentInjectionMode=serviceworker&appCache=false');
+            const onLaunch = await getAppState(driver);
+            assert.ok(onLaunch.bypassAppCacheChecked, 'The launch should have set the AppCache bypass');
+            await dismissDialogue(driver, 'approveConfirm');
+            const afterDismissal = await getAppState(driver);
+            assert.strictEqual(afterDismissal.dialogue, null, 'No further dialogue should be shown');
+            assert.strictEqual(afterDismissal.storedMode, 'jquery', 'The app should have settled in Restricted mode');
+            assert.ok(!afterDismissal.bypassAppCacheChecked, 'The AppCache bypass should have been turned off');
+        });
+
+        after(async function () {
+            // The browser profile is shared with the other specs, so leave the Store in the state they expect:
+            // Restricted mode, with the mode-change alert already answered, so no dialogue greets the next run
+            await driver.executeScript('localStorage.clear();');
+            await driver.get(appUrl + '?contentInjectionMode=jquery&defaultModeChangeAlertDisplayed=true');
+            await driver.sleep(1300);
+            if (!keepDriver) await driver.quit();
+        });
+    });
+}
+
+export default {
+    runTests: runTests
+};

--- a/tests/e2e/spec/serviceworker-unavailable.e2e.spec.js
+++ b/tests/e2e/spec/serviceworker-unavailable.e2e.spec.js
@@ -5,7 +5,8 @@
  * to show the "ServiceWorker API not available" dialogue in an unbreakable loop: dismissing it restored
  * the mode the app had just rejected, which brought the dialogue straight back, so the app could not be
  * used at all. These tests launch the app in exactly that state and check that it warns the user once,
- * then settles in Restricted mode and stays there.
+ * then settles in Restricted mode and stays there, including when the "Bypass AppCache" setting is on,
+ * which used to block Restricted mode from starting and so produced a second loop of its own.
  *
  * There is nothing to test in a browser that has the ServiceWorker API, so the suite skips itself unless
  * the API is missing. In CI that means it runs in IE Mode, and is skipped everywhere else.
@@ -134,9 +135,10 @@ function runTests (driver, keepDriver) {
             assert.ok(state.searchUsable, 'The app should be usable');
         });
 
-        // Restricted mode refuses to start while "Bypass AppCache" is set, which gave a second loop between
-        // that dialogue and the one above. The bypass is meaningless without a Service Worker to bypass
-        it('Turns off "Bypass AppCache" rather than looping when it blocks the fallback', async function () {
+        // Restricted mode used to refuse to start while "Bypass AppCache" was set, bouncing the app back to
+        // ServiceWorker mode, which gave a second loop between that dialogue and the one above. That block has
+        // been removed, so the setting is simply left as the user set it
+        it('Falls back to Restricted mode without looping when "Bypass AppCache" is set', async function () {
             await launchWith(driver, '?contentInjectionMode=serviceworker&appCache=false');
             const onLaunch = await getAppState(driver);
             assert.ok(onLaunch.bypassAppCacheChecked, 'The launch should have set the AppCache bypass');
@@ -144,7 +146,7 @@ function runTests (driver, keepDriver) {
             const afterDismissal = await getAppState(driver);
             assert.strictEqual(afterDismissal.dialogue, null, 'No further dialogue should be shown');
             assert.strictEqual(afterDismissal.storedMode, 'jquery', 'The app should have settled in Restricted mode');
-            assert.ok(!afterDismissal.bypassAppCacheChecked, 'The AppCache bypass should have been turned off');
+            assert.ok(afterDismissal.bypassAppCacheChecked, 'The AppCache bypass should have been left alone');
         });
 
         after(async function () {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -520,14 +520,14 @@ document.getElementById('btnReset').addEventListener('click', function () {
     })
 });
 document.getElementById('bypassAppCacheCheck').addEventListener('change', function () {
-    if (params.contentInjectionMode !== 'serviceworker') {
-        uiUtil.systemAlert(translateUI.t('dialog-bypassappcachecheck-message') || 'This setting can only be used in ServiceWorker mode!');
-        this.checked = false;
-    } else {
-        params.appCache = !this.checked;
-        settingsStore.setItem('appCache', params.appCache, Infinity);
-        settingsStore.reset('cacheAPI');
-    }
+    // DEV: This setting used to be refused outside ServiceWorker mode, but Restricted mode does not stop the Service
+    // Worker running: it only stops it intercepting requests for ZIM assets, so the app's own code is still served
+    // from APP_CACHE, which is exactly what this setting bypasses. The old guard therefore blocked a bypass that
+    // does work, and left it impossible to turn off once the app had auto-switched to Restricted mode by itself,
+    // as it does when the user declines to trust an archive [kiwix-js #1465]
+    params.appCache = !this.checked;
+    settingsStore.setItem('appCache', params.appCache, Infinity);
+    settingsStore.reset('cacheAPI');
     // This will also send any new values to Service Worker
     refreshCacheStatus();
 });
@@ -1197,23 +1197,6 @@ function setContentInjectionMode (value) {
     params.originalContentInjectionMode = null;
     var message = '';
     if (value === 'jquery') {
-        if (!params.appCache) {
-            // DEV: In an extension the ServiceWorker API is legitimately absent (Firefox >= 103), but SW mode is still
-            // reachable by handing off to the PWA, so the API test alone must not decide this
-            if (isServiceWorkerAvailable() || /^(moz|chrome)-extension:/i.test(window.location.protocol)) {
-                uiUtil.systemAlert((translateUI.t('dialog-bypassappcache-conflict-message') || 'You must deselect the "Bypass AppCache" option before switching to Restricted mode!'),
-                    (translateUI.t('dialog-bypassappcache-conflict-title') || 'Deselect "Bypass AppCache"')).then(function () {
-                    setContentInjectionMode('serviceworker');
-                })
-                return;
-            }
-            // This browser cannot run any ServiceWorker mode, so Restricted mode is the only mode available and the
-            // bypass has nothing left to bypass. Insisting on it here would give the user a dialogue they cannot
-            // satisfy, and would send us back to SW mode, which is the loop this fix removes [kiwix-js #1465]. So we
-            // turn the bypass off ourselves, exactly as init.js does when it finds the app already in Restricted mode
-            params.appCache = true;
-            document.getElementById('bypassAppCacheCheck').checked = false;
-        }
         if (params.referrerExtensionURL) {
             // We are in an extension, and the user may wish to revert to local code
             message = translateUI.t('dialog-launchlocal-message') || 'This will switch to using locally packaged code only. Some configuration settings may be lost.<br/><br/>' +

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1198,11 +1198,21 @@ function setContentInjectionMode (value) {
     var message = '';
     if (value === 'jquery') {
         if (!params.appCache) {
-            uiUtil.systemAlert((translateUI.t('dialog-bypassappcache-conflict-message') || 'You must deselect the "Bypass AppCache" option before switching to Restricted mode!'),
-                (translateUI.t('dialog-bypassappcache-conflict-title') || 'Deselect "Bypass AppCache"')).then(function () {
-                setContentInjectionMode('serviceworker');
-            })
-            return;
+            // DEV: In an extension the ServiceWorker API is legitimately absent (Firefox >= 103), but SW mode is still
+            // reachable by handing off to the PWA, so the API test alone must not decide this
+            if (isServiceWorkerAvailable() || /^(moz|chrome)-extension:/i.test(window.location.protocol)) {
+                uiUtil.systemAlert((translateUI.t('dialog-bypassappcache-conflict-message') || 'You must deselect the "Bypass AppCache" option before switching to Restricted mode!'),
+                    (translateUI.t('dialog-bypassappcache-conflict-title') || 'Deselect "Bypass AppCache"')).then(function () {
+                    setContentInjectionMode('serviceworker');
+                })
+                return;
+            }
+            // This browser cannot run any ServiceWorker mode, so Restricted mode is the only mode available and the
+            // bypass has nothing left to bypass. Insisting on it here would give the user a dialogue they cannot
+            // satisfy, and would send us back to SW mode, which is the loop this fix removes [kiwix-js #1465]. So we
+            // turn the bypass off ourselves, exactly as init.js does when it finds the app already in Restricted mode
+            params.appCache = true;
+            document.getElementById('bypassAppCacheCheck').checked = false;
         }
         if (params.referrerExtensionURL) {
             // We are in an extension, and the user may wish to revert to local code
@@ -1252,6 +1262,11 @@ function setContentInjectionMode (value) {
             launchBrowserExtensionServiceWorker();
         } else {
             if (!isServiceWorkerAvailable()) {
+                // We have just established that this browser has no ServiceWorker API, so the mode we came from must not
+                // be restored if it was itself a ServiceWorker mode: that would re-enter this branch and re-display the
+                // dialogue below, indefinitely, leaving the app unusable [kiwix-js #1465]. Note this is computed
+                // before the dialogue is shown, because params.oldInjectionMode is overwritten on every mode change
+                var fallbackMode = params.oldInjectionMode && !/^serviceworker/.test(params.oldInjectionMode) ? params.oldInjectionMode : 'jquery';
                 message = translateUI.t('dialog-launchpwa-unsupported-message') ||
                     '<p>Unfortunately, your browser does not appear to support ServiceWorker mode, which is now the default for this app.</p>' +
                     '<p>You can continue to use the app in Restricted mode, but note that this mode only works well with ' +
@@ -1264,11 +1279,11 @@ function setContentInjectionMode (value) {
                             var uriParams = '?allowInternetAccess=false&contentInjectionMode=jquery&defaultModeChangeAlertDisplayed=true';
                             window.location.href = params.referrerExtensionURL + '/www/index.html' + uriParams;
                         } else {
-                            setContentInjectionMode(params.oldInjectionMode || 'jquery');
+                            setContentInjectionMode(fallbackMode);
                         }
                     });
                 } else {
-                    setContentInjectionMode(params.oldInjectionMode || 'jquery');
+                    setContentInjectionMode(fallbackMode);
                 }
                 return;
             }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -970,8 +970,10 @@ function refreshAPIStatus () {
         pwaOriginStatusDiv.innerHTML = (translateUI.t('api-pwa-origin-label') || 'PWA Origin:') + ' ' + window.location.origin;
         // Add a warning colour to the API Status Panel if any of the above tests failed
         apiStatusPanel.classList.add(apiPanelClass);
-        // Set visibility of UI elements according to mode
-        document.getElementById('bypassAppCacheDiv').style.display = params.contentInjectionMode === 'serviceworker' ? 'block' : 'none';
+        // Set visibility of UI elements. DEV: the question is not which mode we are in, but whether there is a Service
+        // Worker to bypass: this setting works in Restricted mode and in ServiceWorkerLocal mode alike, and does
+        // nothing at all in a browser that has no ServiceWorker API, whatever the mode [kiwix-js #1465]
+        document.getElementById('bypassAppCacheDiv').style.display = isServiceWorkerAvailable() ? 'block' : 'none';
         // Check to see whether we need to alert the user that we have switched to ServiceWorker mode by default
         if (!params.defaultModeChangeAlertDisplayed) checkAndDisplayInjectionModeChangeAlert();
     }, 250);

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -303,10 +303,6 @@ function isTrustedContext () {
     }
 })();
 
-// Since contentInjectionMode can be overriden when returning from remote PWA to extension (for example), we have to prevent an infinite loop
-// with code that warns the user to turn off the App Cache bypass in jQuery mode. Note that to turn OFF the bypass, we have to set the VALUE to true
-params.appCache = params.contentInjectionMode === 'jquery' ? true : params.appCache;
-
 /**
  * Set the State and UI settings associated with parameters defined above
  */


### PR DESCRIPTION
Fixes #1465.

### The boot loop

In a browser with no ServiceWorker API, launching the app in ServiceWorker mode showed the "ServiceWorker API not available" dialogue in a loop: on dismissal the app restored `params.oldInjectionMode`, which was the ServiceWorker mode it had just rejected, so the whole sequence ran again. Both buttons ended on that path, as did the `noPrompts` branch, which recursed synchronously.

The fallback mode is now computed before the dialogue is shown, and never resolves to a ServiceWorker mode in a browser that cannot run one.

### "Bypass AppCache" in Restricted mode

That alone left a second loop: the app refused to start Restricted mode while "Bypass AppCache" was set and bounced back to ServiceWorker mode, so the two dialogues alternated indefinitely.

Rather than special-case it, this PR removes the block altogether, because its premise does not hold. Restricted mode does not stop the Service Worker running — it only stops it intercepting requests for ZIM assets — so the app's own code is still served from `APP_CACHE`, which is exactly what the setting bypasses. The block was also inconsistent: the two paths that switch to Restricted mode automatically, declining to trust an archive (`verifyLoadedArchive()`) and meeting an unsupported Zimit archive (`handleUnsupportedReplayWorker()`), assign the mode directly and never met it. In practice it served mainly to obstruct developers.

Three pieces go together:

- the block in `setContentInjectionMode()` that refused Restricted mode and bounced back to ServiceWorker mode;
- the guard in the `bypassAppCacheCheck` handler, which refused *any* change outside ServiceWorker mode, so the setting could not be turned off once the app had auto-switched to Restricted mode by itself (and whose `this.checked = false` left the checkbox disagreeing with `params.appCache` until relaunch);
- the line in `init.js` whose only purpose was to break the resulting loop at launch, and which would now silently disable a legitimate bypass on every launch in Restricted mode.

### Testing

Two e2e specs cover the two halves of this, each skipping itself in the browsers the other one handles:

- `serviceworker-unavailable.e2e.spec.js` needs a browser with **no** ServiceWorker API, so it runs in IE Mode. It covers both loops and the `noPrompts` path. Verified in IE Mode: before the fix the dialogue returned after either button; after it the app warns once and settles in Restricted mode.
- `appcache-restricted-mode.e2e.spec.js` needs a browser that **has** the ServiceWorker API, so it runs in the Edge runner. It covers entering Restricted mode with the bypass set, turning the setting off and on again from there, and its survival across a relaunch, which is the regression guard for the line removed from `init.js`.

Both were checked against the code as it stood before this PR, not only after it: all four of the new AppCache tests fail on the old code, reporting the `Deselect "Bypass AppCache"` dialogue and the mode bouncing back to ServiceWorker.

Locally: Edge 50 passing / 4 pending, IE Mode 15 passing / 1 pending, unit 61 passing, lint clean.
